### PR TITLE
Make hook URLs camel case

### DIFF
--- a/docs/dev/reference/hooks/activateAccount.md
+++ b/docs/dev/reference/hooks/activateAccount.md
@@ -2,6 +2,9 @@
 title: "activateAccount"
 description: "activateAccount hook"
 tags: ["hook-module", "hook-member"]
+aliases:
+    - /reference/hooks/activateAccount/
+    - /reference/hooks/activateaccount/
 ---
 
 

--- a/docs/dev/reference/hooks/activateRecipient.md
+++ b/docs/dev/reference/hooks/activateRecipient.md
@@ -2,6 +2,9 @@
 title: "activateRecipient"
 description: "activateRecipient hook"
 tags: ["hook-newsletter"]
+aliases:
+    - /reference/hooks/activateRecipient/
+    - /reference/hooks/activaterecipient/
 ---
 
 

--- a/docs/dev/reference/hooks/addComment.md
+++ b/docs/dev/reference/hooks/addComment.md
@@ -2,6 +2,9 @@
 title: "addComment"
 description: "addComment hook"
 tags: ["hook-comment"]
+aliases:
+    - /reference/hooks/addComment/
+    - /reference/hooks/addcomment/
 ---
 
 

--- a/docs/dev/reference/hooks/addCustomRegexp.md
+++ b/docs/dev/reference/hooks/addCustomRegexp.md
@@ -2,6 +2,9 @@
 title: "addCustomRegexp"
 description: "addCustomRegexp hook"
 tags: ["hook-custom", "hook-widget"]
+aliases:
+    - /reference/hooks/addCustomRegexp/
+    - /reference/hooks/addcustomregexp/
 ---
 
 

--- a/docs/dev/reference/hooks/addLogEntry.md
+++ b/docs/dev/reference/hooks/addLogEntry.md
@@ -2,6 +2,9 @@
 title: "addLogEntry"
 description: "addLogEntry hook"
 tags: ["hook-backend"]
+aliases:
+    - /reference/hooks/addLogEntry/
+    - /reference/hooks/addlogentry/
 ---
 
 

--- a/docs/dev/reference/hooks/checkCredentials.md
+++ b/docs/dev/reference/hooks/checkCredentials.md
@@ -2,6 +2,9 @@
 title: "checkCredentials"
 description: "checkCredentials hook"
 tags: ["hook-module", "hook-member"]
+aliases:
+    - /reference/hooks/checkCredentials/
+    - /reference/hooks/checkcredentials/
 ---
 
 

--- a/docs/dev/reference/hooks/closeAccount.md
+++ b/docs/dev/reference/hooks/closeAccount.md
@@ -2,6 +2,9 @@
 title: "closeAccount"
 description: "closeAccount hook"
 tags: ["hook-module", "hook-member"]
+aliases:
+    - /reference/hooks/closeAccount/
+    - /reference/hooks/closeaccount/
 ---
 
 

--- a/docs/dev/reference/hooks/colorizeLogEntries.md
+++ b/docs/dev/reference/hooks/colorizeLogEntries.md
@@ -2,6 +2,9 @@
 title: "colorizeLogEntries"
 description: "colorizeLogEntries hook"
 tags: ["hook-backend"]
+aliases:
+    - /reference/hooks/colorizeLogEntries/
+    - /reference/hooks/colorizelogentries/
 ---
 
 

--- a/docs/dev/reference/hooks/compareThemeFiles.md
+++ b/docs/dev/reference/hooks/compareThemeFiles.md
@@ -2,6 +2,9 @@
 title: "compareThemeFiles"
 description: "compareThemeFiles hook"
 tags: ["hook-theme"]
+aliases:
+    - /reference/hooks/compareThemeFiles/
+    - /reference/hooks/comparethemefiles/
 ---
 
 

--- a/docs/dev/reference/hooks/compileArticle.md
+++ b/docs/dev/reference/hooks/compileArticle.md
@@ -2,6 +2,9 @@
 title: "compileArticle"
 description: "compileArticle hook"
 tags: ["hook-module", "hook-template", "hook-article"]
+aliases:
+    - /reference/hooks/compileArticle/
+    - /reference/hooks/compilearticle/
 ---
 
 

--- a/docs/dev/reference/hooks/compileDefinition.md
+++ b/docs/dev/reference/hooks/compileDefinition.md
@@ -2,6 +2,9 @@
 title: "compileDefinition"
 description: "compileDefinition hook"
 tags: ["hook-stylesheet"]
+aliases:
+    - /reference/hooks/compileDefinition/
+    - /reference/hooks/compiledefinition/
 ---
 
 

