### PR TITLE
Add guide on how to use a custom compiler pass in the Managed Edition

### DIFF
--- a/docs/dev/guides/me-compiler-pass.md
+++ b/docs/dev/guides/me-compiler-pass.md
@@ -22,8 +22,8 @@ container and thus also add compiler passes there.
 ### Contao Manager Plugin to the rescue
 
 Make sure your plugin implements the `ConfigPluginInterface` and implement the
-`registerContainerConfiguration` method. Now the provided loader allows
-accessing the container and adding your compiler pass:
+`registerContainerConfiguration` method (see [Plugin documentation](/framework/manager-plugin#the-configplugininterface)).
+Now the provided loader allows accessing the container and adding your compiler pass:
 
 ```php
 // src/ContaoManager/Plugin.php

--- a/docs/dev/guides/me-compiler-pass.md
+++ b/docs/dev/guides/me-compiler-pass.md
@@ -1,0 +1,46 @@
+---
+title: "Add Custom Compiler Passes (ME)"
+description: "How to add a custom compiler pass in the Contao Managed Edition."
+aliases:
+  - /guides/me-compiler-pass.md
+---
+
+
+## Add Custom Compiler Passes
+
+In a regular Symfony application or bundle a compiler pass can be added by calling
+`$container->addCompilerPass()` inside the `build()` function of the application's
+`Kernel` or the bundle's `Bundle` class (see the [Symfony documentation](https://symfony.com/doc/4.4/service_container/compiler_passes.html)
+for details).
+ 
+In a typical **Contao Managed Edition** setup, we cannot alter the Kernel nor does the
+application - following current best practices to be *bundle-less* - contain a
+`Bundle` class. However, we can also utilize the Contao Manager Plugin to alter the
+container and thus also add compiler passes there.
+
+
+### Contao Manager Plugin to the rescue
+
+Make sure your plugin implements the `ConfigPluginInterface` and implement the
+`registerContainerConfiguration` method. Now the provided loader allows
+accessing the container and adding your compiler pass:
+
+```php
+// src/ContaoManager/Plugin.php
+namespace App\ContaoManager;
+
+use App\DependencyInjection\Compiler\MyCompilerPass;
+use Contao\ManagerPlugin\Config\ConfigPluginInterface;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class Plugin implements ConfigPluginInterface
+{
+    public function registerContainerConfiguration(LoaderInterface $loader, array $managerConfig)
+    {
+        $loader->load(static function (ContainerBuilder $container) {
+            $container->addCompilerPass(new MyCompilerPass());
+        });
+    }
+}
+```

--- a/docs/dev/guides/modify-container-at-compile-time.md
+++ b/docs/dev/guides/modify-container-at-compile-time.md
@@ -6,7 +6,7 @@ aliases:
 ---
 
 
-## Modifying the container at compile time
+## Modifying the Container at Compile Time
 
 In a regular Symfony application or bundle a compiler pass for instance can be added
 by calling`$container->addCompilerPass()` inside the `build()` function of the application's

--- a/docs/dev/guides/modify-container-at-compile-time.md
+++ b/docs/dev/guides/modify-container-at-compile-time.md
@@ -1,29 +1,32 @@
 ---
-title: "Add Custom Compiler Passes (ME)"
-description: "How to add a custom compiler pass in the Contao Managed Edition."
+title: "Modifying the Container at Compile Time (ME)"
+description: "How to make changes to the container at compile time in the Contao Managed Edition."
 aliases:
-  - /guides/me-compiler-pass.md
+  - /guides/modify-container-at-compile-time/
 ---
 
 
-## Add Custom Compiler Passes
+## Modifying the container at compile time
 
-In a regular Symfony application or bundle a compiler pass can be added by calling
-`$container->addCompilerPass()` inside the `build()` function of the application's
+In a regular Symfony application or bundle a compiler pass for instance can be added
+by calling`$container->addCompilerPass()` inside the `build()` function of the application's
 `Kernel` or the bundle's `Bundle` class (see the [Symfony documentation](https://symfony.com/doc/4.4/service_container/compiler_passes.html)
-for details).
+for details). In fact this holds true for any modifications that need to be made to
+the container at compile time.
  
 In a typical **Contao Managed Edition** setup, we cannot alter the Kernel nor does the
 application - following current best practices to be *bundle-less* - contain a
 `Bundle` class. However, we can also utilize the Contao Manager Plugin to alter the
-container and thus also add compiler passes there.
+container and thus also add compiler passes and other things there.
 
 
 ### Contao Manager Plugin to the rescue
 
 Make sure your plugin implements the `ConfigPluginInterface` and implement the
 `registerContainerConfiguration` method (see [Plugin documentation](/framework/manager-plugin#the-configplugininterface)).
-Now the provided loader allows accessing the container and adding your compiler pass:
+Now the provided loader allows accessing the container. 
+
+See this example on how to add a custom compiler pass:
 
 ```php
 // src/ContaoManager/Plugin.php

--- a/docs/dev/guides/modify-container-at-compile-time.md
+++ b/docs/dev/guides/modify-container-at-compile-time.md
@@ -1,12 +1,12 @@
 ---
-title: "Modifying the Container at Compile Time"
+title: "Modify the Container at Compile Time"
 description: "How to make changes to the container at compile time in the Contao Managed Edition."
 aliases:
   - /guides/modify-container-at-compile-time/
 ---
 
 
-## Modifying the Container at Compile Time
+## Modify the Container at Compile Time
 
 In a regular Symfony application or bundle a compiler pass for instance can be added
 by calling`$container->addCompilerPass()` inside the `build()` function of the application's

--- a/docs/dev/guides/modify-container-at-compile-time.md
+++ b/docs/dev/guides/modify-container-at-compile-time.md
@@ -1,5 +1,5 @@
 ---
-title: "Modifying the Container at Compile Time (ME)"
+title: "Modifying the Container at Compile Time"
 description: "How to make changes to the container at compile time in the Contao Managed Edition."
 aliases:
   - /guides/modify-container-at-compile-time/


### PR DESCRIPTION
TLDR; 

The [Symfony documentation for adding compiler passes](https://symfony.com/doc/4.4/service_container/compiler_passes.html) doesn't help in a bundle less managed edition application without access to the Kernel. But the Manager Plugin can be used instead.