### PR TITLE
Update system-requirements.de.md

### DIFF
--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -136,11 +136,11 @@ Hintergrundaufgaben (wie die Indizierung des Seiteninhalts) ausführen, ohne das
 
 ### Hosting-Konfiguration
 
-In Contao befinden sich alle öffentlich erreichbaren Dateien im Unterordner `/web` der Installation. Setze das 
+In Contao befinden sich alle öffentlich erreichbaren Dateien im Unterordner `web` der Installation. Setze das 
 Wurzelverzeichnis (Document Root) der Installation über das Admin-Panel des Hosting-Providers auf diesen 
 Unterordner und richte bei dieser Gelegenheit noch eine Datenbank ein.
 
-Beispiel: `example.com` zeigt auf das Verzeichnis `/www/example/web`
+Beispiel: `example.com` zeigt auf das Verzeichnis `www/example/web`
 
 {{% notice note %}}
 Pro Contao-Installation wird deshalb eine eigene (Sub)Domain benötigt.

--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -134,6 +134,17 @@ FastCGI-Setup zu konfigurieren. Durch die Verwendung von
 [`fastcgi_finish_request()`](https://www.php.net/manual/en/function.fastcgi-finish-request.php) kann Contao 
 Hintergrundaufgaben (wie die Indizierung des Seiteninhalts) ausführen, ohne dass der Browser auf die Antwort wartet.
 
+### Hosting-Konfiguration
+
+In Contao befinden sich alle öffentlich erreichbaren Dateien im Unterordner `/web` der Installation. Setze das 
+Wurzelverzeichnis (Document Root) der Installation über das Admin-Panel des Hosting-Providers auf diesen 
+Unterordner und richte bei dieser Gelegenheit noch eine Datenbank ein.
+
+Beispiel: `example.com` zeigt auf das Verzeichnis `/www/example/web`
+
+{{% notice note %}}
+Pro Contao-Installation wird deshalb eine eigene (Sub)Domain benötigt.
+{{% /notice %}}
 
 ## Contao-Check
 

--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -136,11 +136,11 @@ Hintergrundaufgaben (wie die Indizierung des Seiteninhalts) ausführen, ohne das
 
 ### Hosting-Konfiguration
 
-In Contao befinden sich alle öffentlich erreichbaren Dateien im Unterordner `web` der Installation. Setze das 
+In Contao befinden sich alle öffentlich erreichbaren Dateien im Unterordner `web/` der Installation. Setze das 
 Wurzelverzeichnis (Document Root) der Installation über das Admin-Panel des Hosting-Providers auf diesen 
 Unterordner und richte bei dieser Gelegenheit noch eine Datenbank ein.
 
-Beispiel: `example.com` zeigt auf das Verzeichnis `www/example/web`
+Beispiel: `example.com` zeigt auf das Verzeichnis `/www/example/web`
 
 {{% notice note %}}
 Pro Contao-Installation wird deshalb eine eigene (Sub)Domain benötigt.


### PR DESCRIPTION
Den Abschnitt Hosting-Konfiguration ergänzt (Kopie vom gleichnamigen Abschnitt unter Contao Installation mit der Kommandozeile).

Denn das muss ja immer gemacht werden, deshalb würde ich es hierher setzen. Dann kann man den Abschnitt unter Contao Installation mit der Kommandozeile wegnehmen.