--- a/docs/dev/reference/hooks/compileFormFields.md
+++ b/docs/dev/reference/hooks/compileFormFields.md
@@ -2,6 +2,9 @@
 title: "compileFormFields"
 description: "compileFormFields hook"
 tags: ["hook-form"]
+aliases:
+    - /reference/hooks/compileFormFields/
+    - /reference/hooks/compileformfields/
 ---
 
 

--- a/docs/dev/reference/hooks/createDefinition.md
+++ b/docs/dev/reference/hooks/createDefinition.md
@@ -2,6 +2,9 @@
 title: "createDefinition"
 description: "createDefinition hook"
 tags: ["hook-stylesheet"]
+aliases:
+    - /reference/hooks/createDefinition/
+    - /reference/hooks/createdefinition/
 ---
 
 

--- a/docs/dev/reference/hooks/createNewUser.md
+++ b/docs/dev/reference/hooks/createNewUser.md
@@ -2,6 +2,9 @@
 title: "createNewUser"
 description: "createNewUser hook"
 tags: ["hook-module", "hook-member"]
+aliases:
+    - /reference/hooks/createNewUser/
+    - /reference/hooks/createnewuser/
 ---
 
 

--- a/docs/dev/reference/hooks/customizeSearch.md
+++ b/docs/dev/reference/hooks/customizeSearch.md
@@ -2,6 +2,9 @@
 title: "customizeSearch"
 description: "customizeSearch hook"
 tags: ["hook-module", "hook-search"]
+aliases:
+    - /reference/hooks/customizeSearch/
+    - /reference/hooks/customizesearch/
 ---
 
 

--- a/docs/dev/reference/hooks/executePostActions.md
+++ b/docs/dev/reference/hooks/executePostActions.md
@@ -2,6 +2,9 @@
 title: "executePostActions"
 description: "executePostActions hook"
 tags: ["hook-dca"]
+aliases:
+    - /reference/hooks/customizeSearch/
+    - /reference/hooks/customizesearch/
 ---
 
 

--- a/docs/dev/reference/hooks/executePreActions.md
+++ b/docs/dev/reference/hooks/executePreActions.md
@@ -2,6 +2,9 @@
 title: "executePreActions"
 description: "executePreActions hook"
 tags: ["hook-dca"]
+aliases:
+    - /reference/hooks/executePreActions/
+    - /reference/hooks/executepreactions/
 ---
 
 

--- a/docs/dev/reference/hooks/executeResize.md
+++ b/docs/dev/reference/hooks/executeResize.md
@@ -2,6 +2,9 @@
 title: "executeResize"
 description: "executeResize hook"
 tags: ["hook-image"]
+aliases:
+    - /reference/hooks/executeResize/
+    - /reference/hooks/executeresize/
 ---
 
 

--- a/docs/dev/reference/hooks/exportTheme.md
+++ b/docs/dev/reference/hooks/exportTheme.md
@@ -2,6 +2,9 @@
 title: "exportTheme"
 description: "exportTheme hook"
 tags: ["hook-theme"]
+aliases:
+    - /reference/hooks/exportTheme/
+    - /reference/hooks/exporttheme/
 ---
 
 

--- a/docs/dev/reference/hooks/extractThemeFiles.md
+++ b/docs/dev/reference/hooks/extractThemeFiles.md
@@ -2,6 +2,9 @@
 title: "extractThemeFiles"
 description: "extractThemeFiles hook"
 tags: ["hook-theme"]
+aliases:
+    - /reference/hooks/extractThemeFiles/
+    - /reference/hooks/extractthemefiles/
 ---
 
 

--- a/docs/dev/reference/hooks/generateBreadcrumb.md
+++ b/docs/dev/reference/hooks/generateBreadcrumb.md
@@ -2,6 +2,9 @@
 title: "generateBreadcrumb"
 description: "generateBreadcrumb hook"
 tags: ["hook-module", "hook-navigation"]
+aliases:
+    - /reference/hooks/generateBreadcrumb/
+    - /reference/hooks/generatebreadcrumb/
 ---
 
 

--- a/docs/dev/reference/hooks/generateFrontendUrl.md
+++ b/docs/dev/reference/hooks/generateFrontendUrl.md
@@ -2,6 +2,9 @@
 title: "generateFrontendUrl"
 description: "generateFrontendUrl hook"
 tags: ["hook-controller", "hook-page"]
+aliases:
+    - /reference/hooks/generateFrontendUrl/
+    - /reference/hooks/generatefrontendurl/
 ---
 
 

--- a/docs/dev/reference/hooks/generatePage.md
+++ b/docs/dev/reference/hooks/generatePage.md
@@ -2,6 +2,9 @@
 title: "generatePage"
 description: "generatePage hook"
 tags: ["hook-page"]
