### PR TITLE
Automatically deploy documentation to docs.contao.org

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -1,0 +1,47 @@
+name: Build and deploy to https://docs.contao.org
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    build_and_deploy:
+        runs-on: ubuntu-18.04
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v1.0.0
+              with:
+                  submodules: true
+            - name: Setup Hugo
+              uses: peaceiris/actions-hugo@v2.2.2
+              with:
+                  hugo-version: '0.58.3'
+            - name: Build user manual
+              run: make build-manual
+            - name: Build developer manual
+              run: make build-dev
+            - name: Deploy user manual
+              uses: appleboy/scp-action@master
+              env:
+                  HOST: ${{ secrets.DEPLOY_HOST }}
+                  USERNAME: ${{ secrets.DEPLOY_USERNAME }}
+                  PORT: ${{ secrets.DEPLOY_PORT }}
+                  KEY: ${{ secrets.DEPLOY_KEY }}
+              with:
+                  source: 'build/manual'
+                  target: ${{ secrets.DEPLOY_TARGET_PATH }}/manual
+                  rm: true
+                  strip_components: 2
+            - name: Deploy developer manual
+              uses: appleboy/scp-action@master
+              env:
+                  HOST: ${{ secrets.DEPLOY_HOST }}
+                  USERNAME: ${{ secrets.DEPLOY_USERNAME }}
+                  PORT: ${{ secrets.DEPLOY_PORT }}
+                  KEY: ${{ secrets.DEPLOY_KEY }}
+              with:
+                  source: 'build/dev'
+                  target: ${{ secrets.DEPLOY_TARGET_PATH }}/dev
+                  rm: true
+                  strip_components: 2


### PR DESCRIPTION
This introduces automated deployment of the master branch to docs.contao.org on every push to the master branch.