### PR TITLE
fix color of language switcher in Google Chrome

### DIFF
--- a/page/static/css/theme-contao.css
+++ b/page/static/css/theme-contao.css
@@ -363,3 +363,8 @@ html[lang="de"] div.notices.warning p:first-child:after {
 html[lang="de"] div.notices.note p:first-child:after {
     content: 'Notiz';
 }
+
+/* fix #172 */
+option {
+    color: initial;
+}


### PR DESCRIPTION
Fixes #172. See also https://github.com/matcornic/hugo-theme-learn/pull/345.