+aliases:
+    - /reference/hooks/generatePage/
+    - /reference/hooks/generatepage/
 ---
 
 

--- a/docs/dev/reference/hooks/generateXmlFiles.md
+++ b/docs/dev/reference/hooks/generateXmlFiles.md
@@ -2,6 +2,9 @@
 title: "generateXmlFiles"
 description: "generateXmlFiles hook"
 tags: ["hook-automator"]
+aliases:
+    - /reference/hooks/generateXmlFiles/
+    - /reference/hooks/generatexmlfiles/
 ---
 
 

--- a/docs/dev/reference/hooks/getAllEvents.md
+++ b/docs/dev/reference/hooks/getAllEvents.md
@@ -2,6 +2,9 @@
 title: "getAllEvents"
 description: "getAllEvents hook"
 tags: ["hook-module", "hook-calendar"]
+aliases:
+    - /reference/hooks/getAllEvents/
+    - /reference/hooks/getallevents/
 ---
 
 

--- a/docs/dev/reference/hooks/getArticle.md
+++ b/docs/dev/reference/hooks/getArticle.md
@@ -2,6 +2,9 @@
 title: "getArticle"
 description: "getArticle hook"
 tags: ["hook-controller", "hook-article"]
+aliases:
+    - /reference/hooks/getArticle/
+    - /reference/hooks/getarticle/
 ---
 
 

--- a/docs/dev/reference/hooks/getArticles.md
+++ b/docs/dev/reference/hooks/getArticles.md
@@ -2,6 +2,9 @@
 title: "getArticles"
 description: "getArticles hook"
 tags: ["hook-controller", "hook-article"]
+aliases:
+    - /reference/hooks/getArticles/
+    - /reference/hooks/getarticles/
 ---
 
 

--- a/docs/dev/reference/hooks/getAttributesFromDca.md
+++ b/docs/dev/reference/hooks/getAttributesFromDca.md
@@ -2,6 +2,9 @@
 title: "getAttributesFromDca"
 description: "getAttributesFromDca hook"
 tags: ["hook-widget", "hook-dca", "hook-config"]
+aliases:
+    - /reference/hooks/getAttributesFromDca/
+    - /reference/hooks/getattributesfromdca/
 ---
 
 

--- a/docs/dev/reference/hooks/getCombinedFile.md
+++ b/docs/dev/reference/hooks/getCombinedFile.md
@@ -1,6 +1,9 @@
 ---
 title: "getCombinedFile"
 description: "getCombinedFile hook"
+aliases:
+    - /reference/hooks/getCombinedFile/
+    - /reference/hooks/getcombinedfile/
 ---
 
 

--- a/docs/dev/reference/hooks/getContentElement.md
+++ b/docs/dev/reference/hooks/getContentElement.md
@@ -2,6 +2,9 @@
 title: "getContentElement"
 description: "getContentElement hook"
 tags: ["hook-controller"]
+aliases:
+    - /reference/hooks/getContentElement/
+    - /reference/hooks/getcontentelement/
 ---
 
 

--- a/docs/dev/reference/hooks/getCountries.md
+++ b/docs/dev/reference/hooks/getCountries.md
@@ -2,6 +2,9 @@
 title: "getCountries"
 description: "getCountries hook"
 tags: ["hook-config", "hook-system"]
+aliases:
+    - /reference/hooks/getCountries/
+    - /reference/hooks/getcountries/
 ---
 
 

--- a/docs/dev/reference/hooks/getForm.md
+++ b/docs/dev/reference/hooks/getForm.md
@@ -2,6 +2,9 @@
 title: "getForm"
 description: "getForm hook"
 tags: ["hook-controller", "hook-form"]
+aliases:
+    - /reference/hooks/getForm/
+    - /reference/hooks/getform/
 ---
 
 

--- a/docs/dev/reference/hooks/getFrontendModule.md
+++ b/docs/dev/reference/hooks/getFrontendModule.md
@@ -2,6 +2,9 @@
 title: "getFrontendModule"
 description: "getFrontendModule hook"
 tags: ["hook-controller", "hook-module"]
+aliases:
+    - /reference/hooks/getFrontendModule/
+    - /reference/hooks/getfrontendmodule/
 ---
 
 

--- a/docs/dev/reference/hooks/getImage.md
+++ b/docs/dev/reference/hooks/getImage.md
@@ -2,6 +2,9 @@
 title: "getImage"
 description: "getImage hook"
 tags: ["hook-image"]
+aliases:
+    - /reference/hooks/getImage/
+    - /reference/hooks/getimage/
 ---
 
 

