### PR TITLE
fix url variable

### DIFF
--- a/docs/manual/article-management/_index.de.md
+++ b/docs/manual/article-management/_index.de.md
@@ -2,7 +2,7 @@
 title: "Artikelverwaltung"
 description: "Contao kapselt statische Inhalte in Artikel, die in der Artikelverwaltung einer bestimmten Seite und 
 einem bestimmten Layoutbereich zugeordnet werden."
-url: "de/artikelverwaltung"
+url: "artikelverwaltung"
 weight: 9
 ---
 

--- a/docs/manual/article-management/artikel.de.md
+++ b/docs/manual/article-management/artikel.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Artikel"
 description: "Jeder Artikel ist einer bestimmten Seite und einem bestimmten Layoutbereich zugeordnet."
-url: "de/artikelverwaltung/artikel"
+url: "artikelverwaltung/artikel"
 weight: 1
 ---
 

--- a/docs/manual/article-management/artikel.de.md
+++ b/docs/manual/article-management/artikel.de.md
@@ -10,17 +10,17 @@ findest. Jeder Artikel ist einer bestimmten Seite und einem bestimmten Layoutber
 vielen anderen CMS ist das Einbinden von Artikeln in Contao nicht auf die Hauptspalte beschränkt, sodass du deine 
 Webseite flexibel gestalten kannst.
 
-![Die Artikelverwaltung](/article-management/images/de/die-artikelverwaltung.png)
+![Die Artikelverwaltung](/de/article-management/images/de/die-artikelverwaltung.png)
 
 Jede Seite kann beliebig viele Artikel enthalten, die innerhalb ihres Layoutbereichs untereinander in der von dir 
 festgelegten Reihenfolge dargestellt werden. Contao erkennt selbstständig, ob jeweils der ganze Artikel oder nur der 
 Teasertext, gefolgt von einem `Weiterlesen`-Link, angezeigt werden soll.
 
-![Mehrere Artikel mit Teasertext](/article-management/images/de/mehrere-artikel-mit-teasertext.png)
+![Mehrere Artikel mit Teasertext](/de/article-management/images/de/mehrere-artikel-mit-teasertext.png)
 
 Die Zuweisung eines Artikels zu einem Layoutbereich erfolgt in den Artikeleinstellungen im Feld Anzeigen in. Die 
 Artikeleinstellungen erreichst du am schnellsten, über das Navigationssymbole 
-![Die Artikeleinstellungen bearbeiten](/icons/header.svg?classes=icon) **Die Artikeleinstellungen bearbeiten**.
+![Die Artikeleinstellungen bearbeiten](/de/icons/header.svg?classes=icon) **Die Artikeleinstellungen bearbeiten**.
 
 
 ## Artikelaliase

--- a/docs/manual/article-management/inhaltselemente.de.md
+++ b/docs/manual/article-management/inhaltselemente.de.md
@@ -2,7 +2,7 @@
 title: "Inhaltselemente"
 description: "Um das Anlegen von Inhalten möglichst intuitiv zu gestalten, gibt es in Contao für jeden Inhaltstyp ein 
 Inhaltselement, das genau auf dessen Anforderungen abgestimmt ist."
-url: "de/artikelverwaltung/inhaltselemente"
+url: "artikelverwaltung/inhaltselemente"
 weight: 2
 ---
 

--- a/docs/manual/article-management/inhaltselemente.de.md
+++ b/docs/manual/article-management/inhaltselemente.de.md
@@ -10,7 +10,7 @@ Um das Anlegen von Inhalten möglichst intuitiv zu gestalten, gibt es in Contao 
 das genau auf dessen Anforderungen abgestimmt ist. Du kannst unbegrenzt viele Inhaltselemente pro Artikel anlegen und 
 den Zugriff auf einzelne Elemente bei Bedarf einschränken.
 
-![Den Zugriff auf ein Inhaltselement einschränken](/article-management/images/de/den-zugriff-auf-ein-modul-einschraenken.png)
+![Den Zugriff auf ein Inhaltselement einschränken](/de/article-management/images/de/den-zugriff-auf-ein-modul-einschraenken.png)
 
 **Element schützen:** Das Inhaltselement ist standardmäßig unsichtbar und wird erst eingeblendet, nachdem sich ein 
 Mitglied im Frontend angemeldet hat.
