### PR TITLE
Dca Route in Operations

### DIFF
--- a/docs/dev/reference/dca/reference.md
+++ b/docs/dev/reference/dca/reference.md
@@ -100,6 +100,7 @@ that relate to a particular record only (e.g. editing or deleting a record).
 | class           | CSS class (`string`)              | CSS class attribute of the button.                                                                                 |
 | attributes      | Additional attributes (`string`)  | Additional attributes like event handler or style definitions.                                                     |
 | button_callback | Callback function (`array`)       | Call a custom function instead of using the default button function. Please specify as `array('Class', 'Method')`. |
+| route           | Symfony Route Name (`string`)     | The button will be redirect to the given Symfony route.                                                            |
 
 
 #### Regular operations
@@ -111,6 +112,7 @@ that relate to a particular record only (e.g. editing or deleting a record).
 | icon            | Icon (`string`)                   | Path and filename of the icon.                                                                                     |
 | attributes      | Additional attributes (`string`)  | Additional attributes like event handler or style definitions.                                                     |
 | button_callback | Callback function (`array`)       | Call a custom function instead of using the default button function. Please specify as `array('Class', 'Method')`. |
+| route           | Symfony Route Name (`string`)     | The button will be redirect to the given Symfony route.                                                            |
 
 
 ### Fields

--- a/docs/dev/reference/dca/reference.md
+++ b/docs/dev/reference/dca/reference.md
@@ -100,7 +100,7 @@ that relate to a particular record only (e.g. editing or deleting a record).
 | class           | CSS class (`string`)              | CSS class attribute of the button.                                                                                 |
 | attributes      | Additional attributes (`string`)  | Additional attributes like event handler or style definitions.                                                     |
 | button_callback | Callback function (`array`)       | Call a custom function instead of using the default button function. Please specify as `array('Class', 'Method')`. |
-| route           | Symfony Route Name (`string`)     | The button will be redirect to the given Symfony route.                                                            |
+| route           | Symfony Route Name (`string`)     | The button will redirect to the given Symfony route.                                                            |
 
 
 #### Regular operations
@@ -112,7 +112,7 @@ that relate to a particular record only (e.g. editing or deleting a record).
 | icon            | Icon (`string`)                   | Path and filename of the icon.                                                                                     |
 | attributes      | Additional attributes (`string`)  | Additional attributes like event handler or style definitions.                                                     |
 | button_callback | Callback function (`array`)       | Call a custom function instead of using the default button function. Please specify as `array('Class', 'Method')`. |
-| route           | Symfony Route Name (`string`)     | The button will be redirect to the given Symfony route.                                                            |
+| route           | Symfony Route Name (`string`)     | The button will redirect to the given Symfony route.                                                            |
 
 
 ### Fields

--- a/docs/dev/reference/dca/reference.md
+++ b/docs/dev/reference/dca/reference.md
@@ -100,7 +100,12 @@ that relate to a particular record only (e.g. editing or deleting a record).
 | class           | CSS class (`string`)              | CSS class attribute of the button.                                                                                 |
 | attributes      | Additional attributes (`string`)  | Additional attributes like event handler or style definitions.                                                     |
 | button_callback | Callback function (`array`)       | Call a custom function instead of using the default button function. Please specify as `array('Class', 'Method')`. |
-| route           | Symfony Route Name (`string`)     | The button will redirect to the given Symfony route.                                                            |
+
+{{< version "4.7" >}}
+
+| Key             | Value                             | Description                                                                                                        |
+|-----------------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| route           | Symfony Route Name (`string`)     | The button will redirect to the given Symfony route.                                                               |
 
 
 #### Regular operations
@@ -112,7 +117,12 @@ that relate to a particular record only (e.g. editing or deleting a record).
 | icon            | Icon (`string`)                   | Path and filename of the icon.                                                                                     |
 | attributes      | Additional attributes (`string`)  | Additional attributes like event handler or style definitions.                                                     |
 | button_callback | Callback function (`array`)       | Call a custom function instead of using the default button function. Please specify as `array('Class', 'Method')`. |
-| route           | Symfony Route Name (`string`)     | The button will redirect to the given Symfony route.                                                            |
+
+{{< version "4.7" >}}
+
+| Key             | Value                             | Description                                                                                                        |
+|-----------------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| route           | Symfony Route Name (`string`)     | The button will redirect to the given Symfony route.                                                               |
 
 
 ### Fields


### PR DESCRIPTION
In Operations und Global Operations kann man eine Symfony Route angeben. Hab das gleich mal ergänzt.

Siehe https://github.com/contao/contao/blob/master/core-bundle/src/Resources/contao/classes/DataContainer.php#L826