--- a/docs/dev/reference/hooks/getLanguages.md
+++ b/docs/dev/reference/hooks/getLanguages.md
@@ -2,6 +2,9 @@
 title: "getLanguages"
 description: "getLanguages hook"
 tags: ["hook-system"]
+aliases:
+    - /reference/hooks/getLanguages/
+    - /reference/hooks/getlanguages/
 ---
 
 

--- a/docs/dev/reference/hooks/getPageIdFromUrl.md
+++ b/docs/dev/reference/hooks/getPageIdFromUrl.md
@@ -2,6 +2,9 @@
 title: "getPageIdFormUrl"
 description: "getPageIdFormUrl hook"
 tags: ["hook-routing"]
+aliases:
+    - /reference/hooks/getPageIdFormUrl/
+    - /reference/hooks/getpageIdformurl/
 ---
 
 

--- a/docs/dev/reference/hooks/getPageLayout.md
+++ b/docs/dev/reference/hooks/getPageLayout.md
@@ -2,6 +2,9 @@
 title: "getPageLayout"
 description: "getPageLayout hook"
 tags: ["hook-page"]
+aliases:
+    - /reference/hooks/getPageLayout/
+    - /reference/hooks/getpagelayout/
 ---
 
 

--- a/docs/dev/reference/hooks/getPageStatusIcon.md
+++ b/docs/dev/reference/hooks/getPageStatusIcon.md
@@ -2,6 +2,9 @@
 title: "getPageStatusIcon"
 description: "getPageStatusIcon hook"
 tags: ["hook-page", "hook-controller"]
+aliases:
+    - /reference/hooks/getPageStatusIcon/
+    - /reference/hooks/getpagestatusicon/
 ---
 
 

--- a/docs/dev/reference/hooks/getRootPageFromUrl.md
+++ b/docs/dev/reference/hooks/getRootPageFromUrl.md
@@ -2,6 +2,9 @@
 title: "getRootPageFromUrl"
 description: "getRootPageFromUrl hook"
 tags: ["hook-routing"]
+aliases:
+    - /reference/hooks/getRootPageFromUrl/
+    - /reference/hooks/getrootpagefromurl/
 ---
 
 

--- a/docs/dev/reference/hooks/getSearchablePages.md
+++ b/docs/dev/reference/hooks/getSearchablePages.md
@@ -2,6 +2,9 @@
 title: "getSearchablePages"
 description: "getSearchablePages hook"
 tags: ["hook-automator"]
+aliases:
+    - /reference/hooks/getSearchablePages/
+    - /reference/hooks/getsearchablepages/
 ---
 
 

--- a/docs/dev/reference/hooks/getSystemMessages.md
+++ b/docs/dev/reference/hooks/getSystemMessages.md
@@ -2,6 +2,9 @@
 title: "getSystemMessages"
 description: "getSystemMessages hook"
 tags: ["hook-backend"]
+aliases:
+    - /reference/hooks/getSystemMessages/
+    - /reference/hooks/getsystemmessages/
 ---
 
 

--- a/docs/dev/reference/hooks/getUserNavigation.md
+++ b/docs/dev/reference/hooks/getUserNavigation.md
@@ -2,6 +2,9 @@
 title: "getUserNavigation"
 description: "getUserNavigation hook"
 tags: ["hook-backend"]
+aliases:
+    - /reference/hooks/getUserNavigation/
+    - /reference/hooks/getusernavigation/
 ---
 
 

--- a/docs/dev/reference/hooks/importUser.md
+++ b/docs/dev/reference/hooks/importUser.md
@@ -2,6 +2,9 @@
 title: "importUser"
 description: "importUser hook"
 tags: ["hook-member", "hook-user"]
+aliases:
+    - /reference/hooks/importUser/
+    - /reference/hooks/importuser/
 ---
 
 

--- a/docs/dev/reference/hooks/indexPage.md
+++ b/docs/dev/reference/hooks/indexPage.md
@@ -2,6 +2,9 @@
 title: "indexPage"
 description: "indexPage hook"
 tags: ["hook-page"]
+aliases:
+    - /reference/hooks/indexPage/
+    - /reference/hooks/indexpage/
 ---
 
 

--- a/docs/dev/reference/hooks/initializeSystem.md
+++ b/docs/dev/reference/hooks/initializeSystem.md
@@ -2,6 +2,9 @@
 title: "initializeSystem"
 description: "initializeSystem hook"
 tags: ["hook-system"]
+aliases:
+    - /reference/hooks/initializeSystem/
+    - /reference/hooks/initializesystem/
 ---
 
 

