### PR TITLE
Amend "Dateimanager" to "Dateiverwaltung"

### DIFF
--- a/docs/manual/article-management/inhaltselemente.de.md
+++ b/docs/manual/article-management/inhaltselemente.de.md
@@ -1136,7 +1136,7 @@ Das Inhaltselement »Download« fügt dem Artikel einen Download-Link hinzu. Be
 
 Die Besonderheit in Contao ist, dass dieser Download-Link auch mit geschützten Dateien funktioniert, auf die du nicht 
 direkt über deinen Browser zugreifen kannst. Auf diese Weise kannst du sehr einfach einen geschützten Download-Bereich 
-erstellen. Weitere Informationen dazu erhältst im Abschnitt [Dateimanager](../../dateimanager/).
+erstellen. Weitere Informationen dazu erhältst im Abschnitt [Dateiverwaltung](../../dateimanager/).
 
 **Quelldatei:** Hier kannst du die Download-Datei auswählen.
 
@@ -1174,7 +1174,7 @@ der »Datei speichern unter …«-Dialog, und du kannst die Datei auf deinem lok
 
 Die Besonderheit in Contao ist, dass diese Download-Links auch mit geschützten Dateien funktionieren, auf die du nicht 
 direkt über deinen Browser zugreifen kannst. Auf diese Weise kannst du sehr einfach einen geschützten Download-Bereich 
-erstellen. Weitere Informationen dazu erhältst du im Abschnitt [Dateimanager](../../dateimanager/).
+erstellen. Weitere Informationen dazu erhältst du im Abschnitt [Dateiverwaltung](../../dateimanager/).
 
 **Quelldateien:** Hier wählst du einen oder mehrere Ordner bzw. Dateien aus, die in dem Donwloads-Element enthalten 
 sein sollen. Wenn du einen Ordner auswählst, übernimmt Contao automatisch alle darin enthaltenen herunterladbaren 

--- a/docs/manual/backend/datensaetze-auflisten.de.md
+++ b/docs/manual/backend/datensaetze-auflisten.de.md
@@ -50,7 +50,7 @@ ausgewählten Elternelements an.
 
 Hierbei handelt es sich um Datensätze, die in einer hierarchischen Abhängigkeit zueinander stehen und daher in einer
 Baumstruktur dargestellt werden. Typischerweise ist das bei einem Dateisystem der Fall, in dem es Verzeichnisse und 
-Unterverzeichnisse gibt, deshalb nutzt der Contao-Dateimanager auch diese Ansicht. Hierarchische Strukturen können aber
+Unterverzeichnisse gibt, deshalb nutzt die Contao-Dateiverwaltung auch diese Ansicht. Hierarchische Strukturen können aber
 auch innerhalb einer Tabelle abgebildet werden, wie es z. B. bei der Seitenstruktur deiner Webseite der Fall ist.
 
 ![Der Tree View](/backend/images/de/der-tree-view.png)

--- a/docs/manual/file-manager/_index.de.md
+++ b/docs/manual/file-manager/_index.de.md
@@ -1,12 +1,12 @@
 ---
 title: "Dateimanager"
-description: "Mit dem Dateimanager kannst du Dateien und Ordner auf deinem Server verwalten und Dateien von deinem 
+description: "Mit der Dateiverwaltung kannst du Dateien und Ordner auf deinem Server verwalten und Dateien von deinem 
 lokalen Rechner auf den Server übertragen."
 url: "dateimanager"
 weight: 12
 ---
 