@@ -49,7 +49,7 @@ Rich Text Editor, der es dir ähnlich wie in einem Textverarbeitungsprogramm erl
 Knopfdruck zu setzen. Contao verwendet [TinyMCE](https://www.tiny.cloud/), einen Open Source Editor der schwedischen 
 Firma Moxiecode, der sich gut an die Erfordernisse der Barrierefreiheit anpassen lässt.
 
-![Der Rich Text Editor TinyMCE](/article-management/images/de/der-rich-text-editor-tinymce.png)
+![Der Rich Text Editor TinyMCE](/de/article-management/images/de/der-rich-text-editor-tinymce.png)
 
 **Überschrift:** Hier kannst du eine Überschrift eingeben.
 
@@ -67,7 +67,7 @@ dabei zur Verfügung:
 **Quelldatei:** Hier wählst du das einzufügende Bild aus. Wenn du das Bild noch nicht auf den Server übertragen hast, 
 kannst du den Upload hier nachholen, ohne die Eingabemaske zu verlassen.
 
-![Einem Text ein Bild hinzufügen](/article-management/images/de/einem-text-ein-bild-hinzufuegen.png)
+![Einem Text ein Bild hinzufügen](/de/article-management/images/de/einem-text-ein-bild-hinzufuegen.png)
 
 **Bildgröße:** Hier kannst du die gewünschte Bildgröße angeben. Dabei kannst du zwischen folgenden Skalierungsmodi 
 auswählen:
@@ -93,10 +93,10 @@ auswählen:
 | Rechts / Unten    | Erhält den rechten Teil eines Querformat-Bildes und den unteren Teil eines Hochformat-Bildes.      |
 
 **Bildausrichtung:** Hier legst du die Ausrichtung des Bildes fest. Wird er 
-![oberhalb](/icons/above.svg?classes=icon) **oberhalb**, 
-![unterhalb](/icons/below.svg?classes=icon) **unterhalb**, 
-![linksbündig](/icons/left.svg?classes=icon) **linksbündig** oder 
-![rechtsbündig](/icons/right.svg?classes=icon) **rechtsbündig** eingefügt der Text umfließt das Bild.
+![oberhalb](/de/icons/above.svg?classes=icon) **oberhalb**, 
+![unterhalb](/de/icons/below.svg?classes=icon) **unterhalb**, 
+![linksbündig](/de/icons/left.svg?classes=icon) **linksbündig** oder 
+![rechtsbündig](/de/icons/right.svg?classes=icon) **rechtsbündig** eingefügt der Text umfließt das Bild.
 
 **Bildabstand:** Hier legst du den Abstand des Bilds zum Text fest. Die Reihenfolge der Eingabefelder lautet im 
 Uhrzeigersinn »oben, rechts, unten, links«.
@@ -163,9 +163,9 @@ Das Inhaltselement »Aufzählung« fügt dem Artikel eine nicht verschachtelte 
 nummerierten (»ordered list«) und einer umnummerierten (»unordered list«) Aufzählung wählen. Beim Anlegen und 
 Bearbeiten der Listenpunkte unterstützt dich ein JavaScript-Assistent.
 
-![JavaScript-Assistent für Auflistungen](/article-management/images/de/javascript-assistent-fuer-auflistungen.png)
+![JavaScript-Assistent für Auflistungen](/de/article-management/images/de/javascript-assistent-fuer-auflistungen.png)
 
-Mit einem Klick auf das Icon ![Listendaten aus einer CSV-Datei importieren](/icons/tablewizard.svg?classes=icon) 
+Mit einem Klick auf das Icon ![Listendaten aus einer CSV-Datei importieren](/de/icons/tablewizard.svg?classes=icon) 
 neben der Feldbezeichnung »Listeneinträge« öffnest du den CSV-Import-Wizard, mit dem du Listendaten aus einer CSV-Datei 
 importieren kannst. Die CSV-Datei musst du vorher in das Upload-Verzeichnis übertragen haben.
 
@@ -192,20 +192,20 @@ Eine nummerierte Aufzählung verwendet das `<ol>`-Tag statt des `<ul>`-Tags.
 Das Inhaltselement »Tabelle« fügt dem Artikel eine Tabelle hinzu. Beim Anlegen der Reihen und Spalten unterstützt dich 
 ein JavaScript-Assistent. Mit den folgenden Navigationsicons kannst du die Tabelle bearbeiten:
 
-- ![Die Eingabefelder verkleinern](/icons/demagnify.svg?classes=icon) **Die Eingabefelder verkleinern**
-- ![Die Eingabefelder vergrößern](/icons/magnify.svg?classes=icon) **Die Eingabefelder vergrößern**
-- ![Die Spalte/Reihe duplizieren](/icons/copy.svg?classes=icon) **Die Spalte/Reihe duplizieren**
-- ![Die Spalte eine Position nach links verschieben](/icons/movel.svg?classes=icon) 
+- ![Die Eingabefelder verkleinern](/de/icons/demagnify.svg?classes=icon) **Die Eingabefelder verkleinern**
+- ![Die Eingabefelder vergrößern](/de/icons/magnify.svg?classes=icon) **Die Eingabefelder vergrößern**
+- ![Die Spalte/Reihe duplizieren](/de/icons/copy.svg?classes=icon) **Die Spalte/Reihe duplizieren**
+- ![Die Spalte eine Position nach links verschieben](/de/icons/movel.svg?classes=icon) 
 **Die Spalte eine Position nach links verschieben**
-- ![Die Spalte eine Position nach rechts verschieben](/icons/mover.svg?classes=icon) 
+- ![Die Spalte eine Position nach rechts verschieben](/de/icons/mover.svg?classes=icon) 
 **Die Spalte eine Position nach rechts verschieben**
-- ![Die Spalte/Reihe löschen](/icons/delete.svg?classes=icon) **Die Spalte/Reihe löschen**
-- ![Das Element durch Ziehen und Ablegen verschieben](/icons/drag.svg?classes=icon) 
+- ![Die Spalte/Reihe löschen](/de/icons/delete.svg?classes=icon) **Die Spalte/Reihe löschen**
+- ![Das Element durch Ziehen und Ablegen verschieben](/de/icons/drag.svg?classes=icon) 
 **Das Element durch Ziehen und Ablegen verschieben**
 
-![JavaScript-Assistent für Tabellen](/article-management/images/de/javascript-assistent-fuer-tabellen.png)
+![JavaScript-Assistent für Tabellen](/de/article-management/images/de/javascript-assistent-fuer-tabellen.png)
 
-Mit einem Klick auf das Icon ![Listendaten aus einer CSV-Datei importieren](/icons/tablewizard.svg?classes=icon) 
+Mit einem Klick auf das Icon ![Listendaten aus einer CSV-Datei importieren](/de/icons/tablewizard.svg?classes=icon) 
 neben der Feldbezeichnung »Tabelleneinträge« öffnest du den CSV-Import-Wizard, mit dem du Tabellendaten aus einer 
 CSV-Datei importieren kannst. Die CSV-Datei musst du vorher in das Upload-Verzeichnis übertragen haben.
 
@@ -480,7 +480,7 @@ Wie für Links gibt es auch für Bilder zwei Syntax-Möglichkeiten.
 Ein Inline-Bild sieht wie folgt aus:
 
 ```md
-![Alt text](/pfad/zum/bild.jpg "Optionaler Titel")
+![Alt text](/de/pfad/zum/bild.jpg "Optionaler Titel")
 ```
 
 Ein Bild im Referenz-Stil wird durch folgende Syntax erreicht:
@@ -705,7 +705,7 @@ Das Element generiert folgenden HTML-Code:
 Das Inhaltselement »Hyperlink« fügt dem Artikel einen Link auf eine externe Webseite oder eine E-Mail-Adresse hinzu. Du 
 kannst Hyperlinks natürlich auch über den Rich Text Editor im Textelement eingeben.
 
-![Einen Hyperlink anlegen](/article-management/images/de/einen-hyperlink-anlegen.png)
+![Einen Hyperlink anlegen](/de/article-management/images/de/einen-hyperlink-anlegen.png)
 
 **Link-Adresse:** Gebe die Link-Adresse inklusive des Netzwerkprotokolls ein. Für Webseiten lautet das 
 Netzwerkprotokoll normalerweise `http://` oder `https://`, für E-Mail-Adressen `mailto:` und für Telefonnummern `tel:`. 
@@ -729,7 +729,7 @@ der Satz »Besuchen Sie unsere Firmenseite!« steht.
 Wenn du die Option **Einen Bildlink erstellen** auswählst, kannst du statt eines Textlinks einen Bildlink erstellen. 
 Alternativ dazu kannst du auch ein Bildelement erstellen und mit einem Link versehen.
 
-![Einen Bildlink erstellen](/article-management/images/de/einen-bildlink-erstellen.png)
+![Einen Bildlink erstellen](/de/article-management/images/de/einen-bildlink-erstellen.png)
 
 **Quelldatei:** Hier wählst du das zu verwendende Bild aus.
 
@@ -800,7 +800,7 @@ Das Element generiert folgenden HTML-Code:
 Das Inhaltselement »Bild« fügt dem Artikel ein Bild hinzu. Ein Bild kann eine Großansicht haben oder als Bildlink auf 
 eine bestimmte URL verweisen.
 
-![Ein Bildelement anlegen](/article-management/images/de/ein-bildelement-anlegen.png)
+![Ein Bildelement anlegen](/de/article-management/images/de/ein-bildelement-anlegen.png)
 
 **Quelldatei:** Hier wählst du das zu verwendende Bild aus.
 
@@ -850,7 +850,7 @@ Das Inhaltselement »Bildergalerie« fügt dem Artikel eine Bildergalerie hinzu
 Vorschaubilder (engl. »Thumbnails«), die in einer Liste aufgelistet sind und beim Anklicken vergrößert werden. Bei 
 sehr vielen Bildern kann die Galerie auf mehrere Seiten verteilt werden.
 
-![Die Bildergalerie im Frontend](/article-management/images/de/die-bildergalerie-im-frontend.png)
+![Die Bildergalerie im Frontend](/de/article-management/images/de/die-bildergalerie-im-frontend.png)
 
 **Quelldateien:** Hier wählst du einen oder mehrere Ordner bzw. Dateien aus, die in der Bildergalerie enthalten sein 
 sollen. Wenn du einen Ordner auswählst, übernimmt Contao automatisch alle darin enthaltenen Bilder in die Galerie. Die 
@@ -1170,7 +1170,7 @@ Das Element generiert folgenden HTML-Code:
 Das Inhaltselement »Downloads« fügt dem Artikel mehrere Download-Links hinzu. Beim Anklicken eines Links öffnet sich 
 der »Datei speichern unter …«-Dialog, und du kannst die Datei auf deinem lokalen Rechner speichern.
 
-![Das Downloads-Element im Frontend](/article-management/images/de/das-downloads-element-im-frontend.png)
+![Das Downloads-Element im Frontend](/de/article-management/images/de/das-downloads-element-im-frontend.png)
 
 Die Besonderheit in Contao ist, dass diese Download-Links auch mit geschützten Dateien funktionieren, auf die du nicht 
 direkt über deinen Browser zugreifen kannst. Auf diese Weise kannst du sehr einfach einen geschützten Download-Bereich 
@@ -1331,7 +1331,7 @@ du in der Navigation in der Gruppe Inhalte findest. Dort werden sämtliche Komme
 ein Inhaltselement, einen Artikel oder einen Blog-Beitrag beziehen. Bei Bedarf kannst du die Liste der Kommentare nach 
 ihrem Ursprung oder ihrem Elternelement filtern.
 
-![Kommentare nach ihrem Ursprung filtern](/article-management/images/de/kommentare-nach-ihrem-ursprung-filtern.png)
+![Kommentare nach ihrem Ursprung filtern](/de/article-management/images/de/kommentare-nach-ihrem-ursprung-filtern.png)
 
 Falls du die Option »Kommentare moderieren« aktiviert hast, kannst du neue Kommentare in der Kommentarverwaltung 
 prüfen, bevor sie auf der Webseite erscheinen. So verhinderst du z. B. eventuelle Spamversuche.

--- a/docs/manual/article-management/insert-tags.de.md
+++ b/docs/manual/article-management/insert-tags.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Insert-Tags"
 description: "Insert-Tags sind Platzhalter, die bei der Ausgabe einer Seite durch bestimmte Werte ersetzt werden."
-url: "de/artikelverwaltung/insert-tags"
+url: "artikelverwaltung/insert-tags"
 weight: 3
 ---
 

--- a/docs/manual/backend/_index.de.md
+++ b/docs/manual/backend/_index.de.md
@@ -2,7 +2,7 @@
 title: "Administrationsbereich"
 description: "Im Administrationsbereich, dem sogenannten Backend, kannst du alle Arbeiten im Zusammenhang mit der 
 Verwaltung deiner Webseite erledigen."
-url: "de/administrationsbereich"
+url: "administrationsbereich"
 weight: 3
 ---
 

--- a/docs/manual/backend/aufruf-und-aufbau-des-backends.de.md
+++ b/docs/manual/backend/aufruf-und-aufbau-des-backends.de.md
@@ -17,7 +17,7 @@ vollständige Adresse sieht dann so aus:
 Gebe deinen `Benutzernamen` un dein `Passwort` ein. Die im Internetbrowser voreingestellte Sprache wird auch fürs
 Backend verwendet. Bestätige deine Eingaben mit einem Klick auf die Schaltfläche `Weiter`. 
 
-![Anmeldung im Contao-Backend](/backend/images/de/contao-backend-anmeldung.png)
+![Anmeldung im Contao-Backend](/de/backend/images/de/contao-backend-anmeldung.png)
 
 Die Backend-Anmeldung ist mit einem Zeitverzögerungsmechanismus gegen [Brute-Force-
 Attacken](https://de.wikipedia.org/wiki/Brute-Force-Methode) geschützt. Wenn du mehr als dreimal hintereinander ein
@@ -31,7 +31,7 @@ gefunden hat.
 Das Backend ist in drei Bereiche unterteilt. Oben befindet sich der Infobereich, auf der linken Seite die Navigation und
 auf der rechten der Arbeitsbereich.
 
-![Aufteilung des Contao-Backends](/backend/images/de/contao-backend-aufteilung.png)
+![Aufteilung des Contao-Backends](/de/backend/images/de/contao-backend-aufteilung.png)
 
 
 ### Der Infobereich

--- a/docs/manual/backend/aufruf-und-aufbau-des-backends.de.md
+++ b/docs/manual/backend/aufruf-und-aufbau-des-backends.de.md
@@ -2,7 +2,7 @@
 title: "Aufruf und Aufbau des Backends"
 description: "Im Administrationsbereich, dem sogenannten Backend, kannst du alle Arbeiten im Zusammenhang mit der 
 Verwaltung deiner Webseite erledigen. "
-url: "de/administrationsbereich/aufruf-und-aufbau-des-backends"
+url: "administrationsbereich/aufruf-und-aufbau-des-backends"
 weight: 1
 ---
 

--- a/docs/manual/backend/backend-tastaturkuerzel.de.md
+++ b/docs/manual/backend/backend-tastaturkuerzel.de.md
@@ -2,7 +2,7 @@
 title: "Backend-Tastaturkürzel"
 description: "Um den Workflow bei der Arbeit mit Contao zu beschleunigen, gibt es im Backend etliche Tastaturkürzel, 
 mit denen sich bestimmte Befehle direkt aufrufen lassen."
-url: "de/administrationsbereich/backend-tastaturkuerzel"
+url: "administrationsbereich/backend-tastaturkuerzel"
 weight: 2
 ---
 

--- a/docs/manual/backend/datensaetze-auflisten.de.md
+++ b/docs/manual/backend/datensaetze-auflisten.de.md
@@ -24,7 +24,7 @@ Die drei häufigsten Formen von Auflistungen, die nachfolgend Ansichten genannt 
 Hierbei handelt es sich um Datensätze einer einzelnen Tabelle, die in einer bestimmten Reihenfolge aufgelistet werden. 
 Die Sortierung ist meistens alphabetisch, und die einzelnen Zeilen sind nach Anfangsbuchstaben gruppiert.
 
-![Der List View](/backend/images/de/der-list-view.png)
+![Der List View](/de/backend/images/de/der-list-view.png)
 
 
 ### Parent View
@@ -43,7 +43,7 @@ Wenn du nun den Inhalt eines Warenkorbs auflistest, willst du natürlich nur di
 und nicht die Produkte des zweiten. Daher zeigt Contao dir im Parent View auch nur die Kindelemente des jeweils 
 ausgewählten Elternelements an.
 
-![Der Parent View](/backend/images/de/der-parent-view.png)
+![Der Parent View](/de/backend/images/de/der-parent-view.png)
 
 
 ### Tree View
@@ -53,7 +53,7 @@ Baumstruktur dargestellt werden. Typischerweise ist das bei einem Dateisystem de
 Unterverzeichnisse gibt, deshalb nutzt die Contao-Dateiverwaltung auch diese Ansicht. Hierarchische Strukturen können aber
 auch innerhalb einer Tabelle abgebildet werden, wie es z. B. bei der Seitenstruktur deiner Webseite der Fall ist.
 
-![Der Tree View](/backend/images/de/der-tree-view.png)
+![Der Tree View](/de/backend/images/de/der-tree-view.png)
 
 
 ## Datensätze sortieren und filtern {#datensaetze-sortieren-und-filtern}
@@ -63,7 +63,7 @@ Möglichkeiten, Auflistungen zu sortieren und durch Filter einzuschränken. Die 
 gezieltes Filtern so einschränken, dass dir nur die Datensätze angezeigt werden, die du auch wirklich für eine 
 bestimmte Aktion benötigst.
 
-![Datensätze sortieren und filtern](/backend/images/de/datensaetze-sortieren-und-filtern.png)
+![Datensätze sortieren und filtern](/de/backend/images/de/datensaetze-sortieren-und-filtern.png)
 
 **Filtern:** Hier kannst du einen oder mehrere Filter setzen und dir so z. B. nur die Mitglieder anzeigen lassen, 
 die männlich sind und Deutsch sprechen.
@@ -86,10 +86,10 @@ dem Drop-Down-Menü bzw. löschen den Suchbegriff aus dem Suchfeld.
 
 Durch Klick auf folgende Icons können die Filter angewendet bzw. zurückgesetzt werden:
 
-![Filter anwenden](/icons/filter-apply.svg?classes=icon) **Filter anwenden:** die Filter setzen und danach 
+![Filter anwenden](/de/icons/filter-apply.svg?classes=icon) **Filter anwenden:** die Filter setzen und danach 
 anwenden.
 
-![Filter zurücksetzen](/icons/filter-reset.svg?classes=icon) **Filter zurücksetzen:** die Filter-Auswahl 
+![Filter zurücksetzen](/de/icons/filter-reset.svg?classes=icon) **Filter zurücksetzen:** die Filter-Auswahl 
 zurücksetzen.
 
 
@@ -106,27 +106,27 @@ Die folgenden Navigationssymbole kommen in fast allen Ansichten vor. Aus Gründ
 zusätzlich mit einem Text versehen. Wenn du aber den Zeiger deiner Maus über einem Icon positionierst, wird dir die 
 entsprechende Beschreibung dazu angezeigt.
 
-![Bearbeiten](/icons/edit.svg?classes=icon) **Bearbeiten:** ruft einen bestimmten Datensatz im Bearbeitungsmodus 
+![Bearbeiten](/de/icons/edit.svg?classes=icon) **Bearbeiten:** ruft einen bestimmten Datensatz im Bearbeitungsmodus 
 auf.
 
-![Duplizieren](/icons/copy.svg?classes=icon) **Duplizieren:** erstellt eine Kopie eines vorhandenen Datensatzes.
+![Duplizieren](/de/icons/copy.svg?classes=icon) **Duplizieren:** erstellt eine Kopie eines vorhandenen Datensatzes.
 
-![Löschen](/icons/delete.svg?classes=icon) **Löschen:** löscht einen Datensatz. 
+![Löschen](/de/icons/delete.svg?classes=icon) **Löschen:** löscht einen Datensatz. 
 ([Dieser Vorgang kann widerrufen werden.](#geloeschte-datensaetze-wiederherstellen))
 
-![Veröffentlichen/unveröffentlichen](/icons/visible.svg?classes=icon) **Veröffentlichen/unveröffentlichen:** im 
+![Veröffentlichen/unveröffentlichen](/de/icons/visible.svg?classes=icon) **Veröffentlichen/unveröffentlichen:** im 
 Frontend anzeigen bzw. ausblenden
 
-![Info](/icons/show.svg?classes=icon) **Info:** zeigt Informationen zu einem Datensatz.
+![Info](/de/icons/show.svg?classes=icon) **Info:** zeigt Informationen zu einem Datensatz.
 
 
 ### Icons im List View
 
 Der List View kann neben den grundlegenden Befehlen, noch folgende zusätzlichen Befehle anbieten.
 
-![Icons im List View](/backend/images/de/icons-im-list-view.png)
+![Icons im List View](/de/backend/images/de/icons-im-list-view.png)
 
-![Einstellungen bearbeiten](/icons/header.svg?classes=icon) **Einstellungen bearbeiten:** die Einstellungen für 
+![Einstellungen bearbeiten](/de/icons/header.svg?classes=icon) **Einstellungen bearbeiten:** die Einstellungen für 
 das Eltern-Element anpassen.
 
 
@@ -134,19 +134,19 @@ das Eltern-Element anpassen.
 
 Der Parent View bietet zwei zusätzliche Icons, um die Reihenfolge der Datensätze festlegen zu können. Die Reihenfolge 
 kann auch mittels Drag & Drop geändert werden. Dazu einfach auf das Drag & Drop-Icon 
-![Verschieben](/icons/drag.svg?classes=icon) klicken und an die neue Position bewegen.
+![Verschieben](/de/icons/drag.svg?classes=icon) klicken und an die neue Position bewegen.
 
-![Icons im Parent View](/backend/images/de/icons-im-parent-view.png)
+![Icons im Parent View](/de/backend/images/de/icons-im-parent-view.png)
 
-![Verschieben](/icons/cut.svg?classes=icon) **Verschieben:** verschiebt einen Datensatz an eine andere Position.
+![Verschieben](/de/icons/cut.svg?classes=icon) **Verschieben:** verschiebt einen Datensatz an eine andere Position.
 
-![Neues Element](/icons/new.svg?classes=icon) **Neues Element:** erstellt einen neuen Datensatz nach dem 
+![Neues Element](/de/icons/new.svg?classes=icon) **Neues Element:** erstellt einen neuen Datensatz nach dem 
 aktuellen Datensatz.
 
-![Einfügen](/icons/pasteafter.svg?classes=icon) **Einfügen:** fügt einen Datensatz nach dem aktuellen Datensatz 
+![Einfügen](/de/icons/pasteafter.svg?classes=icon) **Einfügen:** fügt einen Datensatz nach dem aktuellen Datensatz 
 ein.
 
-**![Datei oder Verzeichnis verschieben](/icons/drag.svg?classes=icon) Verschieben:** Eine Datei bzw. einen 
+**![Datei oder Verzeichnis verschieben](/de/icons/drag.svg?classes=icon) Verschieben:** Eine Datei bzw. einen 
 Ordner per Drag & Drop verschieben.
 
 
@@ -157,20 +157,20 @@ untereinander notwendig sind. Du brauchst beispielsweise eine Möglichkeit, beim
 Datensätzen festzulegen, ob diese nach einem Datensatz in derselben Ebene oder unterhalb eines Datensatzes in einer 
 neuen Ebene eingefügt werden sollen.
 
-![Icons im Tree View](/backend/images/de/icons-im-tree-view.png)
+![Icons im Tree View](/de/backend/images/de/icons-im-tree-view.png)
 
-![Unterseiten duplizieren](/icons/copychilds.svg?classes=icon) **Unterseiten duplizieren:** dupliziert eine 
+![Unterseiten duplizieren](/de/icons/copychilds.svg?classes=icon) **Unterseiten duplizieren:** dupliziert eine 
 Seite inklusive aller Unterseiten.
 
-![Seite bearbeiten](/icons/article.svg?classes=icon) **Seite bearbeiten:**  die Seite bearbeiten.
+![Seite bearbeiten](/de/icons/article.svg?classes=icon) **Seite bearbeiten:**  die Seite bearbeiten.
 
-![Dahinter einfügen](/icons/pasteafter.svg?classes=icon) **Dahinter einfügen:** fügt eine Seite nach der 
+![Dahinter einfügen](/de/icons/pasteafter.svg?classes=icon) **Dahinter einfügen:** fügt eine Seite nach der 
 aktuellen Seite ein.
 
-![Darunter einfügen](/icons/pasteinto.svg?classes=icon) **Darunter einfügen:** fügt eine Seite unterhalb der 
+![Darunter einfügen](/de/icons/pasteinto.svg?classes=icon) **Darunter einfügen:** fügt eine Seite unterhalb der 
 aktuellen Seite ein.
 
-![Artikel bearbeiten](/icons/article.svg?classes=icon) **Artikel bearbeiten:** den Artikel der Seite bearbeiten.
+![Artikel bearbeiten](/de/icons/article.svg?classes=icon) **Artikel bearbeiten:** den Artikel der Seite bearbeiten.
 
 
 ## Das Klemmbrett
@@ -183,7 +183,7 @@ Du kannst dir das Klemmbrett wie die Zwischenablage auf deinem Rechner vorstelle
 Daten kopieren und mit `[Ctrl]+[v]` an einer anderen Stelle wieder einfügen kannst. In Contao kannst du so z. B. 
 Inhaltselemente von einem Artikel in einen anderen verschieben.
 
-![Inhaltselemente mittels Klemmbrett verschieben](/backend/images/de/inhaltselemente-mittels-klemmbrett-verschieben.png)
+![Inhaltselemente mittels Klemmbrett verschieben](/de/backend/images/de/inhaltselemente-mittels-klemmbrett-verschieben.png)
 
 
 ## Gelöschte Datensätze wiederherstellen {#geloeschte-datensaetze-wiederherstellen}
@@ -195,7 +195,7 @@ der ursprünglichen Stelle wiederherstellen.
 Du findest den »Papierkorb« im Navigationsbereich in der Gruppe System unter dem Punkt Wiederherstellen. Dort siehst du 
 eine Liste aller gelöschten Datensätze, die du entweder nach dem Datum der Löschung oder dem Ursprung des Datensatzes 
 sortieren kannst. Mit einem Klick auf das entsprechende Navigationssymbol 
-![Eintrag wiederherstellen](/icons/undo.svg?classes=icon) 
+![Eintrag wiederherstellen](/de/icons/undo.svg?classes=icon) 
 kannst du einen Löschvorgang rückgängig machen.
 
-![Einen Löschvorgang rückgängig machen](/backend/images/de/einen-loeschvorgang-rueckgaengig-machen.png)
+![Einen Löschvorgang rückgängig machen](/de/backend/images/de/einen-loeschvorgang-rueckgaengig-machen.png)

--- a/docs/manual/backend/datensaetze-auflisten.de.md
+++ b/docs/manual/backend/datensaetze-auflisten.de.md
@@ -2,7 +2,7 @@
 title: "Datensätze auflisten"
 description: "Contao speichert alle Informationen rund um deine Webseite in der Datenbank. Dazu zählen sowohl 
 Backend-Daten wie Benutzer, Module, Seiten oder Artikel als auch Frontend-Daten wie Gästebucheinträge oder Kommentare."
-url: "de/administrationsbereich/datensaetze-auflisten"
+url: "administrationsbereich/datensaetze-auflisten"
 weight: 3
 ---
 

--- a/docs/manual/backend/datensaetze-bearbeiten.de.md
+++ b/docs/manual/backend/datensaetze-bearbeiten.de.md
@@ -50,7 +50,7 @@ In Contao kannst du sehr komfortabel mehrere Datensätze auf einmal bearbeiten, 
 und ändern zu müssen. Klicke dazu auf den Link `Mehrere bearbeiten`. Wie du siehst, werden die Navigationssymbole
 automatisch durch Checkboxen ersetzt, mit denen du die zu bearbeitenden Datensätze auswählen kannst.
 
-![Mehrere Datensätze bearbeiten](/backend/images/de/mehrere-datensaetze-bearbeiten.png)
+![Mehrere Datensätze bearbeiten](/de/backend/images/de/mehrere-datensaetze-bearbeiten.png)
 
 **Bearbeiten:** Die ausgewählten Datensätze können bearbeitet werden.
 
@@ -72,13 +72,13 @@ ausgewählten Datensätze durch den neuen Wert ersetzt!
 Ein Klick auf `Überschreiben` oder `Bearbeiten` führt dich zur Übersicht der Felder, die in der Tabelle vorhanden sind. 
 Wähle dort gezielt die Eingabefelder aus, die du überschreiben bzw. bearbeiten möchtest, und klicke auf `Weiter`.
 
-![Die zu bearbeitenden Eingabefelder auswählen](/backend/images/de/die-zu-bearbeitenden-eingabefelder-auswaehlen.png)
+![Die zu bearbeitenden Eingabefelder auswählen](/de/backend/images/de/die-zu-bearbeitenden-eingabefelder-auswaehlen.png)
 
 Du siehst jetzt die ausgewählten Eingabefelder der selektierten Datensätze und kannst diese bequem in einem einzigen 
 Arbeitsschritt ändern. Auch bei der Bearbeitung mehrerer Datensätze werden dir natürlich nur die Eingabefelder 
 angezeigt, die du auch tatsächlich für dein Vorhaben benötigst.
 
-![Nur die ausgewählten Eingabefelder werden angezeigt](/backend/images/de/nur-die-ausgewaehlten-eingabefelder-werden-angezeigt.png)
+![Nur die ausgewählten Eingabefelder werden angezeigt](/de/backend/images/de/nur-die-ausgewaehlten-eingabefelder-werden-angezeigt.png)
 
 Analog zu diesem Beispiel hättest du mit der Funktion »Überschreiben« die Sprache aller Seiten in einem Rutsch mit
 einem neuen Wert überschreiben können. Und die Funktion kann noch mehr: Eventuell kommst du irgendwann in die
@@ -86,7 +86,7 @@ Verlegenheit, dass du eine neue Mitgliedergruppe angelegt hast und diese nun bei
 ergänzen möchtest, ohne dabei die bestehende Zuordnung zu löschen. Auch das kannst du mit der »Überschreiben«-Funktion 
 erledigen, indem du den passenden Update-Modus auswählst.
 
-![Auswahl des Update-Modus beim Überschreiben von Datensätzen](/backend/images/de/auswahl-des-update-modus-beim-ueberschreiben-von-datensaetzen.png)
+![Auswahl des Update-Modus beim Überschreiben von Datensätzen](/de/backend/images/de/auswahl-des-update-modus-beim-ueberschreiben-von-datensaetzen.png)
 
 **Ausgewählte Werte hinzufügen:** Die bestehenden Werte bleiben erhalten und werden durch die neu ausgewählten Werte 
 ergänzt. Eine Seite, der bereits die Gruppe *Piano Students* zugewiesen ist, hätte also nach dem Speichern die Gruppen 
@@ -108,9 +108,9 @@ Contao legt bei jedem Speichervorgang automatisch eine neue Version des bearbeit
 Eingabemaske ein Drop-Down-Menü, in dem die verschiedenen Versionen sowie deren Datum und Ersteller aufgelistet
 sind. Mit einem Klick auf `Wiederherstellen` kannst du eine frühere Version wiederherstellen.
 
-![Frühere Versionen eines Datensatzes wiederherstellen](/backend/images/de/fruehere-versionen-eines-datensatzes-wiederherstellen.png)
+![Frühere Versionen eines Datensatzes wiederherstellen](/de/backend/images/de/fruehere-versionen-eines-datensatzes-wiederherstellen.png)
 
-Durch Klick auf das Icon ![Unterschiede anzeigen](/icons/diff.svg?classes=icon) neben dem Drop-Down-Menüs werden 
+Durch Klick auf das Icon ![Unterschiede anzeigen](/de/icons/diff.svg?classes=icon) neben dem Drop-Down-Menüs werden 
 die Unterschiede zwischen der aktuellen und der gewählten Version angezeigt.
 
-![Unterschiede zwischen den gewählten Versionen](/backend/images/de/unterschiede-zwischen-den-gewaehlten-versionen.png)
+![Unterschiede zwischen den gewählten Versionen](/de/backend/images/de/unterschiede-zwischen-den-gewaehlten-versionen.png)

--- a/docs/manual/backend/datensaetze-bearbeiten.de.md
+++ b/docs/manual/backend/datensaetze-bearbeiten.de.md
@@ -2,7 +2,7 @@
 title: "Datensätze bearbeiten"
 description: "Das komfortable Bearbeiten von Daten zu ermöglichen, ist eine der Hauptaufgaben eines CMS – zumindest 
 sollte es so sein."
-url: "de/administrationsbereich/datensaetze-bearbeiten"
+url: "administrationsbereich/datensaetze-bearbeiten"
 weight: 4
 ---
 

--- a/docs/manual/core-extensions/_index.de.md
+++ b/docs/manual/core-extensions/_index.de.md
@@ -2,7 +2,7 @@
 title: "Core-Erweiterungen"
 description: "Die folgenden Erweiterungen sind im Lieferumfang von Contao enthalten: Nachrichten, Events, FAQ, 
 Newsletter, Kommentare und Auflistungen."
-url: "de/core-erweiterungen"
+url: "core-erweiterungen"
 weight: 10
 ---
 

--- a/docs/manual/core-extensions/calendar/_index.de.md
+++ b/docs/manual/core-extensions/calendar/_index.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Kalender-Erweiterung"
 description: "Damit können im Backend zukünftige und vergangene Veranstaltungen verwaltet werden."
-url: "de/core-erweiterung/kalender"
+url: "core-erweiterung/kalender"
 weight: 2
 ---
 

--- a/docs/manual/core-extensions/calendar/frontend-module.de.md
+++ b/docs/manual/core-extensions/calendar/frontend-module.de.md
@@ -2,7 +2,7 @@
 title: "Frontend-Module"
 description: "Die »Kalender«-Erweiterung enthält vier neue Frontend-Module, die du wie gewohnt über die Modulverwaltung 
 konfigurieren kannst."
-url: "de/core-erweiterung/kalender/frontend-module"
+url: "core-erweiterung/kalender/frontend-module"
 weight: 2
 ---
 

--- a/docs/manual/core-extensions/calendar/frontend-module.de.md
+++ b/docs/manual/core-extensions/calendar/frontend-module.de.md
@@ -10,7 +10,7 @@ Nachdem du nun weißt, wie Kalender und Events im Backend verwaltet werden, wird
 im Frontend darstellen kannst. Die »Kalender«-Erweiterung enthält vier neue Frontend-Module, die du wie gewohnt über 
 die Modulverwaltung konfigurieren kannst.
 
-![Kalender-Module](/core-extensions/calendar/images/de/kalender-module.png)
+![Kalender-Module](/de/core-extensions/calendar/images/de/kalender-module.png)
 
 
 ## Kalender
@@ -18,7 +18,7 @@ die Modulverwaltung konfigurieren kannst.
 Das Frontend-Modul »Kalender« fügt der Webseite einen Kalender hinzu, in dem die Events eines oder mehrerer Kalender 
 dargestellt werden.
 
-![Das Kalender-Modul im Frontend](/core-extensions/calendar/images/de/das-kalender-modul-im-frontend.png)
+![Das Kalender-Modul im Frontend](/de/core-extensions/calendar/images/de/das-kalender-modul-im-frontend.png)
 
 
 ### Modul-Konfiguration

--- a/docs/manual/core-extensions/calendar/terminverwaltung.de.md
+++ b/docs/manual/core-extensions/calendar/terminverwaltung.de.md
@@ -2,7 +2,7 @@
 title: "Terminverwaltung"
 description: "Die Terminverwaltung ist ein eigenes Modul im Backend namens »Events«, das du in der Gruppe »Inhalte« an 
 dritter Stelle findest."
-url: "de/core-erweiterung/kalender/terminverwaltung"
+url: "core-erweiterung/kalender/terminverwaltung"
 weight: 1
 ---
 

--- a/docs/manual/core-extensions/calendar/terminverwaltung.de.md
+++ b/docs/manual/core-extensions/calendar/terminverwaltung.de.md
@@ -17,7 +17,7 @@ Archive werden zur Gruppierung und/oder Kategorisierung von Kalendern verwendet.
 bestimmte Sprache oder ein bestimmtes Thema beziehen.
 
 Um einen neuen Kalender anzulegen klicke auf 
-![Einen neuen Kalender erstellen](/icons/new.svg?classes=icon "Einen neuen Kalender erstellen") 
+![Einen neuen Kalender erstellen](/de/icons/new.svg?classes=icon "Einen neuen Kalender erstellen") 
 **Neu**.
 
 
@@ -125,8 +125,8 @@ Die URL lautet:
 </rss>
 ```
 
-Um einen neuen Feed anzulegen klicke auf ![RSS-Feeds verwalten](/icons/rss.svg?classes=icon "RSS-Feeds verwalten") 
-**RSS-Feeds** und danach auf ![Einen neuen Feed erstellen](/icons/new.svg?classes=icon "Einen neuen Feed erstellen") 
+Um einen neuen Feed anzulegen klicke auf ![RSS-Feeds verwalten](/de/icons/rss.svg?classes=icon "RSS-Feeds verwalten") 
+**RSS-Feeds** und danach auf ![Einen neuen Feed erstellen](/de/icons/new.svg?classes=icon "Einen neuen Feed erstellen") 
 **Neu**.
 
 
@@ -169,8 +169,8 @@ daher gibt es hier keine Icons, mit denen du die Reihenfolge ändern könntest.
 Die Events bestehen aus den Einstellungen des Events (»Eventliste«) und aus deren Inhalten (»Eventleser«).
 
 Um einen neuen Event zu erstellen, klicke im gewünschten Archiv auf 
-![Kalender bearbeiten](/icons/edit.svg?classes=icon "Kalender bearbeiten") und danach auf 
-![Ein neues Event erstellen](/icons/new.svg?classes=icon "Ein neues Event erstellen") **Neu**.
+![Kalender bearbeiten](/de/icons/edit.svg?classes=icon "Kalender bearbeiten") und danach auf 
+![Ein neues Event erstellen](/de/icons/new.svg?classes=icon "Ein neues Event erstellen") **Neu**.
 
 
 ### Titel und Autor
@@ -226,7 +226,7 @@ gefolgt von einem Weiterlesen-Link, angezeigt wird.
 **Quelldatei:** Hier wählst du das einzufügende Bild aus. Wenn du das Bild noch nicht auf den Server übertragen hast, 
 kannst du es direkt im Popup-Fenster nachholen, ohne die Eingabemaske zu verlassen.
 
-![Einem Beitrag ein Bild hinzufügen](/core-extensions/calendar/images/de/einem-beitrag-ein-bild-hinzufuegen.png)
+![Einem Beitrag ein Bild hinzufügen](/de/core-extensions/calendar/images/de/einem-beitrag-ein-bild-hinzufuegen.png)
 
 **Bildgröße:** Hier kannst du die gewünschte Bildgröße angeben. Dabei kannst du zwischen folgenden Skalierungsmodi 
 auswählen:
@@ -252,10 +252,10 @@ auswählen:
 | Rechts / Unten    | Erhält den rechten Teil eines Querformat-Bildes und den unteren Teil eines Hochformat-Bildes.      |
 
 **Bildausrichtung:** Hier legst du die Ausrichtung des Bildes fest. Wird er 
-![oberhalb](/icons/above.svg?classes=icon) **oberhalb**, 
-![unterhalb](/icons/below.svg?classes=icon) **unterhalb**, 
-![linksbündig](/icons/left.svg?classes=icon) **linksbündig** oder 
-![rechtsbündig](/icons/right.svg?classes=icon) **rechtsbündig** eingefügt der Text umfließt das Bild.
+![oberhalb](/de/icons/above.svg?classes=icon) **oberhalb**, 
+![unterhalb](/de/icons/below.svg?classes=icon) **unterhalb**, 
+![linksbündig](/de/icons/left.svg?classes=icon) **linksbündig** oder 
+![rechtsbündig](/de/icons/right.svg?classes=icon) **rechtsbündig** eingefügt der Text umfließt das Bild.
 
 **Bildabstand:** Hier legst du den Abstand des Bilds zum Text fest. Die Reihenfolge der Eingabefelder lautet im 
 Uhrzeigersinn »oben, rechts, unten, links«.
@@ -351,8 +351,8 @@ Events automatisch zu einem bestimmten Datum zu aktivieren.
 
 Nachdem wir die Einstellungen für das Event vorgenommen haben, können wir diesem Inhaltselemente für die 
 Ausgabe im »Eventleser« mitgeben, klicke dazu beim gewünschten Event auf 
-![Event bearbeiten](/icons/edit.svg?classes=icon "Event bearbeiten")  und danach auf 
-![Ein neues Inhaltselement erstellen](/icons/new.svg?classes=icon "Ein neues Inhaltselement erstellen") **Neu**.
+![Event bearbeiten](/de/icons/edit.svg?classes=icon "Event bearbeiten")  und danach auf 
+![Ein neues Inhaltselement erstellen](/de/icons/new.svg?classes=icon "Ein neues Inhaltselement erstellen") **Neu**.
 
 In den Events stehen dir alle [Inhaltselemente](../../../artikelverwaltung/inhaltselemente/) von Contao zur 
 Verfügung.

--- a/docs/manual/core-extensions/faq/_index.de.md
+++ b/docs/manual/core-extensions/faq/_index.de.md
@@ -1,7 +1,7 @@
 ---
 title: "FAQ-Erweiterung"
 description: "Damit wird das Verwalten von häufig gestellten Fragen ein Kinderspiel."
-url: "de/core-erweiterung/faq"
+url: "core-erweiterung/faq"
 weight: 3
 ---
 

--- a/docs/manual/core-extensions/faq/faq-verwaltung.de.md
+++ b/docs/manual/core-extensions/faq/faq-verwaltung.de.md
@@ -17,7 +17,7 @@ Kategorien werden zur Gruppierung von FAQs verwendet. Jede Kategorie kann sich a
 bestimmtes Thema beziehen.
 
 Um eine neue Kategorie anzulegen klicke auf 
-![Eine neue Kategorie anlegen](/icons/new.svg?classes=icon "Eine neue Kategorie anlegen") 
+![Eine neue Kategorie anlegen](/de/icons/new.svg?classes=icon "Eine neue Kategorie anlegen") 
 **Neu**.
 
 
@@ -80,10 +80,10 @@ angemeldeten Mitgliedern das Kommentieren erlauben möchtest, kannst du die Sich
 
 In diesem Abschnitt wird dir erklärt, wie du eine Frage anlegst. Die Reihenfolge der Fragen innerhalb einer Kategorie 
 kannst du per Drag-and-Drop mit den entsprechenden 
-Navigationssymbol ![Frage verschieben](/icons/drag.svg?classes=icon "Frage verschieben") festlegen.
+Navigationssymbol ![Frage verschieben](/de/icons/drag.svg?classes=icon "Frage verschieben") festlegen.
 
 Um eine neue Frage anzulegen, klicke auf 
-![Eine neue Frage erstellen](/icons/new.svg?classes=icon "Eine neue Frage erstellen") **Neu**.
+![Eine neue Frage erstellen](/de/icons/new.svg?classes=icon "Eine neue Frage erstellen") **Neu**.
 
 
 ### Titel und Autor
@@ -109,7 +109,7 @@ Text Editor.
 **Quelldatei:** Hier wählst du das einzufügende Bild aus. Wenn du das Bild noch nicht auf den Server übertragen hast, 
 kannst du es direkt im Popup-Fenster nachholen, ohne die Eingabemaske zu verlassen.
 
-![Einer FAQ ein Bild hinzufügen](/core-extensions/faq/images/de/einer-faq-ein-bild-hinzufuegen.png)
+![Einer FAQ ein Bild hinzufügen](/de/core-extensions/faq/images/de/einer-faq-ein-bild-hinzufuegen.png)
 
 **Bildgröße:** Hier kannst du die gewünschte Bildgröße angeben. Dabei kannst du zwischen folgenden Skalierungsmodi 
 auswählen:
@@ -135,10 +135,10 @@ auswählen:
 | Rechts / Unten    | Erhält den rechten Teil eines Querformat-Bildes und den unteren Teil eines Hochformat-Bildes.      |
 
 **Bildausrichtung:** Hier legst du die Ausrichtung des Bildes fest. Wird er 
-![oberhalb](/icons/above.svg?classes=icon) **oberhalb**, 
-![unterhalb](/icons/below.svg?classes=icon) **unterhalb**, 
-![linksbündig](/icons/left.svg?classes=icon) **linksbündig** oder 
-![rechtsbündig](/icons/right.svg?classes=icon) **rechtsbündig** eingefügt der Text umfließt das Bild.
+![oberhalb](/de/icons/above.svg?classes=icon) **oberhalb**, 
+![unterhalb](/de/icons/below.svg?classes=icon) **unterhalb**, 
+![linksbündig](/de/icons/left.svg?classes=icon) **linksbündig** oder 
+![rechtsbündig](/de/icons/right.svg?classes=icon) **rechtsbündig** eingefügt der Text umfließt das Bild.
 
 **Bildabstand:** Hier legst du den Abstand des Bilds zum Text fest. Die Reihenfolge der Eingabefelder lautet im 
 Uhrzeigersinn »oben, rechts, unten, links«.

--- a/docs/manual/core-extensions/faq/faq-verwaltung.de.md
+++ b/docs/manual/core-extensions/faq/faq-verwaltung.de.md
@@ -2,7 +2,7 @@
 title: "FAQ-Verwaltung"
 description: "Die FAQ-Verwaltung ist ein eigenes Modul im Backend, das du in der Gruppe »Inhalte« an vierter Stelle 
 findest."
-url: "de/core-erweiterung/faq/faq-verwaltung"
+url: "core-erweiterung/faq/faq-verwaltung"
 weight: 1
 ---
 

--- a/docs/manual/core-extensions/faq/frontend-module.de.md
+++ b/docs/manual/core-extensions/faq/frontend-module.de.md
@@ -10,7 +10,7 @@ Nachdem du nun weißt, wie Kategorien und Fragen im Backend verwaltet werden, wi
 Inhalte im Frontend darstellen kannst. Die FAQ-Erweiterung enthält drei neue Frontend-Module, die du wie gewohnt über 
 die Modulverwaltung konfigurieren kannst.
 
-![FAQ-Module](/core-extensions/faq/images/de/faq-module.png)
+![FAQ-Module](/de/core-extensions/faq/images/de/faq-module.png)
 
 
 ## FAQ-Liste
@@ -22,7 +22,7 @@ stammen können.
 ### Modul-Konfiguration
 
 **FAQ-Kategorien:** Hier legst du fest, aus welchen Kategorien Fragen angezeigt werden. Du kannst die Reihenfolge der 
-Kategorien mithilfe vom Navigationssymbol ![Frage verschieben](/icons/drag.svg?classes=icon "Frage verschieben") 
+Kategorien mithilfe vom Navigationssymbol ![Frage verschieben](/de/icons/drag.svg?classes=icon "Frage verschieben") 
 anpassen.
   
 **FAQ-Leser:** Hier kannst du festlegen ob automatisch zum FAQ-Leser gewechselt werden soll, wenn ein Beitrag 

--- a/docs/manual/core-extensions/faq/frontend-module.de.md
+++ b/docs/manual/core-extensions/faq/frontend-module.de.md
@@ -2,7 +2,7 @@
 title: "Frontend-Module"
 description: "Die FAQ-Erweiterung enthält drei neue Frontend-Module, die du wie gewohnt über die Modulverwaltung 
 konfigurieren kannst."
-url: "de/core-erweiterung/faq/frontend-module"
+url: "core-erweiterung/faq/frontend-module"
 weight: 2
 ---
 

--- a/docs/manual/core-extensions/news/_index.de.md
+++ b/docs/manual/core-extensions/news/_index.de.md
@@ -1,7 +1,7 @@
 ---
 title: "News/Blog-Erweiterung"
 description: "Damit können im Backend News-Einträge verwaltet und mit Hilfe von Frontend-Modulen ausgegeben werden."
-url: "de/core-erweiterung/nachrichten"
+url: "core-erweiterung/nachrichten"
 weight: 1
 ---
 

--- a/docs/manual/core-extensions/news/frontend-module.de.md
+++ b/docs/manual/core-extensions/news/frontend-module.de.md
@@ -10,7 +10,7 @@ Nachdem du nun weißt, wie Archive und Beiträge im Backend verwaltet werden, wi
 Inhalte im Frontend darstellen kannst. Die Nachrichtenerweiterung enthält vier neue Frontend-Module, die du wie 
 gewohnt über die Modulverwaltung konfigurieren kannst.
 
-![News/Blog-Module](/core-extensions/news/images/de/news-blog-module.png)
+![News/Blog-Module](/de/core-extensions/news/images/de/news-blog-module.png)
 
 
 ## Nachrichtenliste

--- a/docs/manual/core-extensions/news/frontend-module.de.md
+++ b/docs/manual/core-extensions/news/frontend-module.de.md
@@ -2,7 +2,7 @@
 title: "Frontend-Module"
 description: "Die Nachrichtenerweiterung enthält vier neue Frontend-Module, die du wie gewohnt über die Modulverwaltung 
 konfigurieren kannst."
-url: "de/core-erweiterung/nachrichten/frontend-module"
+url: "core-erweiterung/nachrichten/frontend-module"
 weight: 2
 ---
 

--- a/docs/manual/core-extensions/news/nachrichtenverwaltung.de.md
+++ b/docs/manual/core-extensions/news/nachrichtenverwaltung.de.md
@@ -17,7 +17,7 @@ Archive werden zur Gruppierung und/oder Kategorisierung von Nachrichten verwende
 bestimmte Sprache oder ein bestimmtes Thema beziehen.
 
 Um ein neues Nachrichtenarchiv anzulegen klicke auf 
-![Ein neues Nachrichtenarchiv erstellen](/icons/new.svg?classes=icon "Ein neues Nachrichtenarchiv erstellen") 
+![Ein neues Nachrichtenarchiv erstellen](/de/icons/new.svg?classes=icon "Ein neues Nachrichtenarchiv erstellen") 
 **Neu**.
 
 
@@ -127,8 +127,8 @@ Die URL lautet:
 </rss>
 ```
 
-Um einen neuen Feed anzulegen klicke auf ![RSS-Feeds verwalten](/icons/rss.svg?classes=icon "RSS-Feeds verwalten") 
-**RSS-Feeds** und danach auf ![Einen neuen Feed erstellen](/icons/new.svg?classes=icon "Einen neuen Feed erstellen") 
+Um einen neuen Feed anzulegen klicke auf ![RSS-Feeds verwalten](/de/icons/rss.svg?classes=icon "RSS-Feeds verwalten") 
+**RSS-Feeds** und danach auf ![Einen neuen Feed erstellen](/de/icons/new.svg?classes=icon "Einen neuen Feed erstellen") 
 **Neu**.
 
 
@@ -172,8 +172,8 @@ Die Nachrichtenbeiträge bestehen aus den Einstellungen für die Beiträge (»Na
 (»Nachrichtenleser«).
 
 Um einen neuen Beitrag zu erstellen, klicke im gewünschten Archiv auf 
-![Nachrichtenarchiv bearbeiten](/icons/edit.svg?classes=icon "Nachrichtenarchiv bearbeiten") und danach auf 
-![Einen neuen Beitrag erstellen](/icons/new.svg?classes=icon "Einen neuen Beitrag erstellen") **Neu**.
+![Nachrichtenarchiv bearbeiten](/de/icons/edit.svg?classes=icon "Nachrichtenarchiv bearbeiten") und danach auf 
+![Einen neuen Beitrag erstellen](/de/icons/new.svg?classes=icon "Einen neuen Beitrag erstellen") **Neu**.
 
 
 ### Titel und Autor
@@ -219,7 +219,7 @@ dargestellt werden kann.
 **Quelldatei:** Hier wählst du das einzufügende Bild aus. Wenn du das Bild noch nicht auf den Server übertragen hast, 
 kannst du es direkt im Popup-Fenster nachholen, ohne die Eingabemaske zu verlassen.
 
-![Einem Beitrag ein Bild hinzufügen](/core-extensions/news/images/de/einem-beitrag-ein-bild-hinzufuegen.png)
+![Einem Beitrag ein Bild hinzufügen](/de/core-extensions/news/images/de/einem-beitrag-ein-bild-hinzufuegen.png)
 
 **Bildgröße:** Hier kannst du die gewünschte Bildgröße angeben. Dabei kannst du zwischen folgenden Skalierungsmodi 
 auswählen:
@@ -245,10 +245,10 @@ auswählen:
 | Rechts / Unten    | Erhält den rechten Teil eines Querformat-Bildes und den unteren Teil eines Hochformat-Bildes.      |
 
 **Bildausrichtung:** Hier legst du die Ausrichtung des Bildes fest. Wird er 
-![oberhalb](/icons/above.svg?classes=icon) **oberhalb**, 
-![unterhalb](/icons/below.svg?classes=icon) **unterhalb**, 
-![linksbündig](/icons/left.svg?classes=icon) **linksbündig** oder 
-![rechtsbündig](/icons/right.svg?classes=icon) **rechtsbündig** eingefügt der Text umfließt das Bild.
+![oberhalb](/de/icons/above.svg?classes=icon) **oberhalb**, 
+![unterhalb](/de/icons/below.svg?classes=icon) **unterhalb**, 
+![linksbündig](/de/icons/left.svg?classes=icon) **linksbündig** oder 
+![rechtsbündig](/de/icons/right.svg?classes=icon) **rechtsbündig** eingefügt der Text umfließt das Bild.
 
 **Bildabstand:** Hier legst du den Abstand des Bilds zum Text fest. Die Reihenfolge der Eingabefelder lautet im 
 Uhrzeigersinn »oben, rechts, unten, links«.
@@ -338,8 +338,8 @@ aktivieren.
 
 Nachdem wir die Einstellungen für den Beitrag vorgenommen haben, können wir diesem Inhaltselemente für die 
 Ausgabe im »Produktleser« mitgeben, klicke dazu beim gewünschten Beitrag auf 
-![Beitrag bearbeiten](/icons/edit.svg?classes=icon "Beitrag bearbeiten")  und danach auf 
-![Ein neues Inhaltselement erstellen](/icons/new.svg?classes=icon "Ein neues Inhaltselement erstellen") **Neu**.
+![Beitrag bearbeiten](/de/icons/edit.svg?classes=icon "Beitrag bearbeiten")  und danach auf 
+![Ein neues Inhaltselement erstellen](/de/icons/new.svg?classes=icon "Ein neues Inhaltselement erstellen") **Neu**.
 
 In den Nachrichtenbeiträgen stehen dir alle [Inhaltselemente](../../../artikelverwaltung/inhaltselemente/) von Contao 
 zur Verfügung.

--- a/docs/manual/core-extensions/news/nachrichtenverwaltung.de.md
+++ b/docs/manual/core-extensions/news/nachrichtenverwaltung.de.md
@@ -2,7 +2,7 @@
 title: "Nachrichtenverwaltung"
 description: "Die Nachrichtenverwaltung ist ein eigenes Modul im Backend, das du in der Gruppe »Inhalte« an zweiter 
 Stelle findest. "
-url: "de/core-erweiterung/nachrichten/nachrichtenverwaltung"
+url: "core-erweiterung/nachrichten/nachrichtenverwaltung"
 weight: 1
 ---
 

--- a/docs/manual/core-extensions/newsletter/_index.de.md
+++ b/docs/manual/core-extensions/newsletter/_index.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Newsletter-Erweiterung"
 description: "Damit können im Backend Newsletter und verschiedene Empfängerlisten verwaltet werden."
-url: "de/core-erweiterung/newsletter"
+url: "core-erweiterung/newsletter"
 weight: 4
 ---
 

--- a/docs/manual/core-extensions/newsletter/frontend-module.de.md
+++ b/docs/manual/core-extensions/newsletter/frontend-module.de.md
@@ -11,7 +11,7 @@ deine Besucher Verteiler im Frontend abonnieren bzw. kündigen können und wie 
 anzeigt. Die Newsletter-Erweiterung enthält vier zusätzliche Frontend-Module, die du wie gewohnt über die Modulverwaltung
 konfigurieren kannst.
 
-![Newsletter-Module](/core-extensions/newsletter/images/de/newsletter-module.png)
+![Newsletter-Module](/de/core-extensions/newsletter/images/de/newsletter-module.png)
 
 
 ## Abonnieren

--- a/docs/manual/core-extensions/newsletter/frontend-module.de.md
+++ b/docs/manual/core-extensions/newsletter/frontend-module.de.md
@@ -2,7 +2,7 @@
 title: "Frontend-Module"
 description: "Die Newsletter-Erweiterung enthält vier zusätzliche Frontend-Module, die du wie gewohnt über die Modulverwaltung 
 konfigurieren kannst."
-url: "de/core-erweiterung/newsletter/frontend-module"
+url: "core-erweiterung/newsletter/frontend-module"
 weight: 2
 ---
 

--- a/docs/manual/core-extensions/newsletter/newsletter-verwaltung.de.md
+++ b/docs/manual/core-extensions/newsletter/newsletter-verwaltung.de.md
@@ -2,7 +2,7 @@
 title: "Newsletter-Verwaltung"
 description: "Die Newsletter-Verwaltung ist ein eigenes Modul im Backend, das du in der Gruppe »Inhalte« an fünfter 
 Stelle findest. "
-url: "de/core-erweiterung/newsletter/newsletter-verwaltung"
+url: "core-erweiterung/newsletter/newsletter-verwaltung"
 weight: 1
 ---
 

--- a/docs/manual/core-extensions/newsletter/newsletter-verwaltung.de.md
+++ b/docs/manual/core-extensions/newsletter/newsletter-verwaltung.de.md
@@ -14,7 +14,7 @@ Verwendung mehrerer Verteiler können die einzelnen Newsletter nach Thema oder S
 ## Verteiler
 
 Um einen neuen Verteiler anzulegen klicke auf 
-![Einen neuen Verteiler erstellen](/icons/new.svg?classes=icon "Einen neuen Verteiler erstellen") **Neu**.
+![Einen neuen Verteiler erstellen](/de/icons/new.svg?classes=icon "Einen neuen Verteiler erstellen") **Neu**.
 
 
 ### Titel und Weiterleitung
@@ -52,8 +52,8 @@ Wir empfehlen den Versand über das [E-Mail-Transportprotkoll (SMTP)](../../syst
 Newsletter werden grundsätzlich nach ihrem Versanddatum sortiert.
 
 Um einen neuen Newsletter anzulegen klicke auf 
-![Verteiler bearbeiten](/icons/edit.svg?classes=icon "Verteiler bearbeiten") und danach auf 
-![Einen neuen Newsletter erstellen](/icons/new.svg?classes=icon "Einen neuen Newsletter erstellen") 
+![Verteiler bearbeiten](/de/icons/edit.svg?classes=icon "Verteiler bearbeiten") und danach auf 
+![Einen neuen Newsletter erstellen](/de/icons/new.svg?classes=icon "Einen neuen Newsletter erstellen") 
 **Neu**.
 
 
@@ -178,17 +178,17 @@ dass du als Administrator in den Prozess eingreifen musst. Trotzdem hast du natu
 Empfänger manuell zu ändern. Aus Gründen des Datenschutzes werden jeweils nur die E-Mail-Adresse und der
 Aktivierungsstatus gespeichert.
 
-![Einen Empfänger bearbeiten](/core-extensions/newsletter/images/de/einen-empfaenger-bearbeiten.png)
+![Einen Empfänger bearbeiten](/de/core-extensions/newsletter/images/de/einen-empfaenger-bearbeiten.png)
 
 Gemäß des [Double Opt-In-Verfahrens](https://de.wikipedia.org/wiki/Opt-In) erhält jeder Abonnent bei der Bestellung 
 eine E-Mail mit einem Bestätigungslink, ohne den er sein Abonnement nicht abschließen kann. Damit wird den Bestimmungen 
 des §7 Absatz 2 Nummer 2 und 3 des Gesetzes gegen den unlauteren Wettbewerb (UWG) hinreichend Genüge getan.
 
 Um einen Abonnenten des Verteilers zu bearbeiten, klicke auf 
-![Abonnenten des Verteilers bearbeiten](/icons/mgroup.svg?classes=icon "Abonnenten des Verteilers bearbeiten") 
+![Abonnenten des Verteilers bearbeiten](/de/icons/mgroup.svg?classes=icon "Abonnenten des Verteilers bearbeiten") 
 und danach auf 
-![Einen neuen Abonnenten erstellen](/icons/new.svg?classes=icon "Einen neuen Abonnenten erstellen") 
-**Neu** oder ![Abonnent bearbeiten](/icons/edit.svg?classes=icon "Abonnent bearbeiten").
+![Einen neuen Abonnenten erstellen](/de/icons/new.svg?classes=icon "Einen neuen Abonnenten erstellen") 
+**Neu** oder ![Abonnent bearbeiten](/de/icons/edit.svg?classes=icon "Abonnent bearbeiten").
 
 **E-Mail-Adresse:** Gebe hier die E-Mail-Adresse des Empfängers ein.
 
@@ -209,7 +209,7 @@ Zeilenumbrüche als Feldtrenner.
 
 Wähle die Datei für den Import auf deinem Rechner aus.
 
-![Newsletter-Empfänger importieren](/core-extensions/newsletter/images/de/newsletter-empfaenger-importieren.png)
+![Newsletter-Empfänger importieren](/de/core-extensions/newsletter/images/de/newsletter-empfaenger-importieren.png)
 
 Starte den Import anschließend durch einen Klick auf die Schaltfläche `CSV-Import`.
 
@@ -217,12 +217,12 @@ Starte den Import anschließend durch einen Klick auf die Schaltfläche `CSV-Imp
 ## Newsletter versenden
 
 Die Versendung eines Newsletters leitest du über das entsprechende Navigationssymbol 
-![Newsletter versenden](/icons/send.svg?classes=icon "Newsletter versenden") in der Verteiler-Übersicht ein. 
+![Newsletter versenden](/de/icons/send.svg?classes=icon "Newsletter versenden") in der Verteiler-Übersicht ein. 
 Du gelangst zunächst zu einer Vorschauseite, auf der du die Konfiguration und den Inhalt des Newsletters noch einmal 
 prüfen kannst. Es wird zudem empfohlen, regen Gebrauch von der Schaltfläche `Testsendung` zu machen. Die 
 dazugehörige Empfängeradresse kannst du im Feld `Testsendung an` ändern.
 
-![Einen Newsletter versenden](/core-extensions/newsletter/images/de/einen-newsletter-versenden.png)
+![Einen Newsletter versenden](/de/core-extensions/newsletter/images/de/einen-newsletter-versenden.png)
 
 
 ### Serverlimits einkalkulieren
@@ -264,4 +264,4 @@ NEWSLETTER_X, wobei das X für die ID des jeweiligen Newsletters steht. Die Gesa
 du dem Feld <code>Anzeigen</code>. Waren es z. B. 120 Mails, gib "120" ein, um mit dem 121. Empfänger 
 fortzufahren (die Zählung beginnt bei 0).
 
-![Unterbrochene Versendungen wiederaufnehmen](/core-extensions/newsletter/images/de/unterbrochene-versendungen-wiederaufnehmen.png)
+![Unterbrochene Versendungen wiederaufnehmen](/de/core-extensions/newsletter/images/de/unterbrochene-versendungen-wiederaufnehmen.png)

--- a/docs/manual/extensions/_index.de.md
+++ b/docs/manual/extensions/_index.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Erweiterungen"
 description: "Der Leistungsumfang von Contao  kann durch das Installieren von Paketen erweitert werden."
-url: "de/erweiterungen"
+url: "erweiterungen"
 weight: 15
 ---
 

--- a/docs/manual/extensions/cca-merger2.de.md
+++ b/docs/manual/extensions/cca-merger2.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Merger²"
 description: "Merger² ist ein Frondend-Modul um Module/Inhalte unter bestimmten Bedingungen anzuzeigen."
-url: "de/erweiterungen/merger2"
+url: "erweiterungen/merger2"
 ---
 
 **[contao-community-alliance/merger2](https://packagist.org/packages/contao-community-alliance/merger2)**

--- a/docs/manual/extensions/contao-easy_themes.de.md
+++ b/docs/manual/extensions/contao-easy_themes.de.md
@@ -1,7 +1,7 @@
 ---
 title: "EasyThemes"
 description: "Einfacheres Verwalten von Themes mit EasyThemes."
-url: "de/erweiterungen/contao-easy_themes"
+url: "erweiterungen/contao-easy_themes"
 ---
 
 **[terminal42/contao-easy_themes](https://packagist.org/packages/terminal42/contao-easy_themes)**

--- a/docs/manual/extensions/contao-easy_themes.de.md
+++ b/docs/manual/extensions/contao-easy_themes.de.md
@@ -13,10 +13,10 @@ Nicht nur bei mehreren Themes ein Klickzahlreduzierer.
 
 Melde dich, nach erfolgreicher Installation, im Backend an und rufe in der »Benutzerverwaltung« den Reiter »Benutzer« 
 auf. Wähle aus der Benutzerliste den Benutzer der in den Genuss von EasyThemes kommen soll. Klicke auf das 
-![Benutzer bearbeiten](/icons/edit.svg?classes=icon "Benutzer bearbeiten") Bearbeiten-Symbol, um dann im letzten 
+![Benutzer bearbeiten](/de/icons/edit.svg?classes=icon "Benutzer bearbeiten") Bearbeiten-Symbol, um dann im letzten 
 Abschnitt der Benutzerverwaltung den Haken bei **EasyTheme aktivieren** zu setzen.
 
-![EasyTheme aktivieren](/extensions/images/de/contao-easy_themes-aktivieren.png)
+![EasyTheme aktivieren](/de/extensions/images/de/contao-easy_themes-aktivieren.png)
 
 Unter **Aktive Module** bestimmst du, welche Module angezeigt werden sollen.
 
@@ -36,25 +36,25 @@ Im **EasyTheme Modus** musst du dich für eine von vier Anzeige-Arten entscheide
 
 **Kontextmenü:** Das Auswahlmenü erscheint beim Rechtsklick auf Themes.
 
-![EasyTheme Modus: Kontextmenü](/extensions/images/de/contao-easy_themes-modus-kontextmenue.png)
+![EasyTheme Modus: Kontextmenü](/de/extensions/images/de/contao-easy_themes-modus-kontextmenue.png)
 
 **Mouseover:** Das Auswahlmenü erscheint beim Mouseover von Themes.
 
-![EasyTheme Modus: Mouseover](/extensions/images/de/contao-easy_themes-modus-mouseover.png)
+![EasyTheme Modus: Mouseover](/de/extensions/images/de/contao-easy_themes-modus-mouseover.png)
 
 **DOM-Inject:** Das Auswahlmenü wird direkt unter Themes angezeigt.
 
-![EasyTheme Modus: DOM-Inject](/extensions/images/de/contao-easy_themes-modus-dom-inject.png)
+![EasyTheme Modus: DOM-Inject](/de/extensions/images/de/contao-easy_themes-modus-dom-inject.png)
 
 **Backend Module (ohne Auswahl einer Referenz-Gruppe):**
 Erstellt ein zusätzliches Backend-Modul über dem Abschnitt »Inhalte«.
 
-![EasyTheme Modus: Backend Module (ohne Auswahl einer Referenz-Gruppe)](/extensions/images/de/contao-easy_themes-modus-backend-module-ohne-referenz.png)
+![EasyTheme Modus: Backend Module (ohne Auswahl einer Referenz-Gruppe)](/de/extensions/images/de/contao-easy_themes-modus-backend-module-ohne-referenz.png)
 
 **Backend Module (mit Auswahl einer Referenz-Gruppe):**
 Erstellt ein zusätzliches Backend-Modul unter dem gewähltem Abschnitt.
 Im Beispiel wird es unter »Inhalte« platziert.
 
-![EasyTheme Modus: Backend Module (mit Auswahl einer Referenz-Gruppe)](/extensions/images/de/contao-easy_themes-modus-backend-module-mit-referenz.png)
+![EasyTheme Modus: Backend Module (mit Auswahl einer Referenz-Gruppe)](/de/extensions/images/de/contao-easy_themes-modus-backend-module-mit-referenz.png)
 
 Nimm dir Zeit und sei trotzdem schneller.

--- a/docs/manual/extensions/isotope-core.de.md
+++ b/docs/manual/extensions/isotope-core.de.md
@@ -10,6 +10,6 @@ _von [terminal42 gmbh](https://www.terminal42.ch/de/)_
 
 Isotope eCommerce ist eine kostenlose eCommerce-Lösung für das Contao CMS.
 
-![Isotope eCommerce im Backend](/extensions/images/de/isotope-core-backend.png)
+![Isotope eCommerce im Backend](/de/extensions/images/de/isotope-core-backend.png)
 
 Eine detaillierte Anleitung findest du im [Isotope eCommerce Benutzerhandbuch](https://isotopeecommerce.org/de/handbuch.html).

--- a/docs/manual/extensions/isotope-core.de.md
+++ b/docs/manual/extensions/isotope-core.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Isotope eCommerce"
 description: "Isotope eCommerce ist eine kostenlose eCommerce-Lösung für das Contao CMS."
-url: "de/erweiterungen/isotope-core"
+url: "erweiterungen/isotope-core"
 ---
 
 **[isotope/isotope-core](https://packagist.org/packages/isotope/isotope-core)**

--- a/docs/manual/extensions/maklermodul.de.md
+++ b/docs/manual/extensions/maklermodul.de.md
@@ -12,6 +12,6 @@ _Projektwebseite unter [Maklermodul für Contao](https://maklermodul.de)_
 
 Das Maklermodul für Immobilienmakler ist eine kostenpflichtige Erweiterung für das Contao CMS.
 
-![Maklermodul Listenansicht im Frontend](/extensions/images/de/maklermodul-bundle-frontend.png)
+![Maklermodul Listenansicht im Frontend](/de/extensions/images/de/maklermodul-bundle-frontend.png)
 
 Eine detaillierte Anleitung findest du im [Maklermodul Handbuch](https://docs.pdir.de/#/maklermodul/index).

--- a/docs/manual/extensions/maklermodul.de.md
+++ b/docs/manual/extensions/maklermodul.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Maklermodul für Immobilienmakler"
 description: "Das Maklermodul für Immobilienmakler ist eine kostenpflichtige Erweiterung für das Contao CMS."
-url: "de/erweiterungen/maklermodul"
+url: "erweiterungen/maklermodul"
 ---
 
 **[pdir/maklermodul-bundle](https://packagist.org/packages/pdir/maklermodul-bundle)**

--- a/docs/manual/extensions/maklermodul.en.md
+++ b/docs/manual/extensions/maklermodul.en.md
@@ -11,6 +11,6 @@ _Project website under [Broker module for Contao] (https://maklermodul.de)_
 
 The broker module for estate agents is a paid extension for the Contao CMS.
 
-![Broker list view in frontend](/extensions/images/de/maklermodul-bundle-frontend.png)
+![Broker list view in frontend](/de/extensions/images/de/maklermodul-bundle-frontend.png)
 
 Detailed instructions can be found in the [manual](https://docs.pdir.de/#/maklermodul/index).

--- a/docs/manual/extensions/metamodels.de.md
+++ b/docs/manual/extensions/metamodels.de.md
@@ -1,7 +1,7 @@
 ---
 title: "MetaModels"
 description: "MetaModels ist eine Erweiterung für das CMS Contao für einen flexiblen und leichten Aufbau von eigenen Datenmodellen."
-url: "de/erweiterungen/metamodels"
+url: "erweiterungen/metamodels"
 ---
 
 **[metamodels](https://packagist.org/packages/metamodels/)**

--- a/docs/manual/extensions/metamodels.de.md
+++ b/docs/manual/extensions/metamodels.de.md
@@ -16,7 +16,7 @@ Die Möglichkeiten dieser Dateninhalte erstrecken sich von Produktkatalogen, Ver
 Adress- oder Mitarbeiterlisten, Häuser, Mietobjekte bis zu Bildergalerien oder mehrsprachigen Text/Bild-Inhalten -
 und all das nahtlos in Contao eingebunden. 
 
-![MetaModels im Backend](/extensions/images/de/metamodels-backend.jpg)
+![MetaModels im Backend](/de/extensions/images/de/metamodels-backend.jpg)
 
 Für die Arbeit mit MetaModels muss man keine Programmierkenntnisse mitbringen. Für den Start ist es jedoch empfehlenswert,
 sich das [Handbuch](https://metamodels.readthedocs.io/de/latest/) anzusehen oder mit einem der

--- a/docs/manual/extensions/metamodels.en.md
+++ b/docs/manual/extensions/metamodels.en.md
@@ -15,7 +15,7 @@ The possibilities which data content can be used range from product catalogues, 
 lists, houses for sale or rent to picture galleries or multilingual text/image content - all that can be integrated
 seamlessly into Contao. 
 
-![MetaModels at Backend](/extensions/images/en/metamodels-backend.jpg)
+![MetaModels at Backend](/de/extensions/images/en/metamodels-backend.jpg)
 
 For working with MetaModels you don't have to have any programming knowledge. For the start, however, it is recommended,
 to look at the [manual](https://metamodels.readthedocs.io/en/latest/) or to use one of the

--- a/docs/manual/file-manager/_index.de.md
+++ b/docs/manual/file-manager/_index.de.md
@@ -2,7 +2,7 @@
 title: "Dateiverwaltung"
 description: "Mit der Dateiverwaltung kannst du Dateien und Ordner auf deinem Server verwalten und Dateien von deinem 
 lokalen Rechner auf den Server übertragen."
-url: "de/dateiverwaltung"
+url: "dateiverwaltung"
 weight: 12
 ---
 

--- a/docs/manual/file-manager/dateiverwaltung.de.md
+++ b/docs/manual/file-manager/dateiverwaltung.de.md
@@ -6,8 +6,8 @@ weight: 1
 ---
 
 Die Dateiverwaltung bildet die Verzeichnisstruktur in einem hierarchischen Baum ab. Jeder Unterordner ist ein eigener 
-Knoten, den du über das ![Plussymbol](/icons/folPlus.svg?classes=icon) Plus- bzw. 
-![Minussymbol](/icons/folMinus.svg?classes=icon) Minussymbol aus- und einklappen kannst. Innerhalb jedes 
+Knoten, den du über das ![Plussymbol](/de/icons/folPlus.svg?classes=icon) Plus- bzw. 
+![Minussymbol](/de/icons/folMinus.svg?classes=icon) Minussymbol aus- und einklappen kannst. Innerhalb jedes 
 Unterordners werden die darin enthaltenen Dateien aufgelistet. Handelt es sich dabei um Bilder, wird automatisch eine 
 Voransicht angezeigt. Bei einer großen Menge an Bildern kannst du die Voransicht in deinem Benutzerprofil deaktivieren,
 damit die Seite schneller lädt.
@@ -18,44 +18,44 @@ damit die Seite schneller lädt.
 Die Navigation erfolgt wie überall in Contao mithilfe von Navigationssymbolen. Die Optionen sind dabei für Ordner und 
 Dateien unterschiedlich.
 
-![Die Dateiverwaltung](/file-manager/images/de/der-dateimanager.png)
+![Die Dateiverwaltung](/de/file-manager/images/de/der-dateimanager.png)
 
-**![Datei oder Verzeichnis bearbeiten](/icons/edit.svg?classes=icon) Bearbeiten:** Öffnet eine Eingabemaske zum 
+**![Datei oder Verzeichnis bearbeiten](/de/icons/edit.svg?classes=icon) Bearbeiten:** Öffnet eine Eingabemaske zum 
 Umbenennen einer Datei bzw. eines Ordners. Außerdem können Metadaten von Dateien in der passenden Sprache eingepflegt 
 oder Ordner veröffentlicht bzw. vor der Synchronisation ausgeschlossen werden.
 
-**![Datei oder Verzeichnis duplizieren](/icons/copy.svg?classes=icon) Duplizieren:** Kopiert eine Datei bzw. 
+**![Datei oder Verzeichnis duplizieren](/de/icons/copy.svg?classes=icon) Duplizieren:** Kopiert eine Datei bzw. 
 einen Ordner.
 
-**![Datei oder Verzeichnis verschieben](/icons/cut.svg?classes=icon) Verschieben:** Verschiebt eine Datei bzw. 
+**![Datei oder Verzeichnis verschieben](/de/icons/cut.svg?classes=icon) Verschieben:** Verschiebt eine Datei bzw. 
 einen Ordner.
 
-**![Datei oder Verzeichnis löschen](/icons/delete.svg?classes=icon) Löschen:** Löscht eine Datei bzw. einen 
+**![Datei oder Verzeichnis löschen](/de/icons/delete.svg?classes=icon) Löschen:** Löscht eine Datei bzw. einen 
 Ordner.
 
-**![Details der Datei bzw. des Ordners anzeigen](/icons/show.svg?classes=icon) Informationen:** Details der 
+**![Details der Datei bzw. des Ordners anzeigen](/de/icons/show.svg?classes=icon) Informationen:** Details der 
 Datei bzw. des Ordners anzeigen.
 
-**![Dateien in den Ordner hochladen](/icons/new.svg?classes=icon) Hochladen:** Dateien in den Ordner hochladen.
+**![Dateien in den Ordner hochladen](/de/icons/new.svg?classes=icon) Hochladen:** Dateien in den Ordner hochladen.
 
-**![Datei bearbeiten](/icons/editor.svg?classes=icon) Datei bearbeiten:** Öffnet eine Eingabemaske zur 
+**![Datei bearbeiten](/de/icons/editor.svg?classes=icon) Datei bearbeiten:** Öffnet eine Eingabemaske zur 
 Bearbeitung des Inhalts einer Datei mit einem Texteditor. Welche Dateien editiert werden dürfen, kannst du in den 
 Backend-Einstellungen unter »Editierbare Dateien« festlegen.
 
-**![Datei oder Verzeichnis verschieben](/icons/drag.svg?classes=icon) Verschieben:** Eine Datei bzw. einen Ordner per Drag & Drop verschieben.
+**![Datei oder Verzeichnis verschieben](/de/icons/drag.svg?classes=icon) Verschieben:** Eine Datei bzw. einen Ordner per Drag & Drop verschieben.
 
 
 ## Dateien übertragen {#dateien-uebertragen}
 
 Rufe die Dateiverwaltung auf, und klicke auf den Link 
-**![Dateien auf den Server hochladen](/icons/new.svg?classes=icon) Datei-Upload**, um Dateien auf den Server zu 
-übertragen. Über das Navigationssymbol **![In den Ordner einfügen](/icons/pasteinto.svg?classes=icon) Einfügen 
+**![Dateien auf den Server hochladen](/de/icons/new.svg?classes=icon) Datei-Upload**, um Dateien auf den Server zu 
+übertragen. Über das Navigationssymbol **![In den Ordner einfügen](/de/icons/pasteinto.svg?classes=icon) Einfügen 
 in** kannst du das Zielverzeichnis auswählen. Alternativ kannst du direkt beim gewünschten Ordner auf das 
-Navigationssymbol ![Dateien auf den Server hochladen](/icons/new.svg?classes=icon) klicken.
+Navigationssymbol ![Dateien auf den Server hochladen](/de/icons/new.svg?classes=icon) klicken.
 
 In den Benutzereinstellungen kannst du darüber hinaus [DropZone](https://www.dropzonejs.com/) aktivieren.
 
-![Dateien übertragen](/file-manager/images/de/dateien-uebertragen.png)
+![Dateien übertragen](/de/file-manager/images/de/dateien-uebertragen.png)
 
 In beiden Fällen prüft die Dateiverwaltung beim Upload die Größe der zu übertragenden Datei, und – falls es sich dabei um 
 ein Bild handelt – auch dessen Abmessungen. Standardmäßig werden Dateien bis zu 2 MB und Bilder bis zu 3000x3000 Pixel 
@@ -71,7 +71,7 @@ Upload-Dateitypen« festgelegt hast.
 Contao kann sowohl Dateien verarbeiten, die mit der Dateiverwaltung auf den Server übertragen wurden, als auch Dateien 
 bzw. Ordner, die du mit einem FTP-Programm hochgeladen hast. Damit die Ressourcen im datenbankgestützten Dateisystem 
 von Contao hinterlegt werden, musst du auf den Link 
-**![Dateisystem und Datenbank synchronisieren](/icons/sync.svg?classes=icon) Synchronisieren** klicken.
+**![Dateisystem und Datenbank synchronisieren](/de/icons/sync.svg?classes=icon) Synchronisieren** klicken.
 
 Beim Upload über FTP gibt es allerdings eine kleine Einschränkung: Die Dateinamen sollten keine Sonderzeichen 
 enthalten. Viele Server bzw. FTP-Programme verwenden intern eine andere Zeichenkodierung als Contao, daher kann es beim 

--- a/docs/manual/file-manager/dateiverwaltung.de.md
+++ b/docs/manual/file-manager/dateiverwaltung.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Dateien und Ordner verwalten"
 description: "Die Dateiverwaltung bildet die Verzeichnisstruktur in einem hierarchischen Baum ab."
-url: "de/dateiverwaltung/dateien-und-ordner-verwalten"
+url: "dateiverwaltung/dateien-und-ordner-verwalten"
 weight: 1
 ---
 

--- a/docs/manual/file-manager/downloads-kontrollieren.de.md
+++ b/docs/manual/file-manager/downloads-kontrollieren.de.md
@@ -2,7 +2,7 @@
 title: "Downloads kontrollieren"
 description: "Mit Contao kannst du ganz einfach den Zugriff auf bestimmte Dateien beschränken und genau festlegen, wer 
 diese herunterladen darf und wer nicht."
-url: "de/dateiverwaltung/downloads-kontrollieren"
+url: "dateiverwaltung/downloads-kontrollieren"
 weight: 3
 ---
 

--- a/docs/manual/file-manager/downloads-kontrollieren.de.md
+++ b/docs/manual/file-manager/downloads-kontrollieren.de.md
@@ -17,13 +17,13 @@ Wenn du in Contao einen neuen Ordner anlegst, ist dieser standardmäßig inklusi
 Möchtest du ein Verzeichnis schützen, musst du beim Anlegen des Ordners darauf achten, dass »Öffentlich« nicht 
 ausgewählt ist. Ist ein Verzeichnis öffentlich, können die darin befindlichen Ordner und Dateien nicht geschützt werden.
 
-![Verzeichnis schützen](/file-manager/images/de/verzeichnis-schuetzen.png)
+![Verzeichnis schützen](/de/file-manager/images/de/verzeichnis-schuetzen.png)
 
 Ist ein Ordner öffentlich wird unter `web/files/` ein 
 [Symlink](https://de.wikipedia.org/wiki/Symbolische_Verkn%C3%BCpfung) in das Verzeichnis `files` gesetzt. 
 Ohne diese Symlinks wären die Daten für Besucher nicht erreichbar.
 
-![nicht öffentlicher Ordner](/file-manager/images/de/nicht-oeffentlicher-ordner.png)
+![nicht öffentlicher Ordner](/de/file-manager/images/de/nicht-oeffentlicher-ordner.png)
 
 Ist der Ordner nicht öffentlich kann nun niemand mehr mit seinem Internetbrowser auf die Dateien zugreifen und sie 
 direkt herunterladen. Über die Inhaltselemente »Download« bzw. »Downloads« sind die Dateien aber weiterhin erreichbar.
@@ -40,7 +40,7 @@ diese Inhaltselemente eingeschränkt hast, können jetzt nur noch angemeldete Mi
 Schutz lässt sich durch verschiedene Mitgliedergruppen und unterschiedliche Download-Elemente beliebig weiter 
 verfeinern.
 
-![Inhaltselemente Downloads](/file-manager/images/de/inhaltselemente-downloads.png)
+![Inhaltselemente Downloads](/de/file-manager/images/de/inhaltselemente-downloads.png)
 
 
 **HTML-Ausgabe**  

--- a/docs/manual/file-manager/metadaten.de.md
+++ b/docs/manual/file-manager/metadaten.de.md
@@ -16,7 +16,7 @@ Contao unterstützt folgende Metadaten:
 - Link
 - Bildunterschrift
 
-![Pflegen der Metadaten](/file-manager/images/de/pflegen-der-metadaten.png)
+![Pflegen der Metadaten](/de/file-manager/images/de/pflegen-der-metadaten.png)
 
 **HTML-Ausgabe**  
 Das Inhaltselement vom Elementtyp »Bild« generiert folgenden HTML-Code:

--- a/docs/manual/file-manager/metadaten.de.md
+++ b/docs/manual/file-manager/metadaten.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Metadaten"
 description: "In Contao kannst du zu jeder Art von Datei sogenannte Metadaten erfassen."
-url: "de/dateiverwaltung/metadaten"
+url: "dateiverwaltung/metadaten"
 weight: 2
 ---
 

--- a/docs/manual/form-generator/_index.de.md
+++ b/docs/manual/form-generator/_index.de.md
@@ -2,7 +2,7 @@
 title: "Formulargenerator"
 description: "Der Contao-Formulargenerator unterstützt dich bei der Erstellung von Formularen, indem er sowohl den 
 Prozess der Code-Generierung als auch die Validierung der Benutzereingaben abstrahiert."
-url: "de/formulargenerator"
+url: "formulargenerator"
 weight: 11
 ---
 

--- a/docs/manual/form-generator/ein-suuchformular-erstellen.de.md
+++ b/docs/manual/form-generator/ein-suuchformular-erstellen.de.md
@@ -2,7 +2,7 @@
 title: "Ein Suchformular erstellen"
 description: "Du kannst den Formulargenerator dazu nutzen, um ein eigenes Suchformular zu erstellen und dieses 
 beispielsweise in der Kopfzeile deiner Webseite einzubinden."
-url: "de/formulargenerator/ein-suchformular-erstellen"
+url: "formulargenerator/ein-suchformular-erstellen"
 weight: 3
 --- 
 

--- a/docs/manual/form-generator/formulare.de.md
+++ b/docs/manual/form-generator/formulare.de.md
@@ -26,7 +26,7 @@ Wir empfehlen den Versand über das [E-Mail-Transportprotkoll (SMTP)](../../syst
 Den Formulargenerator findest du in der Backend-Navigation in der Gruppe »Inhalte«.
 
 Um ein neues Formular anzulegen klicke auf 
-![Ein neues Formular anlegen](/icons/new.svg?classes=icon "Ein neues Formular anlegen") **Neu**.
+![Ein neues Formular anlegen](/de/icons/new.svg?classes=icon "Ein neues Formular anlegen") **Neu**.
 
 
 ### Titel und Weiterleitung

--- a/docs/manual/form-generator/formulare.de.md
+++ b/docs/manual/form-generator/formulare.de.md
@@ -2,7 +2,7 @@
 title: "Formulare"
 description: "Mit dem Formulargenerator kannst du Formulare erstellen und deren Daten entweder per E-Mail verschicken 
 oder in die Datenbank schreiben."
-url: "de/formulargenerator/formulare"
+url: "formulargenerator/formulare"
 weight: 1
 ---
 

--- a/docs/manual/form-generator/formularfelder.de.md
+++ b/docs/manual/form-generator/formularfelder.de.md
@@ -10,7 +10,7 @@ weight: 2
 das speziell auf die jeweiligen Anforderungen des Eingabefelds ausgerichtet ist. Für jedes Formularfeld musst du 
 mindestens einen Feldnamen und eine Feldbezeichnung eingeben.
 
-![Formularfelder bearbeiten](/form-generator/images/de/formularfelder-bearbeiten.png)
+![Formularfelder bearbeiten](/de/form-generator/images/de/formularfelder-bearbeiten.png)
 
 **Feldname:** Über den Feldnamen wird die Benutzereingabe nach dem Absenden des Formulars referenziert. Falls du die 
 Formulardaten in der Datenbank speicherst, muss es in der Tabelle ein gleich lautendes Feld geben.
@@ -208,7 +208,7 @@ Das Formularfeld `Select-Menü` fügt dem Formular ein Drop-Down-Menü hinzu,
 auswählen kannst. Um die Auswahl mehrerer Optionen zu erlauben, kannst du entweder die Mehrfachauswahl aktivieren oder 
 ein [Checkbox-Menü](#checkbox-menue) anstatt des Select-Menüs verwenden.
 
-![Ein Select-Menü im Frontend](/form-generator/images/de/ein-select-menue-im-frontend.png)
+![Ein Select-Menü im Frontend](/de/form-generator/images/de/ein-select-menue-im-frontend.png)
 
 **Mehrfachauswahl:** Hier kannst du die Auswahl mehrerer Optionen erlauben.
 
@@ -220,7 +220,7 @@ Innerhalb des Feldes kann gescrollt werden.
 Beim Anlegen der Optionen unterstützt dich ein JavaScript-Assistent. Du kannst Optionen gruppieren und jede Gruppe mit 
 einer Überschrift versehen. Um eine Zeile zu einer Gruppenüberschrift zu machen, wähle die Option Gruppe.
 
-![JavaScript-Assistent für das Anlegen von Optionen](/form-generator/images/de/anlegen-von-optionen.png)
+![JavaScript-Assistent für das Anlegen von Optionen](/de/form-generator/images/de/anlegen-von-optionen.png)
 
 **CSS-Klasse:** Hier kannst du eine oder mehrere Klassen eingeben.
 
@@ -257,7 +257,7 @@ Felder mit Mehrfachauswahl verwenden die CSS-Klasse `multiselect` anstatt `selec
 Das Formularfeld Radio-Button-Menü fügt dem Formular eine Liste von Optionen hinzu, aus der du genau eine auswählen 
 kannst. Um die Auswahl mehrerer Optionen zu erlauben, musst du ein [Checkbox-Menü](#checkbox-menue) verwenden.
 
-![Ein Radio-Button-Menü im Frontend](/form-generator/images/de/ein-radio-button-menue-im-frontend.png)
+![Ein Radio-Button-Menü im Frontend](/de/form-generator/images/de/ein-radio-button-menue-im-frontend.png)
 
 **Optionen:** Hier kannst du die verschiedenen Auswahlmöglichkeiten erfassen. Beim Anlegen der Optionen unterstützt 
 dich ein JavaScript-Assistent.
@@ -302,7 +302,7 @@ Das Formularfeld `Checkbox-Menü` fügt dem Formular eine Liste von Optionen h
 Optionen oder auch gar keine auswählen kannst. Um die Auswahl genau einer Option zu erlauben, musst du ein 
 [Radio-Button-Menü](#radio-button-menue) oder ein [Select-Menü](#select-menue) verwenden.
 
-![Ein Checkbox-Menü im Frontend](/form-generator/images/de/ein-checkbox-menue-im-frontend.png)
+![Ein Checkbox-Menü im Frontend](/de/form-generator/images/de/ein-checkbox-menue-im-frontend.png)
 
 **Optionen:** Hier kannst du die verschiedenen Auswahlmöglichkeiten erfassen. Beim Anlegen der Optionen unterstützt 
 dich ein JavaScript-Assistent.

--- a/docs/manual/form-generator/formularfelder.de.md
+++ b/docs/manual/form-generator/formularfelder.de.md
@@ -2,7 +2,7 @@
 title: "Formularfelder"
 description: "Ähnlich wie bei Artikeln und Inhaltselementen gibt es auch bei Formularen für jedes Formularfeld ein 
 eigenes Element, das speziell auf die jeweiligen Anforderungen des Eingabefelds ausgerichtet ist."
-url: "de/formulargenerator/formularfelder"
+url: "formulargenerator/formularfelder"
 weight: 2
 ---
 

--- a/docs/manual/installation/contao-aktualisieren.de.md
+++ b/docs/manual/installation/contao-aktualisieren.de.md
@@ -60,13 +60,13 @@ Zahnrad-Symbol und gebe die gewünschte Version ein. Alle anderen Contao-Paketen
 Aktualisierung vorgemerkt werden. Durch einen Klick auf die Schaltfläche »Änderungen 
 anwenden« schiebst du die Aktualisierung an.
 
-![Aktualisierung für Minor-Release starten](/installation/images/de/aktualisierung-fuer-minor-release-starten.png)
+![Aktualisierung für Minor-Release starten](/de/installation/images/de/aktualisierung-fuer-minor-release-starten.png)
 
 Die Aktualisierung kann nun mehrere Minuten in Anspruch nehmen. Details zum Aktualisierungsprozess können durch Klick 
-auf folgendes Symbol ![Konsolenausgabe anzeigen/verstecken](/icons/konsolenausgabe.png?classes=icon) angezeigt 
+auf folgendes Symbol ![Konsolenausgabe anzeigen/verstecken](/de/icons/konsolenausgabe.png?classes=icon) angezeigt 
 werden.
 
-![Aktualisierung für Minor-Release abgeschloßen](/installation/images/de/aktualisierung-fuer-minor-release-abgeschlossen.png)
+![Aktualisierung für Minor-Release abgeschloßen](/de/installation/images/de/aktualisierung-fuer-minor-release-abgeschlossen.png)
 
 
 #### Datenbanktabellen aktualisieren

--- a/docs/manual/installation/contao-installieren.de.md
+++ b/docs/manual/installation/contao-installieren.de.md
@@ -27,13 +27,13 @@ Bevor du Contao auf deinem Server installieren kannst, musst du den
 Nach der erfolgreichen Grundkonfiguration kann nun Contao installiert werden. Dazu wählst du die gewünschte Version 
 sowie die initiale Konfiguration aus und klickst auf die Schaltfläche »Fertigstellen«. 
 
-![Contao per Contao Manager installieren](/installation/images/de/contao-per-contao-manager-installieren.png)
+![Contao per Contao Manager installieren](/de/installation/images/de/contao-per-contao-manager-installieren.png)
 
 Die Installation kann nun mehrere Minuten in Anspruch nehmen. Details zum Installationsprozess können durch Klick auf 
-folgendes Symbol ![Konsolenausgabe anzeigen/verstecken](/icons/konsolenausgabe.png?classes=icon) angezeigt 
+folgendes Symbol ![Konsolenausgabe anzeigen/verstecken](/de/icons/konsolenausgabe.png?classes=icon) angezeigt 
 werden.
 
-![Contao wird installiert](/installation/images/de/contao-wird-installiert.png)
+![Contao wird installiert](/de/installation/images/de/contao-wird-installiert.png)
 
 
 ### Datenbanktabellen aktualisieren

--- a/docs/manual/installation/contao-installtool.de.md
+++ b/docs/manual/installation/contao-installtool.de.md
@@ -20,7 +20,7 @@ sowieso nur über die Verwaltungssoftware (z. B. Confixx, Plesk oder cPanel) m�
 Verwaltungsoberfläche deines Servers auf, und lege dort eine neue Datenbank an. Gebe danach die Anmeldeinformationen
 für die Datenbank im Contao-Installtool ein.
 
-![Datenbankverbindung für Contao eingeben](/installation/images/de/datenbankverbindung-fuer-contao-eingeben.png)
+![Datenbankverbindung für Contao eingeben](/de/installation/images/de/datenbankverbindung-fuer-contao-eingeben.png)
 
 **Host:** Hier gibst du die Domain oder IP-Adresse des Datenbankservers ein.
 
@@ -40,7 +40,7 @@ vergleicht die darin enthaltenen Tabellen mit den Vorgaben der aktuellen Contao-
 notwendig, präsentiert dir das Installtool automatisch eine Liste der durchzuführenden Änderungen, die du bestätigen 
 oder ablehnen kannst.
 
-![Datenbankänderungen bestätigen](/installation/images/de/datenbankaenderungen-bestaetigen.png)
+![Datenbankänderungen bestätigen](/de/installation/images/de/datenbankaenderungen-bestaetigen.png)
 
 In der Regel solltest du die angebotenen Änderungen übernehmen, damit deine Tabellen immer auf dem neuesten Stand sind 
 und Contao später nicht versucht, auf fehlende Felder zuzugreifen. Bei einer neuen Installation ist die Liste der 
@@ -71,7 +71,7 @@ Beim Import eines Templates werden bestehende Daten überschrieben!
 Wenn du auf den Import eines Templates verzichtet hast, weil du beispielsweise eine neue Webseite mit Contao erstellen 
 möchtest, musst du einen Administrator-Benutzer anlegen, mit dem du dich später im Contao-Backend anmelden kannst.
 
-![Ein Administratorkonto anlegen](/installation/images/de/ein-administratorkonto-anlegen.png)
+![Ein Administratorkonto anlegen](/de/installation/images/de/ein-administratorkonto-anlegen.png)
 
 **Benutzername:** Hier legst du den Benutzernamen des Administrators fest.
 
@@ -98,7 +98,7 @@ automatisch gesperrt, wenn mehr als dreimal hintereinander ein falsches Passwort
 Du hast drei Möglichkeiten das Installtool zu entsperren:
 
 - Über den Contao Manager, indem du unter Systemwartung auf »Installtool entsperren« klickst.
-![Das Installtool zurücksetzen](/installation/images/de/das-installtool-zuruecksetzen.png)
+![Das Installtool zurücksetzen](/de/installation/images/de/das-installtool-zuruecksetzen.png)
 - Über die Kommandozeile, indem du im Hauptverzeichnis deiner Contao-Installation folgendes Kommando absetzt:
 
     ```bash

--- a/docs/manual/installation/contao-manager.de.md
+++ b/docs/manual/installation/contao-manager.de.md
@@ -82,7 +82,7 @@ Manager-Datei zerstört. Füge deshalb die Dateiendung <code>.php</code> erst na
 Rufe anschließend mit deinem Browser die URL <code>www.example.com/contao-manager.phar.php</code> auf. Du solltest nun 
 die Willkommensseite des Contao Managers sehen.
 
-![Willkommensseite des Contao Managers](/installation/images/de/willkommensseite-des-contao-managers.png)
+![Willkommensseite des Contao Managers](/de/installation/images/de/willkommensseite-des-contao-managers.png)
 
 
 ### Grundkonfiguration
@@ -109,7 +109,7 @@ unserem Wiki ergänzen](https://github.com/contao/contao-manager/wiki).
 Wähle die passende Konfiguration für deinen Server- oder Hosting-Anbieter aus. Für eine manuelle Konfiguration wähle 
 »Andere …«.
 
-![Serverkonfiguration](/installation/images/de/serverkonfiguration.png)
+![Serverkonfiguration](/de/installation/images/de/serverkonfiguration.png)
 
 
 #### Composer Resolver Cloud

--- a/docs/manual/installation/contao-umziehen.de.md
+++ b/docs/manual/installation/contao-umziehen.de.md
@@ -19,7 +19,7 @@ Ein MySQL-Dump lässt sich am einfachsten mit der Datenbankverwaltung »[phpMyAd
 erstellen. Melde dich in »phpMyAdmin« an, wähle die zu exportierende Datenbank und klicke die 
 »Export«-Schaltfläche im oberen Menü.
 
-![Datenbank exportieren](/installation/images/de/datenbank-exportieren.png)
+![Datenbank exportieren](/de/installation/images/de/datenbank-exportieren.png)
 
 ### Datenbank auf dem Live-Server importieren
 
@@ -28,7 +28,7 @@ eventuell nur über die Verwaltungsoberfläche (z. B. Confixx, Plesk oder cPanel
 aus und klicke auf die »Import«-Schaltfläche im oberen Menü. Lade dann den SQL-Dump der lokalen Datenbank hoch und 
 starte den Import.
 
-![Datenbank importieren](/installation/images/de/datenbank-importieren.png)
+![Datenbank importieren](/de/installation/images/de/datenbank-importieren.png)
 
 
 ### Contao Manager auf dem Live-Server installieren
@@ -61,13 +61,13 @@ Wenn du auf die Schaltfläche »Installieren« klickst, führt der Manager im Hi
 installiert Contao und die von dir in der lokalen Installation verwendeten Erweiterungen.
 
 
-![Composer-Abhängigkeiten installieren](/installation/images/de/composer-abhaengigkeiten-installieren.png)
+![Composer-Abhängigkeiten installieren](/de/installation/images/de/composer-abhaengigkeiten-installieren.png)
 
 Die Installation kann nun mehrere Minuten in Anspruch nehmen. Details zum Installationsprozess können durch Klick auf 
-folgendes Symbol ![Konsolenausgabe anzeigen/verstecken](/icons/konsolenausgabe.png?classes=icon) angezeigt 
+folgendes Symbol ![Konsolenausgabe anzeigen/verstecken](/de/icons/konsolenausgabe.png?classes=icon) angezeigt 
 werden.
 
-![Umbzug abgeschlossen](/installation/images/de/umzug-abgeschlossen.png)
+![Umbzug abgeschlossen](/de/installation/images/de/umzug-abgeschlossen.png)
 
 Öffne danach das [Contao-Installtool](../contao-installtool/), und gebe die Zugangsdaten zur neuen Datenbank an.
 

--- a/docs/manual/installation/erweiterung-aktualisieren.de.md
+++ b/docs/manual/installation/erweiterung-aktualisieren.de.md
@@ -14,9 +14,9 @@ Wenn du die Erweiterung »contao-easy_themes« aktualisieren möchtest, wechsle 
 Schaltfläche »Aktualisieren« neben der Erweiterung. Du kannst natürlich auch noch weitere Erweiterung zur 
 Aktualisierung vormerken. Klicke auf »Änderungen anwenden« un die Aktualisierung zu starten. Die Aktualisierung kann 
 nun mehrere Minuten in Anspruch nehmen. Details zum Aktualisierungsprozess können durch Klick auf folgendes Symbol 
-![Konsolenausgabe anzeigen/verstecken](/icons/konsolenausgabe.png?classes=icon) angezeigt werden.
+![Konsolenausgabe anzeigen/verstecken](/de/icons/konsolenausgabe.png?classes=icon) angezeigt werden.
 
-![Erweiterungen im Contao Manager aktualisieren](/installation/images/de/erweiterungen-im-contao-manager-aktualisieren.png)
+![Erweiterungen im Contao Manager aktualisieren](/de/installation/images/de/erweiterungen-im-contao-manager-aktualisieren.png)
 
 Sobald der Contao Manager die Erweiterungen aktualisiert hat, musst du das [Contao-Installtool](../contao-installtool/) 
 aufrufen um die Datenbank, falls nötig, zu aktualisieren.

--- a/docs/manual/installation/erweiterung-deinstallieren.de.md
+++ b/docs/manual/installation/erweiterung-deinstallieren.de.md
@@ -14,13 +14,13 @@ Wenn du die Erweiterung »contao-easy_themes« deinstallieren möchtest, wechsle
 Schaltfläche »Entfernen« neben der Erweiterung. Du kannst natürlich auch noch weitere Erweiterung zur Deinstallation 
 vormerken.
 
-![Erweiterungen im Contao Manager zur Deinstallation vormerken](/installation/images/de/erweiterungen-im-contao-manager-zur-deinstallation-vormerken.png)
+![Erweiterungen im Contao Manager zur Deinstallation vormerken](/de/installation/images/de/erweiterungen-im-contao-manager-zur-deinstallation-vormerken.png)
 
 Klicke auf »Änderungen anwenden« um die Deinstallation zu starten. Die Deinstallation kann nun mehrere Minuten in 
 Anspruch nehmen. Details zum Deinstallationsprozess können durch Klick auf folgendes Symbol 
-![Konsolenausgabe anzeigen/verstecken](/icons/konsolenausgabe.png?classes=icon) angezeigt werden.
+![Konsolenausgabe anzeigen/verstecken](/de/icons/konsolenausgabe.png?classes=icon) angezeigt werden.
 
-![Erweiterungen im Contao Manager deinstallieren](/installation/images/de/erweiterungen-im-contao-manager-deinstallieren.png)
+![Erweiterungen im Contao Manager deinstallieren](/de/installation/images/de/erweiterungen-im-contao-manager-deinstallieren.png)
 
 Sobald die Erweiterungen deinstalliert worden sind, musst du das [Contao-Installtool](../contao-installtool/) 
 aufrufen um die Datenbank, falls nötig, zu aktualisieren.

--- a/docs/manual/installation/erweiterung-installieren.de.md
+++ b/docs/manual/installation/erweiterung-installieren.de.md
@@ -14,14 +14,14 @@ Um eine passende Erweiterung für eine gewünschte Funktion zu finden, hast du d
 
 Du kannst auf der Website [extensions.contao.org](https://extensions.contao.org/) ein Erweiterung suchen.  
 
-![Erweiterungssuche auf extensions.contao.org](/installation/images/de/erweiterungssuche-extensions-contao-org.png)
+![Erweiterungssuche auf extensions.contao.org](/de/installation/images/de/erweiterungssuche-extensions-contao-org.png)
 
 
 ### Contao Manager
 
 Du kannst im Contao Manager deiner Installation eine Erweiterung suchen.  
 
-![Erweiterungssuche im Contao Manager](/installation/images/de/erweiterungssuche-im-contao-manager.png)
+![Erweiterungssuche im Contao Manager](/de/installation/images/de/erweiterungssuche-im-contao-manager.png)
 
 
 ### Kommandozeile
@@ -69,18 +69,18 @@ Du musst dich zunächst wieder am Contao Manager anmelden. Dazu rufst du erneut 
 Wenn du die Erweiterung »contao-easy_themes« installieren möchtest, gebe »EasyThemes« im Suchschlitz ein und klicke auf 
 »Hinzufügen«. Wiederhole die Suche, wenn du weitere Erweiterungen finden und zur Installation vormerken möchtest.
 
-![Erweiterungen im Contao Manager suchen](/installation/images/de/erweiterungen-im-contao-manager-suchen.png)
+![Erweiterungen im Contao Manager suchen](/de/installation/images/de/erweiterungen-im-contao-manager-suchen.png)
 
 Wechsle danach in den Reiter »Pakete« und klicke auf »Änderungen anwenden« un die Installation zu starten. Die 
 Installation kann nun mehrere Minuten in Anspruch nehmen. Details zum Installationsprozess können durch Klick auf 
-folgendes Symbol ![Konsolenausgabe anzeigen/verstecken](/icons/konsolenausgabe.png?classes=icon) angezeigt werden.
+folgendes Symbol ![Konsolenausgabe anzeigen/verstecken](/de/icons/konsolenausgabe.png?classes=icon) angezeigt werden.
 
-![Erweiterungen im Contao Manager installieren](/installation/images/de/erweiterungen-im-contao-manager-installieren.png)
+![Erweiterungen im Contao Manager installieren](/de/installation/images/de/erweiterungen-im-contao-manager-installieren.png)
 
 Sobald der Contao Manager die Erweiterungen installiert hat, musst du das [Contao-Installtool](../contao-installtool/) 
 aufrufen um die Datenbank zu aktualisieren.
 
-![Erweiterungen im Contao Manager installiert](/installation/images/de/erweiterungen-im-contao-manager-installiert.png)
+![Erweiterungen im Contao Manager installiert](/de/installation/images/de/erweiterungen-im-contao-manager-installiert.png)
 
 
 

--- a/docs/manual/installation/systemvoraussetzungen.de.md
+++ b/docs/manual/installation/systemvoraussetzungen.de.md
@@ -138,7 +138,7 @@ Hintergrundaufgaben (wie die Indizierung des Seiteninhalts) ausführen, ohne das
 
 Lade den Contao-Check herunter und finde heraus, ob dein Server die Contao-Systemvoraussetzungen erfüllt.
 
-![Der Contao-Check](/installation/images/de/der-contao-check.png)
+![Der Contao-Check](/de/installation/images/de/der-contao-check.png)
 
 Entpacke die ZIP-Datei, übertrage den Ordner <code>check</code> in den Unterordner `web/` deiner Contao-Installation, setze das Wurzelverzeichnis (Document Root) deiner Domain über das Admin-Panel des Hosting-Providers auf diesen Unterordner und öffne 
 <code>www.example.com/check</code> in deinem Browser.

--- a/docs/manual/introduction/_index.de.md
+++ b/docs/manual/introduction/_index.de.md
@@ -2,7 +2,7 @@
 title: "Contao im Überblick"
 description: "Contao ist ein Web Content Management System, das unter einer Open Source-Lizenz, nämlich der Lesser 
 General Public License, veröffentlicht wurde."
-url: "de/einleitung"
+url: "einleitung"
 weight: 1
 ---
 

--- a/docs/manual/introduction/contao-im-schnelldurchlauf.de.md
+++ b/docs/manual/introduction/contao-im-schnelldurchlauf.de.md
@@ -2,7 +2,7 @@
 title: "Contao im Schnelldurchlauf"
 description: "In diesem Abschnitt werden dir die grundsätzlichen Zusammenhänge und Funktionsweisen von Contao in 
 komprimierter Form vorgestellt."
-url: "de/einleitung/contao-im-schnelldurchlauf"
+url: "einleitung/contao-im-schnelldurchlauf"
 weight: 3
 ---
 

--- a/docs/manual/introduction/contao-im-schnelldurchlauf.de.md
+++ b/docs/manual/introduction/contao-im-schnelldurchlauf.de.md
@@ -45,7 +45,7 @@ beliebig verzweigte Unterseiten erstellen. Contao erstellt im Frontend automatis
 entsprechenden Navigationsmenüs mit allen Haupt- und Unterseiten. Wenn du eine neue Seite im Backend hinzufügst oder die
 Reihenfolge der Seiten anpasst, wird diese Änderung sofort auf der Webseite sichtbar.
 
-![Die Seitenstruktur](/introduction/images/de/die-seitenstruktur.png)
+![Die Seitenstruktur](/de/introduction/images/de/die-seitenstruktur.png)
 
 
 ## Jede Seite hat ein Seitenlayout
@@ -72,7 +72,7 @@ und bei Bedarf sogar die Einbindung eines externen Layouts oder die Verwendung e
 Innerhalb der in einem Seitenlayout aktivierten Layoutbereiche kannst du beliebige Frontend-Module platzieren, die beim 
 Aufruf einer Seite der Reihenfolge nach ausgeführt werden und den HTML-Code für das Frontend erzeugen.
 
-![Die Frontend-Module](/introduction/images/de/die-frontend-module.png)
+![Die Frontend-Module](/de/introduction/images/de/die-frontend-module.png)
 
 Genau wie Seitenlayouts können auch Frontend-Module per Mausklick angelegt und konfiguriert werden. Contao enthält 
 bereits ab Werk etliche Modultypen, z. B. zur Erstellung von Navigationsmenüs, zur Verwaltung von Benutzern oder zum 
@@ -104,7 +104,7 @@ Die eigentlichen Inhalte – bisher ging es ja nur um den Seitenaufbau und das D
 gespeichert. Jeder Artikel besteht wiederum aus Inhaltselementen, die für jeden Inhaltstyp wie z. B. Texte, Bilder oder 
 Tabellen eine entsprechende Ein- und Ausgabefunktion bereitstellen.
 
-![Das Inhaltselement »Auflistung« im Backend](/introduction/images/de/das-inhaltselement-auflistung-im-backend.png)
+![Das Inhaltselement »Auflistung« im Backend](/de/introduction/images/de/das-inhaltselement-auflistung-im-backend.png)
 
 Das Konzept der Inhaltselemente hat viele Vorteile. Zum Beispiel reduziert sich das Risiko von redundantem oder sogar 
 invalidem HTML-Code gegenüber der Verwendung eines Rich Text Editors, weil jedes Element separat generiert wird. 

--- a/docs/manual/introduction/contao-open-source-cms.de.md
+++ b/docs/manual/introduction/contao-open-source-cms.de.md
@@ -2,7 +2,7 @@
 title: "Contao Open Source CMS"
 description: "Es handelt sich um ein CMS, also ein Content Management System, das unter einer Open Source-Lizenz steht 
 und Contao heißt."
-url: "de/einleitung/contao-open-source-cms"
+url: "einleitung/contao-open-source-cms"
 weight: 1
 ---
 

--- a/docs/manual/introduction/das-contao-netzwerk.de.md
+++ b/docs/manual/introduction/das-contao-netzwerk.de.md
@@ -24,7 +24,7 @@ um das System kennenzulernen. Aus diesem Grund sind alle wichtigen Informationen
 von der Funktionsübersicht über die News bis hin zur Online-Demo, den Veranstaltungen, den Fallstudien und dem 
 Contao-Team.
 
-![Die Contao-Projektwebseite](/introduction/images/de/die-contao-projektwebseite.png)
+![Die Contao-Projektwebseite](/de/introduction/images/de/die-contao-projektwebseite.png)
 
 Nachdem der Benutzer vom System überzeugt ist, wird er es in aller Regel herunterladen und selbst installieren wollen. 
 Folglich ist `Download` die nächste Kategorie. Neben den Programm-Downloads findest du im Bereich Media das Contao-Logo 
@@ -65,7 +65,7 @@ die Entwicklung so wichtig ist, wird diese transparent auf der Plattform
 über Tickets, welche mit dem Label »up for discussion« gekennzeichnet wurden, 
 austauschen.
 
-![Die Entwicklungsumgebung](/introduction/images/de/die-entwicklungsumgebung.png)
+![Die Entwicklungsumgebung](/de/introduction/images/de/die-entwicklungsumgebung.png)
 
 Im Bereich `Code` findest du einen Überblick über die Commits (Übergabe), die Branches (Zweige), die Releases 
 (Veröffentlichungen) und die Contributors (Beitragenden).
@@ -103,4 +103,4 @@ Wenn du die Menschen, die du in dieser virtuellen Welt kennenlernst, einmal in d
 du das auf der Konferenz, am Camp oder bei den verschiedenen Stammtischen tun. Eine Liste der Veranstaltungen findest 
 du auf der [Projekt-Webseite](https://contao.org/de/veranstaltungen.html).
 
-![Die deutschsprachige Contao-Community](/introduction/images/de/die-deutschsprachige-contao-community.png)
+![Die deutschsprachige Contao-Community](/de/introduction/images/de/die-deutschsprachige-contao-community.png)

--- a/docs/manual/introduction/das-contao-netzwerk.de.md
+++ b/docs/manual/introduction/das-contao-netzwerk.de.md
@@ -2,7 +2,7 @@
 title: "Das Contao-Netzwerk"
 description: "Über die Jahre sind etliche Webseiten und Artikel zu Contao entstanden, teilweise in Absprache mit dem 
 Contao-Team, teilweise vollkommen autark."
-url: "de/einleitung/das-contao-netzwerk"
+url: "einleitung/das-contao-netzwerk"
 weight: 2
 ---
 

--- a/docs/manual/module-management/_index.de.md
+++ b/docs/manual/module-management/_index.de.md
@@ -2,7 +2,7 @@
 title: "Modulverwaltung"
 description: "Frontend-Module generieren den HTML-Code der Webseite. Sie gehören zu den designrelevanten Elementen und 
 sind deswegen dem Theme-Manager untergeordnet."
-url: "de/modulverwaltung"
+url: "modulverwaltung"
 weight: 8
 ---
 

--- a/docs/manual/module-management/_index.de.md
+++ b/docs/manual/module-management/_index.de.md
@@ -22,7 +22,7 @@ Die Modulverwaltung rufst du demzufolge über den Theme-Manager wie im Abschnit
 Genau wie bei den Inhaltselementen kannst du unter **Zugriffsschutz** auch den Zugriff auf ein Frontend-Modul auf bestimmte 
 Mitgliedergruppen beschränken.
 
-![Den Zugriff auf ein Modul einschränken](/module-management/images/de/den-zugriff-auf-ein-modul-einschraenken.png)
+![Den Zugriff auf ein Modul einschränken](/de/module-management/images/de/den-zugriff-auf-ein-modul-einschraenken.png)
 
 **Modul schützen:** Das Modul ist standardmäßig unsichtbar und wird erst eingeblendet, nachdem sich ein Mitglied im 
 Frontend angemeldet hat.

--- a/docs/manual/module-management/anwendungen.de.md
+++ b/docs/manual/module-management/anwendungen.de.md
@@ -23,7 +23,7 @@ Das Frontend-Modul »Auflistung« fügt der Webseite eine Liste von Datensätze
 und durchsucht werden können. Als Grundlage für die Auflistung dient eine beliebige Tabelle der Datenbank, wie z. B. 
 die Mitgliedertabelle `tl_member`.
 
-![Das Auflistungsmodul konfigurieren](/module-management/images/de/das-auflistungsmodul-konfigurieren.png)
+![Das Auflistungsmodul konfigurieren](/de/module-management/images/de/das-auflistungsmodul-konfigurieren.png)
 
 **Tabelle:** Hier legst du die Tabelle fest, deren Datensätze aufgelistet werden sollen.
 

--- a/docs/manual/module-management/anwendungen.de.md
+++ b/docs/manual/module-management/anwendungen.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Anwendungen"
 description: "In diesem Abschnitt werden dir die übrigen Core-Module im Bereich »Anwendungen« vorgestellt."
-url: "de/modulverwaltung/anwendungen"
+url: "modulverwaltung/anwendungen"
 weight: 4
 ---
 

--- a/docs/manual/module-management/benutzermodule.de.md
+++ b/docs/manual/module-management/benutzermodule.de.md
@@ -2,7 +2,7 @@
 title: "Benutzermodule"
 description: "Benutzermodule sind Module, die im Zusammenhang mit der Verwaltung von Frontend-Benutzern gebraucht 
 werden."
-url: "de/modulverwaltung/benutzermodule"
+url: "modulverwaltung/benutzermodule"
 weight: 2
 ---
 <style>

--- a/docs/manual/module-management/benutzermodule.de.md
+++ b/docs/manual/module-management/benutzermodule.de.md
@@ -294,7 +294,7 @@ welche Felder bearbeitet werden dürfen und welche nicht.
 
 **Editierbare Felder:** Hier kannst du die editierbaren Felder festlegen.
 
-![Editierbare Felder festlegen](/module-management/images/de/editierbare-felder-festlegen.png)
+![Editierbare Felder festlegen](/de/module-management/images/de/editierbare-felder-festlegen.png)
 
 **Abonnierbare Newsletter:** Wenn du die Contao Newsletter-Erweiterung verwendest, kannst du hier festlegen, welche 
 Verteiler ein Mitglied abonnieren kann.

--- a/docs/manual/module-management/navigationsmodule.de.md
+++ b/docs/manual/module-management/navigationsmodule.de.md
@@ -24,7 +24,7 @@ Unterebenen bis zur am tiefsten verschachtelten Ebene. Das Startlevel bietet dir
 beispielsweise von der zweiten Ebene aus starten zu lassen, sodass nur ein Teil des Seitenbaums ausgegeben wird 
 (Untermenü).
 
-![Die Navigationsmenüs im Frontend](/module-management/images/de/die-navigationsmenues-im-frontend.png)
+![Die Navigationsmenüs im Frontend](/de/module-management/images/de/die-navigationsmenues-im-frontend.png)
 
 **Stoplevel:** Im Gegensatz zum Startlevel, das die Einstiegsebene des Navigationsmenüs vorgibt, bestimmt das Stoplevel 
 die Ausstiegsebene, also die maximale Tiefe der Verschachtelung. Das Hauptmenü unserer Webseite soll beispielsweise nur 
@@ -147,7 +147,7 @@ angezeigt, die normalerweise übersprungen würden.
 
 **Individuelles Template:** Hier kannst du das Standard-Template `mod_breadcrumb` überschreiben.
 
-![Der Navigationspfad im Frontend](/module-management/images/de/der-navigationspfad-im-frontend.png)
+![Der Navigationspfad im Frontend](/de/module-management/images/de/der-navigationspfad-im-frontend.png)
 
 **HTML-Ausgabe**  
 Das Frontend-Modul generiert folgenden HTML-Code:
@@ -267,7 +267,7 @@ Das Frontend-Modul »Buchnavigation« fügt der Webseite ein Navigationsmenü 
 Seitenstruktur vorwärts, zurück oder eine Ebene nach oben navigieren kannst. Die einzelnen Seiten werden dabei wie bei 
 einem Buch quasi umgeblättert, daher der Name des Moduls.
 
-![Die Buchnavigation im Frontend](/module-management/images/de/die-buchnavigation-im-frontend.png)
+![Die Buchnavigation im Frontend](/de/module-management/images/de/die-buchnavigation-im-frontend.png)
 
 **Referenzseite:** Die Referenzseite legt den Ausgangspunkt der Buchnavigation fest. Übergeordnete Seiten werden nicht 
 in der Buchnavigation angezeigt.
@@ -303,7 +303,7 @@ Das Frontend-Modul generiert folgenden HTML-Code:
 Das Modul »Artikelnavigation« fügt der Webseite ein Navigationsmenü hinzu, mit dem du ähnlich wie bei einer 
 Buchnavigation die Artikel einer bestimmten Seite vorwärts- und rückwärts durchblättern kannst.
 
-![Die Artikelnavigation im Frontend](/module-management/images/de/die-artikelnavigation-im-frontend.png)
+![Die Artikelnavigation im Frontend](/de/module-management/images/de/die-artikelnavigation-im-frontend.png)
 
 **Erstes Element laden:** Wenn du diese Option auswählst, wird automatisch der erste Artikel geladen, wenn kein 
 bestimmter Artikel angefordert wurde.

--- a/docs/manual/module-management/navigationsmodule.de.md
+++ b/docs/manual/module-management/navigationsmodule.de.md
@@ -2,7 +2,7 @@
 title: "Navigationsmodule"
 description: "Navigationsmodule sind mit die wichtigsten Frontend-Module überhaupt und kommen auf fast jeder Webseite 
 in irgendeiner Form zum Einsatz."
-url: "de/modulverwaltung/navigationsmodule"
+url: "modulverwaltung/navigationsmodule"
 weight: 1
 ---
 

--- a/docs/manual/module-management/verschiedenes.de.md
+++ b/docs/manual/module-management/verschiedenes.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Verschiedenes"
 description: "In diesem Abschnitt werden dir die übrigen Core-Module im Bereich »Verschiedenes« vorgestellt."
-url: "de/modulverwaltung/verschiedenes"
+url: "modulverwaltung/verschiedenes"
 weight: 5
 ---
 

--- a/docs/manual/module-management/website-suche.de.md
+++ b/docs/manual/module-management/website-suche.de.md
@@ -2,7 +2,7 @@
 title: "Website-Suche"
 description: "Contao indiziert die Seiten deiner Webpräsenz automatisch, sobald sie aufgerufen werden, und speichert 
 die darauf zu findenden Wörter als Suchbegriffe in einer Tabelle in der Datenbank."
-url: "de/modulverwaltung/website-suche"
+url: "modulverwaltung/website-suche"
 weight: 3
 ---
 

--- a/docs/manual/module-management/website-suche.de.md
+++ b/docs/manual/module-management/website-suche.de.md
@@ -10,7 +10,7 @@ Contao indiziert die Seiten deiner Webpräsenz automatisch, sobald sie aufgerufe
 findenden Wörter als Suchbegriffe in einer Tabelle in der Datenbank. Das Suchmodul durchsucht diese Tabelle und liefert 
 die Seiten zurück, die den gesuchten Begriff bzw. die gesuchten Begriffe enthalten.
 
-![Die On-Site-Suche im Frontend](/module-management/images/de/die-on-site-suche-im-frontend.png)
+![Die On-Site-Suche im Frontend](/de/module-management/images/de/die-on-site-suche-im-frontend.png)
 
 Beachte jedoch, dass deine Webseite aus Sicherheitsgründen nicht indiziert wird, wenn du im Backend angemeldet bist und 
 die Frontend-Vorschau aufrufst. Es könnte ja sein, dass sich dort noch nicht veröffentlichte Inhalte befinden, die vor 

--- a/docs/manual/site-structure/_index.de.md
+++ b/docs/manual/site-structure/_index.de.md
@@ -2,7 +2,7 @@
 title: "Seitenstruktur"
 description: "Um Contao effektiv einsetzen zu können, ist es wichtig, dass du die Grundprinzipien und den Aufbau des 
 Systems verstehst."
-url: "de/seitenstruktur"
+url: "seitenstruktur"
 weight: 6
 ---
 

--- a/docs/manual/site-structure/mehrsprachige-webseiten.de.md
+++ b/docs/manual/site-structure/mehrsprachige-webseiten.de.md
@@ -3,7 +3,7 @@ title: "Mehrsprachige Webseiten"
 description: "Mehrsprachige Webseiten werden in Contao ebenfalls über verschiedene Webseiten in der Seitenstruktur 
 realisiert, die sich im Gegensatz zum Multidomain-Betrieb nicht anhand des Domainnamens unterscheiden, sondern anhand 
 der Sprache."
-url: "de/seitenstruktur/mehrsprachige-webseiten"
+url: "seitenstruktur/mehrsprachige-webseiten"
 weight: 4
 ---
 

--- a/docs/manual/site-structure/multidomain-betrieb.de.md
+++ b/docs/manual/site-structure/multidomain-betrieb.de.md
@@ -2,7 +2,7 @@
 title: "Multidomain-Betrieb"
 description: "Multidomain-Betrieb bedeutet, dass eine Contao-Installation unter mehreren Domains erreichbar ist und 
 diese jeweils eine unterschiedliche Ausgabe bewirken."
-url: "de/seitenstruktur/multidomain-betrieb"
+url: "seitenstruktur/multidomain-betrieb"
 weight: 3
 ---
 

--- a/docs/manual/site-structure/seiten-als-zentrale-elemente.de.md
+++ b/docs/manual/site-structure/seiten-als-zentrale-elemente.de.md
@@ -2,7 +2,7 @@
 title: "Seiten als zentrale Elemente"
 description: "Contao gehört zur Gruppe der seitenbasierten Content Management Systeme, das heißt, die Seitenstruktur 
 ist das zentrale Element deiner Webseite."
-url: "de/seitenstruktur/seiten-als-zentrale-elemente"
+url: "seitenstruktur/seiten-als-zentrale-elemente"
 weight: 1
 ---
 

--- a/docs/manual/site-structure/seiten-als-zentrale-elemente.de.md
+++ b/docs/manual/site-structure/seiten-als-zentrale-elemente.de.md
@@ -22,11 +22,11 @@ Webseite erscheinen werden, wenn sie nicht mit einer Seite (Sendung) verknüpft
 Die Seitenstruktur ist hierarchisch organisiert. Du kannst die einzelnen Seiten ineinander verschachteln und so 
 beliebig verzweigte Unterseiten erstellen, aus denen Contao im Frontend automatisch die entsprechenden Navigationsmenüs 
 mit allen Haupt- und Unterseiten erstellt. Benutze die grauen Icons mit dem 
-![Bereich öffnen](/icons/folPlus.svg?classes=icon) Plus- bzw. 
-![Bereich schließen](/icons/folMinus.svg?classes=icon) Minuszeichen links neben den Seitennamen, um Unterseiten 
+![Bereich öffnen](/de/icons/folPlus.svg?classes=icon) Plus- bzw. 
+![Bereich schließen](/de/icons/folMinus.svg?classes=icon) Minuszeichen links neben den Seitennamen, um Unterseiten 
 aus- oder einzuklappen.
 
-![Unterseiten aus- und einklappen](/site-structure/images/de/unterseiten-aus-und-einklappen.png)
+![Unterseiten aus- und einklappen](/de/site-structure/images/de/unterseiten-aus-und-einklappen.png)
 
 Dank der hierarchischen Seitenstruktur ist es möglich, Eigenschaften einer übergeordneten Seite an ihre Unterseiten zu 
 vererben. Für deine Arbeit bedeutet das, dass du ein bestimmtes Seitenlayout oder eine bestimmte Zugriffsberechtigung 

--- a/docs/manual/site-structure/seiten-konfigurieren.de.md
+++ b/docs/manual/site-structure/seiten-konfigurieren.de.md
@@ -2,7 +2,7 @@
 title: "Seiten konfigurieren"
 description: "Nachdem du die richtigen Seitentypen für deine Seiten ausgewählt hast, kannst du diese deinen 
 Anforderungen entsprechend konfigurieren. Die Einstellungsmöglichkeiten variieren dabei je nach Seitentyp."
-url: "de/seitenstruktur/seiten-konfigurieren"
+url: "seitenstruktur/seiten-konfigurieren"
 weight: 2
 ---
 

--- a/docs/manual/site-structure/seiten-konfigurieren.de.md
+++ b/docs/manual/site-structure/seiten-konfigurieren.de.md
@@ -186,7 +186,7 @@ Benutzergruppe Nachrichten. Sowohl der Benutzer als auch alle Mitglieder der Ben
 dieser Seite Artikel bearbeiten, aber nur der Besitzer h.lewis – und du als Administrator natürlich – dürfen die Seite 
 an sich bearbeiten und z. B. den Seitentitel ändern.
 
-![Zugriffsrechte zuweisen](/site-structure/images/de/zugriffsrechte-zuweisen.png)
+![Zugriffsrechte zuweisen](/de/site-structure/images/de/zugriffsrechte-zuweisen.png)
 
 **Zugriffsrechte zuweisen:** Hier kannst du einer Seite Zugriffsrechte zuweisen. Wenn du die Option nicht auswählst, 
 werden die Zugriffsrechte von einer übergeordneten Seite geerbt.

--- a/docs/manual/system/systemwartung.de.md
+++ b/docs/manual/system/systemwartung.de.md
@@ -16,7 +16,7 @@ Wiederherstellen gelöschter Datensätze oder früherer Versionen verwendet werd
 bereinigen, um z. B. alte Vorschaubilder zu entfernen oder die XML-Sitemaps nach einer Änderung an der Seitenstruktur 
 zu aktualisieren.
 
-![Daten manuell bereinigen](/system/images/de/daten-manuell-bereinigen.png)
+![Daten manuell bereinigen](/de/system/images/de/daten-manuell-bereinigen.png)
 
 
 ## Suchindex neu aufbauen
@@ -26,7 +26,7 @@ musst du dich um den Suchindex normalerweise keine Gedanken machen. Wenn du alle
 aktualisiert hast, ist es bequemer, den Suchindex manuell neu aufzubauen, als alle geänderten Seiten einzeln im Browser 
 aufzurufen.
 
-![Den Suchindex automatisch aufbauen](/system/images/de/den-suchindex-automatisch-aufbauen.png)
+![Den Suchindex automatisch aufbauen](/de/system/images/de/den-suchindex-automatisch-aufbauen.png)
 
 
 ## Geschützte Seiten indizieren

--- a/docs/manual/theme-manager/seitenlayouts-verwalten.de.md
+++ b/docs/manual/theme-manager/seitenlayouts-verwalten.de.md
@@ -30,10 +30,10 @@ anderem das Firmenlogo und in der Fußzeile Informationen zum Copyright und ein 
 
 **Zeilen**: Hier fügst du dem Layout eine Kopfzeile und Fusszeile hinzu.
 
-![Keine Kopf- und Fusszeile](/icons/1rw.svg?classes=icon "Keine Kopf- und Fusszeile")
-![Kopfzeile hinzufügen](/icons/2rwh.svg?classes=icon "Kopfzeile hinzufügen")
-![Fusszeile hinzufügen](/icons/2rwf.svg?classes=icon "Fusszeile hinzufügen")
-![Kopf- und Fusszeile hinzufügen](/icons/3rw.svg?classes=icon "Kopf- und Fusszeile hinzufügen")
+![Keine Kopf- und Fusszeile](/de/icons/1rw.svg?classes=icon "Keine Kopf- und Fusszeile")
+![Kopfzeile hinzufügen](/de/icons/2rwh.svg?classes=icon "Kopfzeile hinzufügen")
+![Fusszeile hinzufügen](/de/icons/2rwf.svg?classes=icon "Fusszeile hinzufügen")
+![Kopf- und Fusszeile hinzufügen](/de/icons/3rw.svg?classes=icon "Kopf- und Fusszeile hinzufügen")
 
 **Höhe der Kopfzeile**: Hier kannst du die Höhe der Kopfzeile festlegen.
 
@@ -47,10 +47,10 @@ vorgeben, die Hauptspalte passt sich jeweils automatisch an.
 
 **Spalten**: Hier wählst du die Anzahl der Spalten deines Seitenlayouts aus.
 
-![Keine Spalten](/icons/1cl.svg?classes=icon "Keine Spalten")
-![Linke Spalte hinzufügen](/icons/2cll.svg?classes=icon "Linke Spalte hinzufügen")
-![Rechte Spalte hinzufügen](/icons/2clr.svg?classes=icon "Rechte Spalte hinzufügen")
-![Linke und rechte Spalte hinzufügen](/icons/3cl.svg?classes=icon "Linke und rechte Spalte hinzufügen")
+![Keine Spalten](/de/icons/1cl.svg?classes=icon "Keine Spalten")
+![Linke Spalte hinzufügen](/de/icons/2cll.svg?classes=icon "Linke Spalte hinzufügen")
+![Rechte Spalte hinzufügen](/de/icons/2clr.svg?classes=icon "Rechte Spalte hinzufügen")
+![Linke und rechte Spalte hinzufügen](/de/icons/3cl.svg?classes=icon "Linke und rechte Spalte hinzufügen")
 
 **Breite der linken Spalte**: Hier legst du die Breite der linken Spalte fest.
 
@@ -169,7 +169,7 @@ Seitenlayouts gemeint, sondern das `<head>`-Tag des HTML-Quelltextes.
 In dieser Sektion weist du den einzelnen Layoutbereichen die Frontend-Module zu, die auf der Seite dargestellt werden 
 sollen. Die Module jedes Layoutbereichs werden in der von dir festgelegten Reihenfolge untereinander angeordnet.
 
-![Frontend-Module der Contao Official Demo](/theme-manager/images/de/frontend-module-der-contao-official-demo.png)
+![Frontend-Module der Contao Official Demo](/de/theme-manager/images/de/frontend-module-der-contao-official-demo.png)
 
 **Eingebundene Module:** Hier wählst du die Module für das Seitenlayout aus.
 

--- a/docs/manual/theme-manager/stylesheets-verwalten.de.md
+++ b/docs/manual/theme-manager/stylesheets-verwalten.de.md
@@ -100,7 +100,7 @@ In Contao kannst du mit dieser Schreibweise allerdings so gar nicht in Berühru
 Eingabemaske festlegen kannst. Lediglich den Teil vor den geschweiften Klammern, den sogenannten Selektor, musst du von 
 Hand in das dafür vorgesehene Feld eingeben.
 
-![Den Außenabstand im Stylesheet-Editor festlegen](/theme-manager/images/de/den-aussenabstand-im-stylesheet-editor-festlegen.png)
+![Den Außenabstand im Stylesheet-Editor festlegen](/de/theme-manager/images/de/den-aussenabstand-im-stylesheet-editor-festlegen.png)
 
 
 ### Reihenfolge der Formatdefinitionen
@@ -126,9 +126,9 @@ geladen und danach wieder durch das allgemeingültige Format für alle Browser
 käme also niemals zur Anwendung, und der Außenabstand betrüge immer 24 Pixel.
 
 Du kannst die Reihenfolge der Datensätze in Contao über die Navigationsicons 
-![Formatdefinition verschieben](/icons/drag.svg?classes=icon) **Drag&Drop** oder 
-![Formatdefinition verschieben](/icons/cut.svg?classes=icon) **Verschieben** und 
-![Nach der Formatdefinition einfügen](/icons/pasteafter.svg?classes=icon) **Danach einfügen** ändern.
+![Formatdefinition verschieben](/de/icons/drag.svg?classes=icon) **Drag&Drop** oder 
+![Formatdefinition verschieben](/de/icons/cut.svg?classes=icon) **Verschieben** und 
+![Nach der Formatdefinition einfügen](/de/icons/pasteafter.svg?classes=icon) **Danach einfügen** ändern.
 
 Zudem hast du die Möglichkeit, Formatdefinitionen eine Kategorie zuzuweisen, um die Datensätze später nach dieser 
 Kategorie filtern und zusammengehörende Definitionen leichter erkennen zu können. Diese Kategorien dienen lediglich der 
@@ -138,7 +138,7 @@ besseren Übersicht im Backend und werden nicht für die Sortierung im Styleshe
 ## Stylesheets exportieren
 
 Du kannst einzelne Stylesheets exportieren, indem du hinter dem Stylesheet auf das Navigationsicons 
-![Stylesheet exportieren](/icons/theme_export.svg?classes=icon) **Stylesheet exportieren** klickst.
+![Stylesheet exportieren](/de/icons/theme_export.svg?classes=icon) **Stylesheet exportieren** klickst.
 
 
 ## Stylesheets importieren

--- a/docs/manual/theme-manager/themes-verwalten.de.md
+++ b/docs/manual/theme-manager/themes-verwalten.de.md
@@ -39,18 +39,18 @@ allein deinem bevorzugten Organisationsansatz.
 Die Bedienung des Theme-Managers funktioniert genau wie die der meisten anderen Backend-Module, nämlich mithilfe von 
 Navigationssymbolen.
 
-![Navigationssymbole im Theme-Manager](/theme-manager/images/de/navigationssymbole-im-theme-manager.png)
+![Navigationssymbole im Theme-Manager](/de/theme-manager/images/de/navigationssymbole-im-theme-manager.png)
 
-- ![Theme bearbeiten](/icons/edit.svg?classes=icon) Theme bearbeiten
-- ![Theme löschen](/icons/delete.svg?classes=icon) Theme löschen
-- ![Details des Theme anzeigen](/icons/show.svg?classes=icon) Details des Theme anzeigen
-- ![Die Stylesheets des Theme bearbeiten](/icons/css.svg?classes=icon) Die Stylesheets des Theme bearbeiten
-- ![Die Frontend-Module des Theme bearbeiten](/icons/modules.svg?classes=icon) Die Frontend-Module des Theme 
+- ![Theme bearbeiten](/de/icons/edit.svg?classes=icon) Theme bearbeiten
+- ![Theme löschen](/de/icons/delete.svg?classes=icon) Theme löschen
+- ![Details des Theme anzeigen](/de/icons/show.svg?classes=icon) Details des Theme anzeigen
+- ![Die Stylesheets des Theme bearbeiten](/de/icons/css.svg?classes=icon) Die Stylesheets des Theme bearbeiten
+- ![Die Frontend-Module des Theme bearbeiten](/de/icons/modules.svg?classes=icon) Die Frontend-Module des Theme 
 bearbeiten
-- ![Die Seitenlayouts des Theme bearbeiten](/icons/layout.svg?classes=icon) Die Seitenlayouts des Theme 
+- ![Die Seitenlayouts des Theme bearbeiten](/de/icons/layout.svg?classes=icon) Die Seitenlayouts des Theme 
 bearbeiten
-- ![Die Bildgrößen des Theme bearbeiten](/icons/sizes.svg?classes=icon) Die Bildgrößen des Theme bearbeiten
-- ![Theme exportieren](/icons/theme_export.svg?classes=icon) Theme exportieren
+- ![Die Bildgrößen des Theme bearbeiten](/de/icons/sizes.svg?classes=icon) Die Bildgrößen des Theme bearbeiten
+- ![Theme exportieren](/de/icons/theme_export.svg?classes=icon) Theme exportieren
 
 **Theme-Titel**: Hier gibst du den Theme-Titel ein.
 
@@ -93,7 +93,7 @@ die Datei aus und starte den Importvorgang.
 Contao führt dann eine Reihe von Prüfungen durch, um eventuelle Inkompatibilitäten zwischen dem Theme und deiner 
 Contao-Installation zu entdecken.
 
-![Die Theme-Daten werden überprüft](/theme-manager/images/de/die-theme-daten-werden-ueberprueft.png)
+![Die Theme-Daten werden überprüft](/de/theme-manager/images/de/die-theme-daten-werden-ueberprueft.png)
 
 Die Überprüfung beinhaltet insbesondere:
 
@@ -121,7 +121,7 @@ Aufbau einer Seite festlegt.
 Zur Veranschaulichung wurde hier das Theme »[Contao Official Demo](https://packagist.org/packages/contao/official-demo)« 
 importiert und das Seitenlayout »2 columns - [ default ]« dem Startpunkt der Webseite in der Seitenstruktur zugewiesen.
 
-![Contao Official Demo](/theme-manager/images/de/contao-official-demo.png)
+![Contao Official Demo](/de/theme-manager/images/de/contao-official-demo.png)
 
 
 ## Bezugsquellen für Themes

--- a/docs/manual/user-management/_index.de.md
+++ b/docs/manual/user-management/_index.de.md
@@ -2,7 +2,7 @@
 title: "Benutzerverwaltung"
 description: "Die Benutzerverwaltung ist eine eigene Kategorie in der Backend-Navigation und beinhaltet vier Module, 
 mit denen jeweils die Benutzer und Gruppen des Backends und des Frontends verwaltet werden können."
-url: "de/benutzerverwaltung"
+url: "benutzerverwaltung"
 weight: 5
 ---
 

--- a/docs/manual/user-management/benutzer.de.md
+++ b/docs/manual/user-management/benutzer.de.md
@@ -9,14 +9,14 @@ Bisher haben wir ausschließlich als Administrator gearbeitet, der auf alle Bere
 darf. Ein Benutzer wird in der Regel aber nur Zugriff auf die Ressourcen erhalten, die er für eine bestimmte 
 Aufgabe tatsächlich benötigt.
 
-![Das Backend aus Sicht des Benutzers](/user-management/images/de/das-backend-aus-sicht-des-benutzers.png)
+![Das Backend aus Sicht des Benutzers](/de/user-management/images/de/das-backend-aus-sicht-des-benutzers.png)
 
 Normale Benutzer haben im Gegensatz zu Administratoren standardmäßig überhaupt keine Rechte und dürfen grundsätzlich 
 nur das tun, was du ihnen explizit erlaubst. Die sehr umfassende Rechteverwaltung in Contao ermöglicht es dir als 
 Administrator nicht nur, den Zugriff auf bestimmte Backend-Module einzuschränken, sondern bei Bedarf jedes einzelne
 Eingabefeld abzuschalten.
 
-![Einzelne Eingabefelder freischalten](/user-management/images/de/einzelne-eingabefelder-freischalten.png)
+![Einzelne Eingabefelder freischalten](/de/user-management/images/de/einzelne-eingabefelder-freischalten.png)
 
 ## Benutzergruppen
 
@@ -52,13 +52,13 @@ dürfen vgl. [Seitentypen](../../seitenstruktur/seiten-als-zentrale-elemente/#s
 Analog zum Pagemount, der den Einstiegspunkt in die Seitenstruktur bestimmt, legt der Filemount den Einstiegspunkt in 
 das Dateisystem fest. Auf Ordner außerhalb des Filemount kann der Benutzer nicht zugreifen.
 
-![Filemounts des Benutzers](/user-management/images/de/filemounts-des-benutzers.png)
+![Filemounts des Benutzers](/de/user-management/images/de/filemounts-des-benutzers.png)
 
 Der Benutzer sieht also nur die Ordner `files/public/media/content-images`, `files/public/media/documents` sowie 
 `files/public/media/slider` und alle eventuell darin enthaltenen Unterordner. Alle übrigen Verzeichnisse, die sich 
 auf derselben oder einer übergeordneten Ebene befinden, werden nicht angezeigt
 
-![Die Dateiverwaltung aus Sicht des Benutzers](/user-management/images/de/die-dateiverwaltung-aus-sicht-des-benutzers.png)
+![Die Dateiverwaltung aus Sicht des Benutzers](/de/user-management/images/de/die-dateiverwaltung-aus-sicht-des-benutzers.png)
 
 **Filemounts:** Hier wählst du die Filemounts der Gruppe aus.
 
@@ -283,7 +283,7 @@ In Abschnitt [Zugriffsrechte](../../seitenstruktur/seiten-konfigurieren/#zugriff
 dass jede Seite einem bestimmten Benutzer und einer bestimmten Gruppe gehört und dass es darauf basierend verschiedene 
 Zugriffsebenen gibt.
 
-![Zugriffsrechte einer Seite](/user-management/images/de/zugriffsrechte-einer-seite.png)
+![Zugriffsrechte einer Seite](/de/user-management/images/de/zugriffsrechte-einer-seite.png)
 
 Diese Seite gehört z. B. dem Benutzer `Helen Lewis`, der sie und die darin enthaltenen Artikel bearbeiten, verschieben 
 oder löschen darf. Andere Benutzer der Gruppe Nachrichten dürfen lediglich die Artikel bearbeiten, nicht aber die Seite 
@@ -293,4 +293,4 @@ Du musst also die Seiten, die ein Benutzer bearbeiten soll oder auf denen er Art
 Zugriffsrechten versehen und sie entweder dem Benutzer oder seiner Gruppe zuweisen. Damit schaffst du die 
 Voraussetzungen dafür, dass ein Benutzer die entsprechenden Navigationssymbole anklicken kann.
 
-![Die Seitenstruktur ohne zugewiesene Zugriffsrechte](/user-management/images/de/die-seitenstruktur-ohne-zugewiesene-zugriffsrechte.png)
+![Die Seitenstruktur ohne zugewiesene Zugriffsrechte](/de/user-management/images/de/die-seitenstruktur-ohne-zugewiesene-zugriffsrechte.png)


### PR DESCRIPTION
During testing of https://github.com/contao/docs/pull/105 I accidentally used Hugo `0.54.0` instead of `0.58.3` or higher. It seems the [documentation](https://gohugo.io/content-management/front-matter/) is wrong about the `url` front matter variable and it does in fact not override the language path as well (https://github.com/gohugoio/hugo/issues/6448).

This PR fixes the `de/de/` URLs.