--- a/docs/dev/reference/hooks/insertTagFlags.md
+++ b/docs/dev/reference/hooks/insertTagFlags.md
@@ -2,6 +2,9 @@
 title: "insertTagFlags"
 description: "insertTagFlags hook"
 tags: ["hook-custom"]
+aliases:
+    - /reference/hooks/insertTagFlags/
+    - /reference/hooks/inserttagflags/
 ---
 
 

--- a/docs/dev/reference/hooks/isAllowedToEditComment.md
+++ b/docs/dev/reference/hooks/isAllowedToEditComment.md
@@ -2,6 +2,9 @@
 title: "isAllowedToEditComment"
 description: "isAllowedToEditComment hook"
 tags: ["hook-comment", "hook-backend", "hook-dca"]
+aliases:
+    - /reference/hooks/isAllowedToEditComment/
+    - /reference/hooks/isallowedtoeditcomment/
 ---
 
 

--- a/docs/dev/reference/hooks/isVisibleElement.md
+++ b/docs/dev/reference/hooks/isVisibleElement.md
@@ -2,6 +2,9 @@
 title: "isVisibleElement"
 description: "isVisibleElement hook"
 tags: ["hook-controller"]
+aliases:
+    - /reference/hooks/isVisibleElement/
+    - /reference/hooks/isvisibleelement/
 ---
 
 

--- a/docs/dev/reference/hooks/listComments.md
+++ b/docs/dev/reference/hooks/listComments.md
@@ -2,6 +2,9 @@
 title: "listComments"
 description: "listComments hook"
 tags: ["hook-comment", "hook-backend", "hook-dca"]
+aliases:
+    - /reference/hooks/listComments/
+    - /reference/hooks/listcomments/
 ---
 
 

--- a/docs/dev/reference/hooks/loadDataContainer.md
+++ b/docs/dev/reference/hooks/loadDataContainer.md
@@ -2,6 +2,9 @@
 title: "loadDataContainer"
 description: "loadDataContainer hook"
 tags: ["hook-dca", "hook-system"]
+aliases:
+    - /reference/hooks/loadDataContainer/
+    - /reference/hooks/loaddatacontainer/
 ---
 
 

--- a/docs/dev/reference/hooks/loadFormField.md
+++ b/docs/dev/reference/hooks/loadFormField.md
@@ -2,6 +2,9 @@
 title: "loadFormField"
 description: "loadFormField hook"
 tags: ["hook-form"]
+aliases:
+    - /reference/hooks/loadFormField/
+    - /reference/hooks/loadformfield/
 ---
 
 

--- a/docs/dev/reference/hooks/loadLanguageFile.md
+++ b/docs/dev/reference/hooks/loadLanguageFile.md
@@ -2,6 +2,9 @@
 title: "loadLanguageFile"
 description: "loadLanguageFile hook"
 tags: ["hook-system"]
+aliases:
+    - /reference/hooks/loadLanguageFile/
+    - /reference/hooks/loadlanguagefile/
 ---
 
 

--- a/docs/dev/reference/hooks/loadPageDetails.md
+++ b/docs/dev/reference/hooks/loadPageDetails.md
@@ -2,6 +2,9 @@
 title: "loadPageDetails"
 description: "loadPageDetails hook"
 tags: ["hook-page"]
+aliases:
+    - /reference/hooks/loadPageDetails/
+    - /reference/hooks/loadpagedetails/
 ---
 
 

--- a/docs/dev/reference/hooks/modifyFrontendPage.md
+++ b/docs/dev/reference/hooks/modifyFrontendPage.md
@@ -2,6 +2,9 @@
 title: "modifyFrontendPage"
 description: "modifyFrontendPage hook"
 tags: ["hook-template"]
+aliases:
+    - /reference/hooks/modifyFrontendPage/
+    - /reference/hooks/modifyfrontendpage/
 ---
 
 

--- a/docs/dev/reference/hooks/newsListCountItems.md
+++ b/docs/dev/reference/hooks/newsListCountItems.md
@@ -2,6 +2,9 @@
 title: "newsListCountItems"
 description: "newsListCountItems hook"
 tags: ["hook-news", "hook-module"]
+aliases:
+    - /reference/hooks/newsListCountItems/
+    - /reference/hooks/newslistcountitems/
 ---
 
 

--- a/docs/dev/reference/hooks/newsListFetchItems.md
+++ b/docs/dev/reference/hooks/newsListFetchItems.md
@@ -2,6 +2,9 @@
 title: "newsListFetchItems"
 description: "newsListFetchItems hook"
 tags: ["hook-news", "hook-module"]
