### PR TITLE
Änderung Ordner-URL

### DIFF
--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -66,7 +66,7 @@ angezeigt werden dürfen.
 
 **Ordner-URLs verwenden:** Hier kannst du Ordnerstrukturen in Seitenaliasen aktivieren. Damit werden die in der
 Seitenhierarchie vorhandenen Aliase in den Alias mit übernommen z. B. die Seite "Download" im Seitenpfad 
-"Docs > Install" zu `docs/install/download.html` anstatt nur `download.html`.
+»Docs > Install« zu `docs/install/download.html` anstatt nur `download.html`.
 
 **Leere URLs nicht umleiten:** Bei einer leeren URL die Webseite anzeigen anstatt auf den Startpunkt der Sprache 
 weiterzuleiten _(nicht empfohlen)_.

--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -65,7 +65,7 @@ angezeigt werden dürfen.
 ### Frontend-Einstellungen
 
 **Ordner-URLs verwenden:** Hier kannst du Ordnerstrukturen in Seitenaliasen aktivieren. Damit werden die in der
-Seitenhierarchie vorhandenen Aliase in den Alias mit übernommen z. B. die Seite "Download" im Seitenpfad 
+Seitenhierarchie vorhandenen Aliase in den Alias mit übernommen z. B. die Seite »Download« im Seitenpfad 
 »Docs > Install« zu `docs/install/download.html` anstatt nur `download.html`.
 
 **Leere URLs nicht umleiten:** Bei einer leeren URL die Webseite anzeigen anstatt auf den Startpunkt der Sprache 

--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -64,8 +64,9 @@ angezeigt werden dürfen.
 
 ### Frontend-Einstellungen
 
-**Ordner-URLs verwenden:** Hier kannst du Ordnerstrukturen in Seitenaliasen aktivieren (z. B. 
-`docs/install/download.html` anstatt `docs-install-download.html`).
+**Ordner-URLs verwenden:** Hier kannst du Ordnerstrukturen in Seitenaliasen aktivieren. Damit werden die in der
+Seitenhierarchie vorhandenen Aliase in den Alias mit übernommen z. B. die Seite "Download" im Seitenpfad 
+"Docs > Install" zu `docs/install/download.html` anstatt nur `download.html`.
 
 **Leere URLs nicht umleiten:** Bei einer leeren URL die Webseite anzeigen anstatt auf den Startpunkt der Sprache 
 weiterzuleiten _(nicht empfohlen)_.


### PR DESCRIPTION
Wenn die Ordner-URL nicht gesetzt ist, wird im Alias die Hierarchie nicht beachtet - siehe z. B. https://demo.contao.org/contao?do=page&act=edit&id=51&rt=oXhDLe3yviXcAztv538re1Qtqywg1_YxBETTX2wD4UU&ref=ZUgj-I2c - und der Alias allein aus dem Seitentitel erstellt.