### PR TITLE
Update system-requirements.de.md

### DIFF
--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -18,6 +18,7 @@ empfohlen, diese immer zu verwenden.
 
 - **PHP:** Version 7.3+ (neueste Patch-Version)
 - **MySQL:** Version 5.7+ oder gleichwertiger **MariaDB** Server
+
 {{% notice warning %}}
 Derzeit besteht eine Inkompatibilität mit MySQL Version **8.0.14+**.
 {{% /notice %}}

--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -17,7 +17,10 @@ gepflegten Versionen von Contao sind mit den neuesten PHP- und MySQL-Versionen k
 empfohlen, diese immer zu verwenden.
 
 - **PHP:** Version 7.3+ (neueste Patch-Version)
-- **MySQL:** Version 5.7+ aber vor 8.014 oder gleichwertiger **MariaDB** Server
+- **MySQL:** Version 5.7+ oder gleichwertiger **MariaDB** Server
+{{% notice warning %}}
+Derzeit besteht eine Inkompatibilität mit MySQL Version **8.0.14+**.
+{{% /notice %}}
 
 
 #### PHP-Erweiterungen

--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -20,7 +20,7 @@ empfohlen, diese immer zu verwenden.
 - **MySQL:** Version 5.7+ oder gleichwertiger **MariaDB** Server
 
 {{% notice warning %}}
-Derzeit besteht eine Inkompatibilität mit MySQL Version **8.0.14+**.
+Derzeit besteht eine Inkompatibilität mit MySQL Version **8.0.17+**.
 {{% /notice %}}
 
 

--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -17,7 +17,7 @@ gepflegten Versionen von Contao sind mit den neuesten PHP- und MySQL-Versionen k
 empfohlen, diese immer zu verwenden.
 
 - **PHP:** Version 7.3+ (neueste Patch-Version)
-- **MySQL:** Version 5.7+ oder gleichwertiger **MariaDB** Server
+- **MySQL:** Version 5.7+ aber vor 8.014 oder gleichwertiger **MariaDB** Server
 
 
 #### PHP-Erweiterungen


### PR DESCRIPTION
MySql Versionen ab 8.014 beinhalten neue reservierte Wörter, welches dazu führt, dass Contao nicht vollständig installiert werden kann.