+aliases:
+    - /reference/hooks/newsListFetchItems/
+    - /reference/hooks/newslistfetchitems/
 ---
 
 

--- a/docs/dev/reference/hooks/outputBackendTemplate.md
+++ b/docs/dev/reference/hooks/outputBackendTemplate.md
@@ -2,6 +2,9 @@
 title: "outputBackendTemplate"
 description: "outputBackendTemplate hook"
 tags: ["hook-template"]
+aliases:
+    - /reference/hooks/outputBackendTemplate/
+    - /reference/hooks/outputbackendtemplate/
 ---
 
 

--- a/docs/dev/reference/hooks/outputFrontendTemplate.md
+++ b/docs/dev/reference/hooks/outputFrontendTemplate.md
@@ -2,6 +2,9 @@
 title: "outputFrontendTemplate"
 description: "outputFrontendTemplate hook"
 tags: ["hook-template"]
+aliases:
+    - /reference/hooks/outputFrontendTemplate/
+    - /reference/hooks/outputfrontendtemplate/
 ---
 
 

--- a/docs/dev/reference/hooks/parseArticles.md
+++ b/docs/dev/reference/hooks/parseArticles.md
@@ -3,7 +3,8 @@ title: "parseArticles"
 description: "parseArticles hook"
 tags: ["hook-news", "hook-template", "hook-module"]
 aliases:
-  - /reference/hooks/parsearticles/
+    - /reference/hooks/parseArticles/
+    - /reference/hooks/parsearticles/
 ---
 
 

--- a/docs/dev/reference/hooks/parseBackendTemplate.md
+++ b/docs/dev/reference/hooks/parseBackendTemplate.md
@@ -2,6 +2,9 @@
 title: "parseBackendTemplate"
 description: "parseBackendTemplate hook"
 tags: ["hook-template"]
+aliases:
+    - /reference/hooks/parseBackendTemplate/
+    - /reference/hooks/parsebackendtemplate/
 ---
 
 

--- a/docs/dev/reference/hooks/parseDate.md
+++ b/docs/dev/reference/hooks/parseDate.md
@@ -1,6 +1,9 @@
 ---
 title: "parseDate"
 description: "parseDate hook"
+aliases:
+    - /reference/hooks/parseDate/
+    - /reference/hooks/parsedate/
 ---
 
 

--- a/docs/dev/reference/hooks/parseFrontendTemplate.md
+++ b/docs/dev/reference/hooks/parseFrontendTemplate.md
@@ -2,6 +2,9 @@
 title: "parseFrontendTemplate"
 description: "parseFrontendTemplate hook"
 tags: ["hook-template"]
+aliases:
+    - /reference/hooks/parseFrontendTemplate/
+    - /reference/hooks/parsefrontendtemplate/
 ---
 
 

--- a/docs/dev/reference/hooks/parseTemplate.md
+++ b/docs/dev/reference/hooks/parseTemplate.md
@@ -2,6 +2,9 @@
 title: "parseTemplate"
 description: "parseTemplate hook"
 tags: ["hook-template"]
+aliases:
+    - /reference/hooks/parseTemplate/
+    - /reference/hooks/parsetemplate/
 ---
 
 

--- a/docs/dev/reference/hooks/parseWidget.md
+++ b/docs/dev/reference/hooks/parseWidget.md
@@ -2,6 +2,9 @@
 title: "parseWidget"
 description: "parseWidget hook"
 tags: ["hook-widget"]
+aliases:
+    - /reference/hooks/parseWidget/
+    - /reference/hooks/parsewidget/
 ---
 
 

--- a/docs/dev/reference/hooks/postAuthenticate.md
+++ b/docs/dev/reference/hooks/postAuthenticate.md
@@ -2,6 +2,9 @@
 title: "postAuthenticate"
 description: "postAuthenticate hook"
 tags: ["hook-user", "hook-member"]
+aliases:
+    - /reference/hooks/postAuthenticate/
+    - /reference/hooks/postauthenticate/
 ---
 
 

--- a/docs/dev/reference/hooks/postDownload.md
+++ b/docs/dev/reference/hooks/postDownload.md
@@ -2,6 +2,9 @@
 title: "postDownload"
 description: "postDownload hook"
 tags: ["hook-controller"]
+aliases:
+    - /reference/hooks/postDownload/
+    - /reference/hooks/postdownload/
 ---
 
 

--- a/docs/dev/reference/hooks/postLogin.md
+++ b/docs/dev/reference/hooks/postLogin.md
@@ -2,6 +2,9 @@
 title: "postLogin"
 description: "postLogin hook"
 tags: ["hook-user", "hook-member"]