-Mit dem Dateimanager kannst du Dateien und Ordner auf deinem Server verwalten und Dateien von deinem lokalen Rechner 
+Mit der Dateiverwaltung kannst du Dateien und Ordner auf deinem Server verwalten und Dateien von deinem lokalen Rechner 
 auf den Server übertragen. Benutzerressourcen werden standardmäßig im Contao-Ordner `files` gespeichert. 
 Das datenbankgestützte Dateisystem von Contao speichert Dateiinformationen in der Datenbank und referenziert die 
 Einträge über deren [UUIDs (Universally Unique Identifier)](https://de.wikipedia.org/wiki/Universally_Unique_Identifier). 

--- a/docs/manual/file-manager/dateiverwaltung.de.md
+++ b/docs/manual/file-manager/dateiverwaltung.de.md
@@ -1,5 +1,5 @@
 ---
-title: "Dateiverwaltung"
+title: "Dateien und Ordner verwalten"
 description: "Die Dateiverwaltung bildet die Verzeichnisstruktur in einem hierarchischen Baum ab."
 url: "dateimanager/dateiverwaltung"
 weight: 1

--- a/docs/manual/file-manager/dateiverwaltung.de.md
+++ b/docs/manual/file-manager/dateiverwaltung.de.md
@@ -1,11 +1,11 @@
 ---
 title: "Dateiverwaltung"
-description: "Der Dateimanager bildet die Verzeichnisstruktur in einem hierarchischen Baum ab."
+description: "Die Dateiverwaltung bildet die Verzeichnisstruktur in einem hierarchischen Baum ab."
 url: "dateimanager/dateiverwaltung"
 weight: 1
 ---
 
-Der Dateimanager bildet die Verzeichnisstruktur in einem hierarchischen Baum ab. Jeder Unterordner ist ein eigener 
+Die Dateiverwaltung bildet die Verzeichnisstruktur in einem hierarchischen Baum ab. Jeder Unterordner ist ein eigener 
 Knoten, den du über das ![Plussymbol](/icons/folPlus.svg?classes=icon) Plus- bzw. 
 ![Minussymbol](/icons/folMinus.svg?classes=icon) Minussymbol aus- und einklappen kannst. Innerhalb jedes 
 Unterordners werden die darin enthaltenen Dateien aufgelistet. Handelt es sich dabei um Bilder, wird automatisch eine 
@@ -18,7 +18,7 @@ damit die Seite schneller lädt.
 Die Navigation erfolgt wie überall in Contao mithilfe von Navigationssymbolen. Die Optionen sind dabei für Ordner und 
 Dateien unterschiedlich.
 
-![Der Dateimanager](/file-manager/images/de/der-dateimanager.png)
+![Die Dateiverwaltung](/file-manager/images/de/der-dateimanager.png)
 
 **![Datei oder Verzeichnis bearbeiten](/icons/edit.svg?classes=icon) Bearbeiten:** Öffnet eine Eingabemaske zum 
 Umbenennen einer Datei bzw. eines Ordners. Außerdem können Metadaten von Dateien in der passenden Sprache eingepflegt 
@@ -47,7 +47,7 @@ Backend-Einstellungen unter »Editierbare Dateien« festlegen.
 
 ## Dateien übertragen {#dateien-uebertragen}
 
-Rufe den Dateimanager auf, und klicke auf den Link 
+Rufe die Dateiverwaltung auf, und klicke auf den Link 
 **![Dateien auf den Server hochladen](/icons/new.svg?classes=icon) Datei-Upload**, um Dateien auf den Server zu 
 übertragen. Über das Navigationssymbol **![In den Ordner einfügen](/icons/pasteinto.svg?classes=icon) Einfügen 
 in** kannst du das Zielverzeichnis auswählen. Alternativ kannst du direkt beim gewünschten Ordner auf das 
@@ -57,7 +57,7 @@ In den Benutzereinstellungen kannst du darüber hinaus [DropZone](https://www.d
 
 ![Dateien übertragen](/file-manager/images/de/dateien-uebertragen.png)
 
-In beiden Fällen prüft der Dateimanager beim Upload die Größe der zu übertragenden Datei, und – falls es sich dabei um 
+In beiden Fällen prüft die Dateiverwaltung beim Upload die Größe der zu übertragenden Datei, und – falls es sich dabei um 
 ein Bild handelt – auch dessen Abmessungen. Standardmäßig werden Dateien bis zu 2 MB und Bilder bis zu 3000x3000 Pixel 
 akzeptiert. Ist eine Datei zu groß bzw. ein Bild zu breit oder zu hoch, verweigert Contao den Upload bzw. verkleinert 
 das Bild automatisch auf die maximal zulässigen Abmessungen.
@@ -68,7 +68,7 @@ Upload-Dateitypen« festgelegt hast.
 
 ## Dateien per FTP übertragen {#dateien-per-ftp-uebertragen}
 
-Contao kann sowohl Dateien verarbeiten, die mit dem Dateimanager auf den Server übertragen wurden, als auch Dateien 
+Contao kann sowohl Dateien verarbeiten, die mit der Dateiverwaltung auf den Server übertragen wurden, als auch Dateien 
 bzw. Ordner, die du mit einem FTP-Programm hochgeladen hast. Damit die Ressourcen im datenbankgestützten Dateisystem 
 von Contao hinterlegt werden, musst du auf den Link 
 **![Dateisystem und Datenbank synchronisieren](/icons/sync.svg?classes=icon) Synchronisieren** klicken.
@@ -90,5 +90,5 @@ optimal:
 
 `Hendl-und-Mass-im-Schuetzenfestzelt.jpg`
 
-Beim Upload über den Dateimanager überprüft Contao die Dateinamen und passt sie gegebenenfalls automatisch an, sodass 
+Beim Upload über die Dateiverwaltung überprüft Contao die Dateinamen und passt sie gegebenenfalls automatisch an, sodass 
 Probleme mit falsch kodierten Sonderzeichen in der Bezeichnung von vornherein vermieden werden.

--- a/docs/manual/system/einstellungen.de.md
+++ b/docs/manual/system/einstellungen.de.md
@@ -97,15 +97,15 @@ dürfen. Bei einer Überschreitung dieses Werts wird das entsprechende Objekt a
 **Erlaubte Upload-Dateitypen:** Hier kannst du festlegen, welche Dateitypen auf deinen Server übertragen werden dürfen 
 (Upload).
 
-**Maximale Upload-Dateigrösse:** Hier kannst du festlegen, wie groß eine mit dem Dateimanager auf deinen Server 
+**Maximale Upload-Dateigrösse:** Hier kannst du festlegen, wie groß eine mit der Dateiverwaltung auf deinen Server 
 übertragene Datei maximal sein darf. Die Eingabe erfolgt in Bytes (1 MB = 1024 KB = 1.024.000 Bytes). Größere Dateien 
 werden abgelehnt.
 
-**Maximale Bildbreite:** Beim Upload von Bildern prüft der Dateimanager automatisch deren Breite und vergleicht diese 
+**Maximale Bildbreite:** Beim Upload von Bildern prüft die Dateiverwaltung automatisch deren Breite und vergleicht diese 
 Werte mit deiner hier festgelegten Vorgaben. Überschreitet ein Bild die maximale Breite, wird es automatisch 
 verkleinert.
 
-**Maximale Bildhöhe:** Beim Upload von Bildern prüft der Dateimanager automatisch deren Höhe und vergleicht diese Werte 
+**Maximale Bildhöhe:** Beim Upload von Bildern prüft die Dateiverwaltung automatisch deren Höhe und vergleicht diese Werte 
 mit deiner hier festgelegten Vorgaben. Überschreitet ein Bild die maximale Höhe, wird es automatisch verkleinert.
 
 

--- a/docs/manual/user-management/benutzer.de.md
+++ b/docs/manual/user-management/benutzer.de.md
@@ -67,7 +67,7 @@ dass ein Benutzer diese auch bearbeiten darf. Du kannst hier festlegen, was mit 
 
 | Operation                                                           | Erklärung                                                                                           |
 |:--------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
-| Dateien auf den Server hochladen                                    | Der Benutzer darf bestimmte Dateien über den Dateimanager auf den Server übertragen (Upload). Die erlaubten Dateien kannst du in den Backend-Einstellungen festlegen. |
+| Dateien auf den Server hochladen                                    | Der Benutzer darf bestimmte Dateien über die Dateiverwaltung auf den Server übertragen (Upload). Die erlaubten Dateien kannst du in den Backend-Einstellungen festlegen. |
 | Dateien und Verzeichnisse bearbeiten, kopieren und verschieben      | Der Benutzer darf Dateien und Verzeichnisse umbenennen, duplizieren und verschieben. |
 | Einzelne Dateien und leere Verzeichnisse löschen                    | Der Benutzer darf einzelne Dateien und leere Verzeichnisse löschen (nicht rekursiv). |
 | Verzeichnisse inklusive aller Dateien und Unterordner löschen (!)   | Der Benutzer darf Dateien und Verzeichnisse rekursiv, also inklusive aller enthaltenen Unterorder und Dateien, löschen. |
@@ -197,7 +197,7 @@ Jeder Benutzer kann das Backend an seine persönlichen Vorstellungen anpassen.
 **Erklärungen anzeigen:** Standardmäßig zeigt Contao unter jedem Eingabefeld eine kurze Erklärung an, die du bei Bedarf 
 hier abschalten kannst.
 
-**Vorschaubilder anzeigen:** Hier kannst du die Vorschaubilder in der Dateiübersicht des Dateimanagers deaktivieren, 
+**Vorschaubilder anzeigen:** Hier kannst du die Vorschaubilder in der Dateiübersicht der Dateiverwaltung deaktivieren, 
 damit die Verzeichnisstruktur schneller lädt.
 
 **Rich Text Editor verwenden:** Hier kannst du den Rich Text Editor deaktivieren.

--- a/docs/manual/user-management/mitglieder.de.md
+++ b/docs/manual/user-management/mitglieder.de.md
@@ -113,7 +113,7 @@ anmelden kann. Dazu sollte es mindestens einer Mitgliedergruppe angehören.
 
 ### Home-Verzeichnis
 
-Hier kannst du dem Mitglied ein eigenes Home-Verzeichnis zuweisen und dort z. B. mit dem Dateimanager bestimmte Dateien 
+Hier kannst du dem Mitglied ein eigenes Home-Verzeichnis zuweisen und dort z. B. mit der Dateiverwaltung bestimmte Dateien 
 bereitstellen. Sowohl das Modul »Bildergalerie« als auch das Modul »Downloads« bieten die Möglichkeit, das 
 Benutzerverzeichnis eines Mitglieds als Datenquelle zu verwenden.
 


### PR DESCRIPTION
In Contao the German translation of "file manager" is "Dateiverwaltung" and not "Dateimanager".