### PR TITLE
add language parameter (for all languages)

### DIFF
--- a/docs/manual/_index.en.md
+++ b/docs/manual/_index.en.md
@@ -1,0 +1,31 @@
+---
+title: "Contao Manual"
+---
+
+# Welcome
+
+You are here because the following people (in alphabetical order), and the Contao
+Community as a whole, were up day and night in order to further the development
+of Contao:
+
+- [Andreas (@aschempp)](https://github.com/aschempp)
+- [David (@bytehead)](https://github.com/bytehead)
+- [Jim (@sheeep)](https://github.com/sheeep)
+- [Leo (@leofeyer)](https://github.com/leofeyer), initiator
+- [Martin (@ausi)](https://github.com/ausi)
+- [Yanick (@toflar)](https://github.com/toflar)
+
+In addition to the core team, many more [contributors](https://github.com/contao/contao/graphs/contributors)
+make sure that Contao remains a unique and beautiful experience. We welcome anyone 
+who wants to be a part of this!
+
+This manual was created with support & funding of the [Contao Association](https://association.contao.org/)
+and the with support from the [Contao Community](https://community.contao.org/) 
+and is managed by the following people (in alphabetical order):
+
+- [Bjarke (@netzarbeiter)](https://github.com/netzarbeiter)
+- [Fritz Michael (@fritzmg)](https://github.com/fritzmg)
+
+{{% notice info %}}
+The English version of the manual is still a work in progress.
+{{% /notice %}}

--- a/docs/manual/article-management/_index.de.md
+++ b/docs/manual/article-management/_index.de.md
@@ -2,7 +2,7 @@
 title: "Artikelverwaltung"
 description: "Contao kapselt statische Inhalte in Artikel, die in der Artikelverwaltung einer bestimmten Seite und 
 einem bestimmten Layoutbereich zugeordnet werden."
-url: "artikelverwaltung"
+url: "de/artikelverwaltung"
 weight: 9
 ---
 

--- a/docs/manual/article-management/artikel.de.md
+++ b/docs/manual/article-management/artikel.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Artikel"
 description: "Jeder Artikel ist einer bestimmten Seite und einem bestimmten Layoutbereich zugeordnet."
-url: "artikelverwaltung/artikel"
+url: "de/artikelverwaltung/artikel"
 weight: 1
 ---
 

--- a/docs/manual/article-management/inhaltselemente.de.md
+++ b/docs/manual/article-management/inhaltselemente.de.md
@@ -2,7 +2,7 @@
 title: "Inhaltselemente"
 description: "Um das Anlegen von Inhalten möglichst intuitiv zu gestalten, gibt es in Contao für jeden Inhaltstyp ein 
 Inhaltselement, das genau auf dessen Anforderungen abgestimmt ist."
-url: "artikelverwaltung/inhaltselemente"
+url: "de/artikelverwaltung/inhaltselemente"
 weight: 2
 ---
 

--- a/docs/manual/article-management/insert-tags.de.md
+++ b/docs/manual/article-management/insert-tags.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Insert-Tags"
 description: "Insert-Tags sind Platzhalter, die bei der Ausgabe einer Seite durch bestimmte Werte ersetzt werden."
-url: "artikelverwaltung/insert-tags"
+url: "de/artikelverwaltung/insert-tags"
 weight: 3
 ---
 

--- a/docs/manual/backend/_index.de.md
+++ b/docs/manual/backend/_index.de.md
@@ -2,7 +2,7 @@
 title: "Administrationsbereich"
 description: "Im Administrationsbereich, dem sogenannten Backend, kannst du alle Arbeiten im Zusammenhang mit der 
 Verwaltung deiner Webseite erledigen."
-url: "administrationsbereich"
+url: "de/administrationsbereich"
 weight: 3
 ---
 

--- a/docs/manual/backend/aufruf-und-aufbau-des-backends.de.md
+++ b/docs/manual/backend/aufruf-und-aufbau-des-backends.de.md
@@ -2,7 +2,7 @@
 title: "Aufruf und Aufbau des Backends"
 description: "Im Administrationsbereich, dem sogenannten Backend, kannst du alle Arbeiten im Zusammenhang mit der 
 Verwaltung deiner Webseite erledigen. "
-url: "administrationsbereich/aufruf-und-aufbau-des-backends"
+url: "de/administrationsbereich/aufruf-und-aufbau-des-backends"
 weight: 1
 ---
 

--- a/docs/manual/backend/backend-tastaturkuerzel.de.md
+++ b/docs/manual/backend/backend-tastaturkuerzel.de.md
@@ -2,7 +2,7 @@
 title: "Backend-Tastaturkürzel"
 description: "Um den Workflow bei der Arbeit mit Contao zu beschleunigen, gibt es im Backend etliche Tastaturkürzel, 
 mit denen sich bestimmte Befehle direkt aufrufen lassen."
-url: "administrationsbereich/backend-tastaturkuerzel"
+url: "de/administrationsbereich/backend-tastaturkuerzel"
 weight: 2
 ---
 

--- a/docs/manual/backend/datensaetze-auflisten.de.md
+++ b/docs/manual/backend/datensaetze-auflisten.de.md
@@ -2,7 +2,7 @@
 title: "Datensätze auflisten"
 description: "Contao speichert alle Informationen rund um deine Webseite in der Datenbank. Dazu zählen sowohl 
 Backend-Daten wie Benutzer, Module, Seiten oder Artikel als auch Frontend-Daten wie Gästebucheinträge oder Kommentare."
-url: "administrationsbereich/datensaetze-auflisten"
+url: "de/administrationsbereich/datensaetze-auflisten"
 weight: 3
 ---
 

--- a/docs/manual/backend/datensaetze-bearbeiten.de.md
+++ b/docs/manual/backend/datensaetze-bearbeiten.de.md
@@ -2,7 +2,7 @@
 title: "Datensätze bearbeiten"
 description: "Das komfortable Bearbeiten von Daten zu ermöglichen, ist eine der Hauptaufgaben eines CMS – zumindest 
 sollte es so sein."
-url: "administrationsbereich/datensaetze-bearbeiten"
+url: "de/administrationsbereich/datensaetze-bearbeiten"
 weight: 4
 ---
 

--- a/docs/manual/core-extensions/_index.de.md
+++ b/docs/manual/core-extensions/_index.de.md
@@ -2,7 +2,7 @@
 title: "Core-Erweiterungen"
 description: "Die folgenden Erweiterungen sind im Lieferumfang von Contao enthalten: Nachrichten, Events, FAQ, 
 Newsletter, Kommentare und Auflistungen."
-url: "core-erweiterungen"
+url: "de/core-erweiterungen"
 weight: 10
 ---
 

--- a/docs/manual/core-extensions/calendar/_index.de.md
+++ b/docs/manual/core-extensions/calendar/_index.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Kalender-Erweiterung"
 description: "Damit können im Backend zukünftige und vergangene Veranstaltungen verwaltet werden."
-url: "core-erweiterung/kalender"
+url: "de/core-erweiterung/kalender"
 weight: 2
 ---
 

--- a/docs/manual/core-extensions/calendar/frontend-module.de.md
+++ b/docs/manual/core-extensions/calendar/frontend-module.de.md
@@ -2,7 +2,7 @@
 title: "Frontend-Module"
 description: "Die »Kalender«-Erweiterung enthält vier neue Frontend-Module, die du wie gewohnt über die Modulverwaltung 
 konfigurieren kannst."
-url: "core-erweiterung/kalender/frontend-module"
+url: "de/core-erweiterung/kalender/frontend-module"
 weight: 2
 ---
 

--- a/docs/manual/core-extensions/calendar/terminverwaltung.de.md
+++ b/docs/manual/core-extensions/calendar/terminverwaltung.de.md
@@ -2,7 +2,7 @@
 title: "Terminverwaltung"
 description: "Die Terminverwaltung ist ein eigenes Modul im Backend namens »Events«, das du in der Gruppe »Inhalte« an 
 dritter Stelle findest."
-url: "core-erweiterung/kalender/terminverwaltung"
+url: "de/core-erweiterung/kalender/terminverwaltung"
 weight: 1
 ---
 

--- a/docs/manual/core-extensions/faq/_index.de.md
+++ b/docs/manual/core-extensions/faq/_index.de.md
@@ -1,7 +1,7 @@
 ---
 title: "FAQ-Erweiterung"
 description: "Damit wird das Verwalten von häufig gestellten Fragen ein Kinderspiel."
-url: "core-erweiterung/faq"
+url: "de/core-erweiterung/faq"
 weight: 3
 ---
 

--- a/docs/manual/core-extensions/faq/faq-verwaltung.de.md
+++ b/docs/manual/core-extensions/faq/faq-verwaltung.de.md
@@ -2,7 +2,7 @@
 title: "FAQ-Verwaltung"
 description: "Die FAQ-Verwaltung ist ein eigenes Modul im Backend, das du in der Gruppe »Inhalte« an vierter Stelle 
 findest."
-url: "core-erweiterung/faq/faq-verwaltung"
+url: "de/core-erweiterung/faq/faq-verwaltung"
 weight: 1
 ---
 

--- a/docs/manual/core-extensions/faq/frontend-module.de.md
+++ b/docs/manual/core-extensions/faq/frontend-module.de.md
@@ -2,7 +2,7 @@
 title: "Frontend-Module"
 description: "Die FAQ-Erweiterung enthält drei neue Frontend-Module, die du wie gewohnt über die Modulverwaltung 
 konfigurieren kannst."
-url: "core-erweiterung/faq/frontend-module"
+url: "de/core-erweiterung/faq/frontend-module"
 weight: 2
 ---
 

--- a/docs/manual/core-extensions/news/_index.de.md
+++ b/docs/manual/core-extensions/news/_index.de.md
@@ -1,7 +1,7 @@
 ---
 title: "News/Blog-Erweiterung"
 description: "Damit können im Backend News-Einträge verwaltet und mit Hilfe von Frontend-Modulen ausgegeben werden."
-url: "core-erweiterung/nachrichten"
+url: "de/core-erweiterung/nachrichten"
 weight: 1
 ---
 

--- a/docs/manual/core-extensions/news/frontend-module.de.md
+++ b/docs/manual/core-extensions/news/frontend-module.de.md
@@ -2,7 +2,7 @@
 title: "Frontend-Module"
 description: "Die Nachrichtenerweiterung enthält vier neue Frontend-Module, die du wie gewohnt über die Modulverwaltung 
 konfigurieren kannst."
-url: "core-erweiterung/nachrichten/frontend-module"
+url: "de/core-erweiterung/nachrichten/frontend-module"
 weight: 2
 ---
 

--- a/docs/manual/core-extensions/news/nachrichtenverwaltung.de.md
+++ b/docs/manual/core-extensions/news/nachrichtenverwaltung.de.md
@@ -2,7 +2,7 @@
 title: "Nachrichtenverwaltung"
 description: "Die Nachrichtenverwaltung ist ein eigenes Modul im Backend, das du in der Gruppe »Inhalte« an zweiter 
 Stelle findest. "
-url: "core-erweiterung/nachrichten/nachrichtenverwaltung"
+url: "de/core-erweiterung/nachrichten/nachrichtenverwaltung"
 weight: 1
 ---
 

--- a/docs/manual/core-extensions/newsletter/_index.de.md
+++ b/docs/manual/core-extensions/newsletter/_index.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Newsletter-Erweiterung"
 description: "Damit können im Backend Newsletter und verschiedene Empfängerlisten verwaltet werden."
-url: "core-erweiterung/newsletter"
+url: "de/core-erweiterung/newsletter"
 weight: 4
 ---
 

--- a/docs/manual/core-extensions/newsletter/frontend-module.de.md
+++ b/docs/manual/core-extensions/newsletter/frontend-module.de.md
@@ -2,7 +2,7 @@
 title: "Frontend-Module"
 description: "Die Newsletter-Erweiterung enthält vier zusätzliche Frontend-Module, die du wie gewohnt über die Modulverwaltung 
 konfigurieren kannst."
-url: "core-erweiterung/newsletter/frontend-module"
+url: "de/core-erweiterung/newsletter/frontend-module"
 weight: 2
 ---
 

--- a/docs/manual/core-extensions/newsletter/newsletter-verwaltung.de.md
+++ b/docs/manual/core-extensions/newsletter/newsletter-verwaltung.de.md
@@ -2,7 +2,7 @@
 title: "Newsletter-Verwaltung"
 description: "Die Newsletter-Verwaltung ist ein eigenes Modul im Backend, das du in der Gruppe »Inhalte« an fünfter 
 Stelle findest. "
-url: "core-erweiterung/newsletter/newsletter-verwaltung"
+url: "de/core-erweiterung/newsletter/newsletter-verwaltung"
 weight: 1
 ---
 

--- a/docs/manual/extensions/_index.de.md
+++ b/docs/manual/extensions/_index.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Erweiterungen"
 description: "Der Leistungsumfang von Contao  kann durch das Installieren von Paketen erweitert werden."
-url: "erweiterungen"
+url: "de/erweiterungen"
 weight: 15
 ---
 

--- a/docs/manual/extensions/_index.en.md
+++ b/docs/manual/extensions/_index.en.md
@@ -1,0 +1,9 @@
+---
+title: "Extensions"
+description: "Contao's functionality can be extended by installing certain packages."
+weight: 15
+---
+
+Contao's functionality can be extended by installing certain packages.
+
+{{% children description="true" sort="Name" %}}

--- a/docs/manual/extensions/cca-merger2.de.md
+++ b/docs/manual/extensions/cca-merger2.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Merger²"
 description: "Merger² ist ein Frondend-Modul um Module/Inhalte unter bestimmten Bedingungen anzuzeigen."
-url: "erweiterung/merger2"
+url: "de/erweiterung/merger2"
 ---
 
 **[contao-community-alliance/merger2](https://packagist.org/packages/contao-community-alliance/merger2)**

--- a/docs/manual/extensions/cca-merger2.de.md
+++ b/docs/manual/extensions/cca-merger2.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Merger²"
 description: "Merger² ist ein Frondend-Modul um Module/Inhalte unter bestimmten Bedingungen anzuzeigen."
-url: "de/erweiterung/merger2"
+url: "de/erweiterungen/merger2"
 ---
 
 **[contao-community-alliance/merger2](https://packagist.org/packages/contao-community-alliance/merger2)**

--- a/docs/manual/extensions/cca-merger2.en.md
+++ b/docs/manual/extensions/cca-merger2.en.md
@@ -1,7 +1,6 @@
 ---
 title: "Merger²"
 description: "Merger² is a frontend module to display modules/contents under certain conditions."
-url: "de/extension/merger2"
 ---
 
 **[contao-community-alliance/merger2](https://packagist.org/packages/contao-community-alliance/merger2)**

--- a/docs/manual/extensions/cca-merger2.en.md
+++ b/docs/manual/extensions/cca-merger2.en.md
@@ -1,7 +1,7 @@
 ---
 title: "Merger²"
 description: "Merger² is a frontend module to display modules/contents under certain conditions."
-url: "extension/merger2"
+url: "de/extension/merger2"
 ---
 
 **[contao-community-alliance/merger2](https://packagist.org/packages/contao-community-alliance/merger2)**

--- a/docs/manual/extensions/contao-easy_themes.de.md
+++ b/docs/manual/extensions/contao-easy_themes.de.md
@@ -1,7 +1,7 @@
 ---
 title: "EasyThemes"
 description: "Einfacheres Verwalten von Themes mit EasyThemes."
-url: "de/erweiterung/contao-easy_themes"
+url: "de/erweiterungen/contao-easy_themes"
 ---
 
 **[terminal42/contao-easy_themes](https://packagist.org/packages/terminal42/contao-easy_themes)**

--- a/docs/manual/extensions/contao-easy_themes.de.md
+++ b/docs/manual/extensions/contao-easy_themes.de.md
@@ -1,7 +1,7 @@
 ---
 title: "EasyThemes"
 description: "Einfacheres Verwalten von Themes mit EasyThemes."
-url: "erweiterung/contao-easy_themes"
+url: "de/erweiterung/contao-easy_themes"
 ---
 
 **[terminal42/contao-easy_themes](https://packagist.org/packages/terminal42/contao-easy_themes)**

--- a/docs/manual/extensions/isotope-core.de.md
+++ b/docs/manual/extensions/isotope-core.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Isotope eCommerce"
 description: "Isotope eCommerce ist eine kostenlose eCommerce-Lösung für das Contao CMS."
-url: "de/erweiterung/isotope-core"
+url: "de/erweiterungen/isotope-core"
 ---
 
 **[isotope/isotope-core](https://packagist.org/packages/isotope/isotope-core)**

--- a/docs/manual/extensions/isotope-core.de.md
+++ b/docs/manual/extensions/isotope-core.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Isotope eCommerce"
 description: "Isotope eCommerce ist eine kostenlose eCommerce-Lösung für das Contao CMS."
-url: "erweiterung/isotope-core"
+url: "de/erweiterung/isotope-core"
 ---
 
 **[isotope/isotope-core](https://packagist.org/packages/isotope/isotope-core)**

--- a/docs/manual/extensions/maklermodul.de.md
+++ b/docs/manual/extensions/maklermodul.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Maklermodul für Immobilienmakler"
 description: "Das Maklermodul für Immobilienmakler ist eine kostenpflichtige Erweiterung für das Contao CMS."
-url: "de/erweiterung/maklermodul"
+url: "de/erweiterungen/maklermodul"
 ---
 
 **[pdir/maklermodul-bundle](https://packagist.org/packages/pdir/maklermodul-bundle)**

--- a/docs/manual/extensions/maklermodul.de.md
+++ b/docs/manual/extensions/maklermodul.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Maklermodul für Immobilienmakler"
 description: "Das Maklermodul für Immobilienmakler ist eine kostenpflichtige Erweiterung für das Contao CMS."
-url: "erweiterung/maklermodul"
+url: "de/erweiterung/maklermodul"
 ---
 
 **[pdir/maklermodul-bundle](https://packagist.org/packages/pdir/maklermodul-bundle)**

--- a/docs/manual/extensions/metamodels.de.md
+++ b/docs/manual/extensions/metamodels.de.md
@@ -1,7 +1,7 @@
 ---
 title: "MetaModels"
 description: "MetaModels ist eine Erweiterung für das CMS Contao für einen flexiblen und leichten Aufbau von eigenen Datenmodellen."
-url: "erweiterung/metamodels"
+url: "de/erweiterung/metamodels"
 ---
 
 **[metamodels](https://packagist.org/packages/metamodels/)**

--- a/docs/manual/extensions/metamodels.de.md
+++ b/docs/manual/extensions/metamodels.de.md
@@ -1,7 +1,7 @@
 ---
 title: "MetaModels"
 description: "MetaModels ist eine Erweiterung für das CMS Contao für einen flexiblen und leichten Aufbau von eigenen Datenmodellen."
-url: "de/erweiterung/metamodels"
+url: "de/erweiterungen/metamodels"
 ---
 
 **[metamodels](https://packagist.org/packages/metamodels/)**

--- a/docs/manual/extensions/metamodels.en.md
+++ b/docs/manual/extensions/metamodels.en.md
@@ -1,7 +1,7 @@
 ---
 title: "MetaModels"
 description: "MetaModels is an extension for CMS Contao and provides a flexible and easy way to build your own data models."
-url: "extension/metamodels"
+url: "de/extension/metamodels"
 ---
 
 **[metamodels](https://packagist.org/packages/metamodels/)**

--- a/docs/manual/extensions/metamodels.en.md
+++ b/docs/manual/extensions/metamodels.en.md
@@ -1,7 +1,6 @@
 ---
 title: "MetaModels"
 description: "MetaModels is an extension for CMS Contao and provides a flexible and easy way to build your own data models."
-url: "de/extension/metamodels"
 ---
 
 **[metamodels](https://packagist.org/packages/metamodels/)**

--- a/docs/manual/file-manager/_index.de.md
+++ b/docs/manual/file-manager/_index.de.md
@@ -2,7 +2,7 @@
 title: "Dateiverwaltung"
 description: "Mit der Dateiverwaltung kannst du Dateien und Ordner auf deinem Server verwalten und Dateien von deinem 
 lokalen Rechner auf den Server übertragen."
-url: "dateiverwaltung"
+url: "de/dateiverwaltung"
 weight: 12
 ---
 

--- a/docs/manual/file-manager/dateiverwaltung.de.md
+++ b/docs/manual/file-manager/dateiverwaltung.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Dateien und Ordner verwalten"
 description: "Die Dateiverwaltung bildet die Verzeichnisstruktur in einem hierarchischen Baum ab."
-url: "dateiverwaltung/dateien-und-ordner-verwalten"
+url: "de/dateiverwaltung/dateien-und-ordner-verwalten"
 weight: 1
 ---
 

--- a/docs/manual/file-manager/downloads-kontrollieren.de.md
+++ b/docs/manual/file-manager/downloads-kontrollieren.de.md
@@ -2,7 +2,7 @@
 title: "Downloads kontrollieren"
 description: "Mit Contao kannst du ganz einfach den Zugriff auf bestimmte Dateien beschränken und genau festlegen, wer 
 diese herunterladen darf und wer nicht."
-url: "dateiverwaltung/downloads-kontrollieren"
+url: "de/dateiverwaltung/downloads-kontrollieren"
 weight: 3
 ---
 

--- a/docs/manual/file-manager/metadaten.de.md
+++ b/docs/manual/file-manager/metadaten.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Metadaten"
 description: "In Contao kannst du zu jeder Art von Datei sogenannte Metadaten erfassen."
-url: "dateiverwaltung/metadaten"
+url: "de/dateiverwaltung/metadaten"
 weight: 2
 ---
 

--- a/docs/manual/form-generator/_index.de.md
+++ b/docs/manual/form-generator/_index.de.md
@@ -2,7 +2,7 @@
 title: "Formulargenerator"
 description: "Der Contao-Formulargenerator unterstützt dich bei der Erstellung von Formularen, indem er sowohl den 
 Prozess der Code-Generierung als auch die Validierung der Benutzereingaben abstrahiert."
-url: "formulargenerator"
+url: "de/formulargenerator"
 weight: 11
 ---
 

--- a/docs/manual/form-generator/ein-suuchformular-erstellen.de.md
+++ b/docs/manual/form-generator/ein-suuchformular-erstellen.de.md
@@ -2,7 +2,7 @@
 title: "Ein Suchformular erstellen"
 description: "Du kannst den Formulargenerator dazu nutzen, um ein eigenes Suchformular zu erstellen und dieses 
 beispielsweise in der Kopfzeile deiner Webseite einzubinden."
-url: "formulargenerator/ein-suchformular-erstellen"
+url: "de/formulargenerator/ein-suchformular-erstellen"
 weight: 3
 --- 
 

--- a/docs/manual/form-generator/formulare.de.md
+++ b/docs/manual/form-generator/formulare.de.md
@@ -2,7 +2,7 @@
 title: "Formulare"
 description: "Mit dem Formulargenerator kannst du Formulare erstellen und deren Daten entweder per E-Mail verschicken 
 oder in die Datenbank schreiben."
-url: "formulargenerator/formulare"
+url: "de/formulargenerator/formulare"
 weight: 1
 ---
 

--- a/docs/manual/form-generator/formularfelder.de.md
+++ b/docs/manual/form-generator/formularfelder.de.md
@@ -2,7 +2,7 @@
 title: "Formularfelder"
 description: "Ähnlich wie bei Artikeln und Inhaltselementen gibt es auch bei Formularen für jedes Formularfeld ein 
 eigenes Element, das speziell auf die jeweiligen Anforderungen des Eingabefelds ausgerichtet ist."
-url: "formulargenerator/formularfelder"
+url: "de/formulargenerator/formularfelder"
 weight: 2
 ---
 

--- a/docs/manual/introduction/_index.de.md
+++ b/docs/manual/introduction/_index.de.md
@@ -2,7 +2,7 @@
 title: "Contao im Überblick"
 description: "Contao ist ein Web Content Management System, das unter einer Open Source-Lizenz, nämlich der Lesser 
 General Public License, veröffentlicht wurde."
-url: "einleitung"
+url: "de/einleitung"
 weight: 1
 ---
 

--- a/docs/manual/introduction/contao-im-schnelldurchlauf.de.md
+++ b/docs/manual/introduction/contao-im-schnelldurchlauf.de.md
@@ -2,7 +2,7 @@
 title: "Contao im Schnelldurchlauf"
 description: "In diesem Abschnitt werden dir die grundsätzlichen Zusammenhänge und Funktionsweisen von Contao in 
 komprimierter Form vorgestellt."
-url: "einleitung/contao-im-schnelldurchlauf"
+url: "de/einleitung/contao-im-schnelldurchlauf"
 weight: 3
 ---
 

--- a/docs/manual/introduction/contao-open-source-cms.de.md
+++ b/docs/manual/introduction/contao-open-source-cms.de.md
@@ -2,7 +2,7 @@
 title: "Contao Open Source CMS"
 description: "Es handelt sich um ein CMS, also ein Content Management System, das unter einer Open Source-Lizenz steht 
 und Contao heißt."
-url: "einleitung/contao-open-source-cms"
+url: "de/einleitung/contao-open-source-cms"
 weight: 1
 ---
 

--- a/docs/manual/introduction/das-contao-netzwerk.de.md
+++ b/docs/manual/introduction/das-contao-netzwerk.de.md
@@ -2,7 +2,7 @@
 title: "Das Contao-Netzwerk"
 description: "Über die Jahre sind etliche Webseiten und Artikel zu Contao entstanden, teilweise in Absprache mit dem 
 Contao-Team, teilweise vollkommen autark."
-url: "einleitung/das-contao-netzwerk"
+url: "de/einleitung/das-contao-netzwerk"
 weight: 2
 ---
 

--- a/docs/manual/module-management/_index.de.md
+++ b/docs/manual/module-management/_index.de.md
@@ -2,7 +2,7 @@
 title: "Modulverwaltung"
 description: "Frontend-Module generieren den HTML-Code der Webseite. Sie gehören zu den designrelevanten Elementen und 
 sind deswegen dem Theme-Manager untergeordnet."
-url: "modulverwaltung"
+url: "de/modulverwaltung"
 weight: 8
 ---
 

--- a/docs/manual/module-management/anwendungen.de.md
+++ b/docs/manual/module-management/anwendungen.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Anwendungen"
 description: "In diesem Abschnitt werden dir die übrigen Core-Module im Bereich »Anwendungen« vorgestellt."
-url: "modulverwaltung/anwendungen"
+url: "de/modulverwaltung/anwendungen"
 weight: 4
 ---
 

--- a/docs/manual/module-management/benutzermodule.de.md
+++ b/docs/manual/module-management/benutzermodule.de.md
@@ -2,7 +2,7 @@
 title: "Benutzermodule"
 description: "Benutzermodule sind Module, die im Zusammenhang mit der Verwaltung von Frontend-Benutzern gebraucht 
 werden."
-url: "modulverwaltung/benutzermodule"
+url: "de/modulverwaltung/benutzermodule"
 weight: 2
 ---
 <style>

--- a/docs/manual/module-management/navigationsmodule.de.md
+++ b/docs/manual/module-management/navigationsmodule.de.md
@@ -2,7 +2,7 @@
 title: "Navigationsmodule"
 description: "Navigationsmodule sind mit die wichtigsten Frontend-Module überhaupt und kommen auf fast jeder Webseite 
 in irgendeiner Form zum Einsatz."
-url: "modulverwaltung/navigationsmodule"
+url: "de/modulverwaltung/navigationsmodule"
 weight: 1
 ---
 

--- a/docs/manual/module-management/verschiedenes.de.md
+++ b/docs/manual/module-management/verschiedenes.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Verschiedenes"
 description: "In diesem Abschnitt werden dir die übrigen Core-Module im Bereich »Verschiedenes« vorgestellt."
-url: "modulverwaltung/verschiedenes"
+url: "de/modulverwaltung/verschiedenes"
 weight: 5
 ---
 

--- a/docs/manual/module-management/website-suche.de.md
+++ b/docs/manual/module-management/website-suche.de.md
@@ -2,7 +2,7 @@
 title: "Website-Suche"
 description: "Contao indiziert die Seiten deiner Webpräsenz automatisch, sobald sie aufgerufen werden, und speichert 
 die darauf zu findenden Wörter als Suchbegriffe in einer Tabelle in der Datenbank."
-url: "modulverwaltung/website-suche"
+url: "de/modulverwaltung/website-suche"
 weight: 3
 ---
 

--- a/docs/manual/site-structure/_index.de.md
+++ b/docs/manual/site-structure/_index.de.md
@@ -2,7 +2,7 @@
 title: "Seitenstruktur"
 description: "Um Contao effektiv einsetzen zu können, ist es wichtig, dass du die Grundprinzipien und den Aufbau des 
 Systems verstehst."
-url: "seitenstruktur"
+url: "de/seitenstruktur"
 weight: 6
 ---
 

--- a/docs/manual/site-structure/mehrsprachige-webseiten.de.md
+++ b/docs/manual/site-structure/mehrsprachige-webseiten.de.md
@@ -3,7 +3,7 @@ title: "Mehrsprachige Webseiten"
 description: "Mehrsprachige Webseiten werden in Contao ebenfalls über verschiedene Webseiten in der Seitenstruktur 
 realisiert, die sich im Gegensatz zum Multidomain-Betrieb nicht anhand des Domainnamens unterscheiden, sondern anhand 
 der Sprache."
-url: "seitenstruktur/mehrsprachige-webseiten"
+url: "de/seitenstruktur/mehrsprachige-webseiten"
 weight: 4
 ---
 

--- a/docs/manual/site-structure/multidomain-betrieb.de.md
+++ b/docs/manual/site-structure/multidomain-betrieb.de.md
@@ -2,7 +2,7 @@
 title: "Multidomain-Betrieb"
 description: "Multidomain-Betrieb bedeutet, dass eine Contao-Installation unter mehreren Domains erreichbar ist und 
 diese jeweils eine unterschiedliche Ausgabe bewirken."
-url: "seitenstruktur/multidomain-betrieb"
+url: "de/seitenstruktur/multidomain-betrieb"
 weight: 3
 ---
 

--- a/docs/manual/site-structure/seiten-als-zentrale-elemente.de.md
+++ b/docs/manual/site-structure/seiten-als-zentrale-elemente.de.md
@@ -2,7 +2,7 @@
 title: "Seiten als zentrale Elemente"
 description: "Contao gehört zur Gruppe der seitenbasierten Content Management Systeme, das heißt, die Seitenstruktur 
 ist das zentrale Element deiner Webseite."
-url: "seitenstruktur/seiten-als-zentrale-elemente"
+url: "de/seitenstruktur/seiten-als-zentrale-elemente"
 weight: 1
 ---
 

--- a/docs/manual/site-structure/seiten-konfigurieren.de.md
+++ b/docs/manual/site-structure/seiten-konfigurieren.de.md
@@ -2,7 +2,7 @@
 title: "Seiten konfigurieren"
 description: "Nachdem du die richtigen Seitentypen für deine Seiten ausgewählt hast, kannst du diese deinen 
 Anforderungen entsprechend konfigurieren. Die Einstellungsmöglichkeiten variieren dabei je nach Seitentyp."
-url: "seitenstruktur/seiten-konfigurieren"
+url: "de/seitenstruktur/seiten-konfigurieren"
 weight: 2
 ---
 

--- a/docs/manual/user-management/_index.de.md
+++ b/docs/manual/user-management/_index.de.md
@@ -2,7 +2,7 @@
 title: "Benutzerverwaltung"
 description: "Die Benutzerverwaltung ist eine eigene Kategorie in der Backend-Navigation und beinhaltet vier Module, 
 mit denen jeweils die Benutzer und Gruppen des Backends und des Frontends verwaltet werden können."
-url: "benutzerverwaltung"
+url: "de/benutzerverwaltung"
 weight: 5
 ---
 

--- a/page/config/manual/config.yml
+++ b/page/config/manual/config.yml
@@ -1,7 +1,7 @@
 contentDir: '../docs/manual'
 title: 'Contao Manual'
-#defaultContentLanguageInSubdir: true
+defaultContentLanguageInSubdir: true
 
 # temporary
 DefaultContentLanguage: de
-disableLanguages: ['en']
+#disableLanguages: ['en']


### PR DESCRIPTION
This (re-)adds the language parameters to the URLs, so that URLs will be correct in the future.

A few things to note here:

* We are using the `url` [front matter variable](https://gohugo.io/content-management/front-matter/) in order to "translate" the URL path for a page. However, this parameter overrides _the whole_ URL, including any language parameter that would be present otherwise. Thus we need to manually include that (this PR fixes that for each page).

* Originally I wanted to completely disable the English language, as long as the English translation is still incomplete. However, since there would be only one language left, Hugo automatically does not add the language prefix any more then. Thus the English language is currently enabled and I have translated at least the home page and the index page for "Extensions" - since those would be the only "visible" pages for the English page tree.

* We had some trouble with images not showing up before, but I think it is fine now.