+aliases:
+    - /reference/hooks/postLogin/
+    - /reference/hooks/postlogin/
 ---
 
 

--- a/docs/dev/reference/hooks/postLogout.md
+++ b/docs/dev/reference/hooks/postLogout.md
@@ -2,6 +2,9 @@
 title: "postLogout"
 description: "postLogout hook"
 tags: ["hook-user", "hook-member"]
+aliases:
+    - /reference/hooks/postLogout/
+    - /reference/hooks/postlogout/
 ---
 
 

--- a/docs/dev/reference/hooks/postUpload.md
+++ b/docs/dev/reference/hooks/postUpload.md
@@ -2,6 +2,9 @@
 title: "postUpload"
 description: "postUpload hook"
 tags: ["hook-backend"]
+aliases:
+    - /reference/hooks/postUpload/
+    - /reference/hooks/postupload/
 ---
 
 

--- a/docs/dev/reference/hooks/prepareFormData.md
+++ b/docs/dev/reference/hooks/prepareFormData.md
@@ -2,6 +2,9 @@
 title: "prepareFormData"
 description: "prepareFormData hook"
 tags: ["hook-form"]
+aliases:
+    - /reference/hooks/prepareFormData/
+    - /reference/hooks/prepareformdata/
 ---
 
 

--- a/docs/dev/reference/hooks/printArticleAsPdf.md
+++ b/docs/dev/reference/hooks/printArticleAsPdf.md
@@ -2,6 +2,9 @@
 title: "printArticleAsPdf"
 description: "printArticleAsPdf hook"
 tags: ["hook-module", "hook-article"]
+aliases:
+    - /reference/hooks/printArticleAsPdf/
+    - /reference/hooks/printarticleaspdf/
 ---
 
 

--- a/docs/dev/reference/hooks/processFormData.md
+++ b/docs/dev/reference/hooks/processFormData.md
@@ -2,6 +2,9 @@
 title: "processFormData"
 description: "processFormData hook"
 tags: ["hook-form"]
+aliases:
+    - /reference/hooks/processFormData/
+    - /reference/hooks/processformdata/
 ---
 
 

--- a/docs/dev/reference/hooks/removeOldFeeds.md
+++ b/docs/dev/reference/hooks/removeOldFeeds.md
@@ -2,6 +2,9 @@
 title: "removeOldFeeds"
 description: "removeOldFeeds hook"
 tags: ["hook-automator"]
+aliases:
+    - /reference/hooks/removeOldFeeds/
+    - /reference/hooks/removeoldfeeds/
 ---
 
 

--- a/docs/dev/reference/hooks/removeRecipient.md
+++ b/docs/dev/reference/hooks/removeRecipient.md
@@ -2,6 +2,9 @@
 title: "removeRecipient"
 description: "removeRecipient hook"
 tags: ["hook-newsletter", "hook-module"]
+aliases:
+    - /reference/hooks/removeRecipient/
+    - /reference/hooks/removerecipient/
 ---
 
 

--- a/docs/dev/reference/hooks/replaceDynamicScriptTags.md
+++ b/docs/dev/reference/hooks/replaceDynamicScriptTags.md
@@ -2,6 +2,9 @@
 title: "replaceDynamicScriptTags"
 description: "replaceDynamicScriptTags hook"
 tags: ["hook-controller"]
+aliases:
+    - /reference/hooks/replaceDynamicScriptTags/
+    - /reference/hooks/replacedynamicscripttags/
 ---
 
 

--- a/docs/dev/reference/hooks/replaceInsertTags.md
+++ b/docs/dev/reference/hooks/replaceInsertTags.md
@@ -2,6 +2,9 @@
 title: "replaceInsertTags"
 description: "replaceInsertTags hook"
 tags: ["hook-custom"]
+aliases:
+    - /reference/hooks/replaceInsertTags/
+    - /reference/hooks/replaceinserttags/
 ---
 
 

--- a/docs/dev/reference/hooks/reviseTable.md
+++ b/docs/dev/reference/hooks/reviseTable.md
@@ -2,6 +2,9 @@
 title: "reviseTable"
 description: "reviseTable hook"
 tags: ["hook-dca", "hook-backend"]
+aliases:
+    - /reference/hooks/reviseTable/
+    - /reference/hooks/revisetable/
 ---
 
 

--- a/docs/dev/reference/hooks/sendNewsletter.md
+++ b/docs/dev/reference/hooks/sendNewsletter.md
@@ -2,6 +2,9 @@
 title: "sendNewsletter"
 description: "sendNewsletter hook"
 tags: ["hook-newsletter"]
+aliases:
+    - /reference/hooks/sendNewsletter/
+    - /reference/hooks/sendnewsletter/
 ---
 
 

