### PR TITLE
Add annotation reference to fragment controller documentation

### DIFF
--- a/docs/dev/framework/caching.md
+++ b/docs/dev/framework/caching.md
@@ -1,6 +1,8 @@
 ---
 title: "Caching"
 description: "HTTP caching in Contao"
+alias:
+  - /framework/caching/
 ---
 
 
@@ -215,8 +217,27 @@ Moreover, you don't have to register to all the different callbacks such as `ons
 You can register to the [`oninvalidate_cache_tags` callback][5] and add your own tags.
 
 
+## Fragments and Edge Side Includes
+
+In Contao, content elements and front end modules can be implemented as so called
+_fragment controllers_. These fragments are then rendered with their defined renderer 
+and merged into the main content. Each fragment can also provide its own response
+and thus define whether it can be cached or not. If a fragment returns a response
+with a `Cache-Control: private` header for example, then the page on which the fragment
+is visible cannot be cached. On the other hand, if the fragment can be cached, it
+can provide its own cache tags, as mentioned previously.
+
+Contao brings its own `forward` fragment renderer, which provides the fragment with 
+a full clone of the request (contrary to Symfony's default `inline` renderer). The 
+renderer can also be set to `esi`. In that case, if Symfony detects that it is talking 
+to  a gateway cache that supports ESI (like Symfony's built in reverse proxy, that 
+Contao uses), it generates an ESI include tag. See also [Symfony's documentation][esi] 
+on _Edge Side Includes_.
+
+
 [1]: https://github.com/Toflar/psr6-symfony-http-cache-store
 [2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching
 [3]: https://foshttpcachebundle.readthedocs.io/en/latest/
 [4]: https://symfony.com/doc/current/components/http_kernel.html
-[5]: ../../reference/dca/callbacks/#config-oninvalidate-cache-tags
+[5]: /reference/dca/callbacks/#config-oninvalidate-cache-tags
+[esi]: https://symfony.com/doc/current/http_cache/esi.html

--- a/docs/dev/framework/caching.md
+++ b/docs/dev/framework/caching.md
@@ -228,10 +228,12 @@ is visible cannot be cached. On the other hand, if the fragment can be cached, i
 can provide its own cache tags, as mentioned previously.
 
 Contao brings its own `forward` fragment renderer, which provides the fragment with 
-a full clone of the request (contrary to Symfony's default `inline` renderer). The 
-renderer can also be set to `esi`. In that case, if Symfony detects that it is talking 
-to  a gateway cache that supports ESI (like Symfony's built in reverse proxy, that 
-Contao uses), it generates an ESI include tag. See also [Symfony's documentation][esi] 
+a full clone of the request. This provides the fragment with the full `POST` data
+for example, contrary to Symfony's default `inline` renderer.
+
+The renderer can also be set to `esi`. In that case, if Symfony detects that it 
+is talking to  a gateway cache that supports ESI (like Symfony's built in reverse 
+proxy, that Contao uses), it generates an ESI include tag. See also [Symfony's documentation][esi] 
 on _Edge Side Includes_.
 
 

--- a/docs/dev/framework/content-elements.md
+++ b/docs/dev/framework/content-elements.md
@@ -143,6 +143,47 @@ $GLOBALS['TL_LANG']['CTE']['my_content_element'] = [
 ```
 
 
+## Annotation
+
+{{< version "4.8" >}}
+
+Instead of tagging the content element controller service via the service configuration,
+the service tag can also be configured through annotations, as already used in the 
+code example above. The annotation can be used on the class of the content element 
+or on the method that will deliver the response.
+
+The following example sets the type of the content element to `my_example`, puts 
+it in the `media` category, sets the template name to `ce_some_example` and defines
+the renderer to be `inline` (which is the default):
+
+```php
+// src/Controller/ContentElement/ExampleElement.php
+namespace App\Controller\ContentElement;
+
+use Contao\CoreBundle\Controller\ContentElement\AbstractContentElementController;
+use Contao\CoreBundle\ServiceAnnotation\ContentElement;
+use Contao\ContentModel;
+use Contao\Template;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @ContentElement("my_example",
+ *   category="media", 
+ *   template="ce_some_example",
+ *   renderer="inline"
+ * )
+ */
+class ExampleElement extends AbstractContentElementController
+{
+    protected function getResponse(Template $template, ContentModel $model, Request $request): ?Response
+    {
+        return $template->getResponse();
+    }
+}
+```
+
+
 ## Read more
 
 * [Manipulate and create palettes][palettes]

--- a/docs/dev/framework/content-elements.md
+++ b/docs/dev/framework/content-elements.md
@@ -149,8 +149,9 @@ $GLOBALS['TL_LANG']['CTE']['my_content_element'] = [
 
 Instead of tagging the content element controller service via the service configuration,
 the service tag can also be configured through annotations, as already used in the 
-code example above. The annotation can be used on the class of the content element 
-or on the method that will deliver the response.
+code example above. The annotation can be used on the class of the content element,
+if the class is invokable (has an `__invoke` method) or extends from the `AbstractFragmentController`.
+Otherwise the annotation can be used on the method that will deliver the response.
 
 The following example sets the type of the content element to `my_example`, puts 
 it in the `media` category, sets the template name to `ce_some_example` and defines

--- a/docs/dev/framework/content-elements.md
+++ b/docs/dev/framework/content-elements.md
@@ -6,10 +6,21 @@ aliases:
     - /framework/content-elements/
 ---
 
+{{% notice note %}}
+This covers the documentation on how to create content elements in Contao **4.6**
+and up. In previous Contao version, Content elements must extend from `\Contao\ContentElement`
+and then be registered via the `$GLOBAL['TL_CTE']` array.
+{{% /notice %}}
 
 In Contao, Content Elements are the fundamental content blocks. In its simplest
 form it is a fragment controller which receives data in form of a content model
 and returns a response.
+
+These elements are implemented as so called _fragment controllers_ which  Contao 
+then renders into the main content, using their defined renderer. See the [caching documentation][fragments] 
+for more information.
+
+Creating a content element is very similar to creating [front end modules][modules].
 
 
 ## Definition
@@ -42,7 +53,7 @@ To create a new content element, the following things must be defined and implem
 
 ## Example
 
-Usually a content element is based on a specific [palette][2] in the `tl_content`
+Usually a content element is based on a specific [palette][palettes] in the `tl_content`
 DCA configuration.
 
 ```php
@@ -109,7 +120,7 @@ options are available.
 | name     | `string`  | Must be `contao.content_element`.                                                                   |
 | category | `string`  | Defines in which option group this content element will be placed in the content element selector.  |
 | type     | `string`  | _Optional:_ The *type* mentioned in [Type]({{< ref "#type" >}}) can be customized.                  |
-| renderer | `string`  | _Optional:_ The renderer can be changed to `esi`. Defaults to `inline`.                             |
+| renderer | `string`  | _Optional:_ The renderer can be changed to `inline` or `esi`. Defaults to `forward`.                |
 | method   | `integer` | _Optional:_  Which method should be invoked on the controller.                                      |
 
 A more complex example of a Content Element could look like this.
@@ -155,7 +166,7 @@ Otherwise the annotation can be used on the method that will deliver the respons
 
 The following example sets the type of the content element to `my_example`, puts 
 it in the `media` category, sets the template name to `ce_some_example` and defines
-the renderer to be `inline` (which is the default):
+the renderer to be `forward` (which is the default):
 
 ```php
 // src/Controller/ContentElement/ExampleElement.php
@@ -172,7 +183,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @ContentElement("my_example",
  *   category="media", 
  *   template="ce_some_example",
- *   renderer="inline"
+ *   renderer="forward"
  * )
  */
 class ExampleElement extends AbstractContentElementController
@@ -192,6 +203,8 @@ class ExampleElement extends AbstractContentElementController
 * [Customize Caching][caching]
 
 
-[palettes]: ../../reference/dca/palettes
-[templates]: ../templates
-[caching]: ../caching
+[palettes]: /reference/dca/palettes/
+[templates]: /templates/
+[caching]: /caching/
+[modules]: /framework/front-end-modules/
+[fragments]: /framework/caching/#fragments-and-edge-side-includes

--- a/docs/dev/framework/front-end-modules.md
+++ b/docs/dev/framework/front-end-modules.md
@@ -166,8 +166,9 @@ $GLOBALS['TL_LANG']['FMD']['my_frontend_module'] = [
 
 Instead of tagging the front end module controller service via the service configuration,
 the service tag can also be configured through annotations, as already used in the 
-code example above. The annotation can be used on the class of the module or on
-the method that will deliver the response.
+code example above. The annotation can be used on the class of the content element,
+if the class is invokable (has an `__invoke` method) or extends from the `AbstractFragmentController`.
+Otherwise the annotation can be used on the method that will deliver the response.
 
 The following example sets the type of the module to `my_example`, puts it in the
 `miscellaneous` category, sets the template name to `mod_some_example` and defines

--- a/docs/dev/framework/front-end-modules.md
+++ b/docs/dev/framework/front-end-modules.md
@@ -93,7 +93,7 @@ class MyFrontendModuleController extends AbstractFrontendModuleController
 }
 ```
 
-In this example the service tag was implemented via annotations. The controller itself
+In this example the service tag was implemented via [annotations](#annotation). The controller itself
 processes the request and checks, if it was a POST request. In that case, the
 redirect page is loaded via Contao's model functionality and a `RedirectResponseException`
 is thrown to redirect to that page.
@@ -157,6 +157,47 @@ $GLOBALS['TL_LANG']['FMD']['my_frontend_module'] = [
     'My front end module', 
     'A front end module for testing purposes.',
 ];
+```
+
+
+## Annotation
+
+{{< version "4.8" >}}
+
+Instead of tagging the front end module controller service via the service configuration,
+the service tag can also be configured through annotations, as already used in the 
+code example above. The annotation can be used on the class of the module or on
+the method that will deliver the response.
+
+The following example sets the type of the module to `my_example`, puts it in the
+`miscellaneous` category, sets the template name to `mod_some_example` and defines
+the renderer to be `inline` (which is the default):
+
+```php
+// src/Controller/FrontendModule/ExampleModule.php
+namespace App\Controller\FrontendModule;
+
+use Contao\CoreBundle\Controller\FrontendModule\AbstractFrontendModuleController;
+use Contao\CoreBundle\ServiceAnnotation\FrontendModule;
+use Contao\ModuleModel;
+use Contao\Template;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @FrontendModule("my_example",
+ *   category="miscellaneous", 
+ *   template="mod_some_example",
+ *   renderer="inline"
+ * )
+ */
+class ExampleModule extends AbstractFrontendModuleController
+{
+    protected function getResponse(Template $template, ModuleModel $model, Request $request): ?Response
+    {
+        return $template->getResponse();
+    }
+}
 ```
 
 

--- a/docs/dev/framework/front-end-modules.md
+++ b/docs/dev/framework/front-end-modules.md
@@ -4,12 +4,22 @@ description: "Complex functionalities within your web pages."
 aliases:
     - /documentation/front-end-modules/
     - /framework/content-modules/
+    - /framework/front-end-modules/
 ---
 
+{{% notice note %}}
+This covers the documentation on how to create front end modules in Contao **4.6**
+and up. In previous Contao version, front end modules must extend from `\Contao\Module`
+and then be registered via the `$GLOBAL['FE_MOD']` array.
+{{% /notice %}}
 
 Front end modules in Contao are used for more complex functionality, which are typically
 used on more than one page or even in page layouts. They are used to generate dynamic 
 content, like news lists, displaying the detailed content of news or navigation items.
+
+These modules are implemented as so called _fragment controllers_ which Contao then
+renders into the main content, using their defined renderer. See the [caching documentation][fragments]
+for more information.
 
 Creating a front end module is very similar to creating [content elements][1].
 
@@ -126,7 +136,7 @@ options are available.
 | name     | `string` | Must be `contao.frontend_module`.                                                                   |
 | category | `string` | Defines in which option group this front end module will be placed in the module type selector.     |
 | type     | `string` | _Optional:_ The *type* mentioned in [Type]({{< ref "#type" >}}) can be customized.                  |
-| renderer | `string` | _Optional:_ The renderer can be changed to `esi`. Defaults to `inline`.                             |
+| renderer | `string` | _Optional:_ The renderer can be changed to `inline` or `esi`. Defaults to `forward`.                |
 | method   | `string` | _Optional:_  Which method should be invoked on the controller.                                      |
 
 A more complex example of a front end module could look like this.
@@ -172,7 +182,7 @@ Otherwise the annotation can be used on the method that will deliver the respons
 
 The following example sets the type of the module to `my_example`, puts it in the
 `miscellaneous` category, sets the template name to `mod_some_example` and defines
-the renderer to be `inline` (which is the default):
+the renderer to be `forward` (which is the default):
 
 ```php
 // src/Controller/FrontendModule/ExampleModule.php
@@ -189,7 +199,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @FrontendModule("my_example",
  *   category="miscellaneous", 
  *   template="mod_some_example",
- *   renderer="inline"
+ *   renderer="forward"
  * )
  */
 class ExampleModule extends AbstractFrontendModuleController
@@ -211,7 +221,8 @@ class ExampleModule extends AbstractFrontendModuleController
 
 
 [1]: /framework/content-elements/
-[2]: ../../reference/dca/reference
-[3]: ../../reference/dca/palettes
-[4]: ../templates
-[5]: ../caching
+[2]: /reference/dca/reference/
+[3]: /reference/dca/palettes/
+[4]: /templates/
+[5]: /caching/
+[fragments]: /framework/caching/#fragments-and-edge-side-includes


### PR DESCRIPTION
Annotations were only mentioned as a side note so far. This adds a more complete reference to those articles.