--- a/docs/dev/reference/hooks/setCookie.md
+++ b/docs/dev/reference/hooks/setCookie.md
@@ -2,6 +2,9 @@
 title: "setCookie"
 description: "setCookie hook"
 tags: ["hook-system"]
+aliases:
+    - /reference/hooks/setCookie/
+    - /reference/hooks/setcookie/
 ---
 
 

--- a/docs/dev/reference/hooks/setNewPassword.md
+++ b/docs/dev/reference/hooks/setNewPassword.md
@@ -2,6 +2,9 @@
 title: "setNewPassword"
 description: "setNewPassword hook"
 tags: ["hook-member", "hook-module", "hook-backend"]
+aliases:
+    - /reference/hooks/setNewPassword/
+    - /reference/hooks/setnewpassword/
 ---
 
 

--- a/docs/dev/reference/hooks/sqlCompileCommands.md
+++ b/docs/dev/reference/hooks/sqlCompileCommands.md
@@ -2,6 +2,9 @@
 title: "sqlCompileCommands"
 description: "sqlCompileCommands hook"
 tags: ["hook-installer"]
+aliases:
+    - /reference/hooks/sqlCompileCommands/
+    - /reference/hooks/sqlcompilecommands/
 ---
 
 

--- a/docs/dev/reference/hooks/sqlGetFromDB.md
+++ b/docs/dev/reference/hooks/sqlGetFromDB.md
@@ -2,6 +2,9 @@
 title: "sqlGetFromDB"
 description: "sqlGetFromDB hook"
 tags: ["hook-installer"]
+aliases:
+    - /reference/hooks/sqlGetFromDB/
+    - /reference/hooks/sqlgetfromdb/
 ---
 
 

--- a/docs/dev/reference/hooks/sqlGetFromDca.md
+++ b/docs/dev/reference/hooks/sqlGetFromDca.md
@@ -2,6 +2,9 @@
 title: "sqlGetFromDca"
 description: "sqlGetFromDca hook"
 tags: ["hook-installer"]
+aliases:
+    - /reference/hooks/sqlGetFromDca/
+    - /reference/hooks/sqlgetfromdca/
 ---
 
 

--- a/docs/dev/reference/hooks/sqlGetFromFile.md
+++ b/docs/dev/reference/hooks/sqlGetFromFile.md
@@ -2,6 +2,9 @@
 title: "sqlGetFromFile"
 description: "sqlGetFromFile hook"
 tags: ["hook-installer"]
+aliases:
+    - /reference/hooks/sqlGetFromFile/
+    - /reference/hooks/sqlgetfromfile/
 ---
 
 

--- a/docs/dev/reference/hooks/storeFormData.md
+++ b/docs/dev/reference/hooks/storeFormData.md
@@ -2,6 +2,9 @@
 title: "storeFormData"
 description: "storeFormData hook"
 tags: ["hook-form"]
+aliases:
+    - /reference/hooks/storeFormData/
+    - /reference/hooks/storeformdata/
 ---
 
 

--- a/docs/dev/reference/hooks/updatePersonalData.md
+++ b/docs/dev/reference/hooks/updatePersonalData.md
@@ -2,6 +2,9 @@
 title: "updatePersonalData"
 description: "updatePersonalData hook"
 tags: ["hook-member", "hook-module"]
+aliases:
+    - /reference/hooks/updatePersonalData/
+    - /reference/hooks/updatepersonaldata/
 ---
 
 

--- a/docs/dev/reference/hooks/validateFormField.md
+++ b/docs/dev/reference/hooks/validateFormField.md
@@ -2,6 +2,9 @@
 title: "validateFormField"
 description: "validateFormField hook"
 tags: ["hook-form"]
+aliases:
+    - /reference/hooks/validateFormField/
+    - /reference/hooks/validateformfield/
 ---
 
 

--- a/page/config/_default/config.yml
+++ b/page/config/_default/config.yml
@@ -3,5 +3,6 @@ title: 'Contao Documentation'
 theme: 'hugo-theme-learn'
 canonifyURLs: true
 enableGitInfo: true
+disablePathToLower: true
 outputs:
   home: ['HTML', 'JSON']


### PR DESCRIPTION
This PR changes the Hugo config to allow URLs with upper case letters, to retain the camel case of hooks in their URLs. This also allows then to use the following rewrite rule within the `.htaccess` of the docs:

```
RewriteRule ^books/api/extensions/hooks/([a-zA-Z]*).html$    /dev/reference/hooks/$1/ [R=301,L]
```

This PR also adds appropriate aliases to each hook reference article, so that a redirect from the old lower case URL is made.