### PR TITLE
Update front-end-modules.md

### DIFF
--- a/docs/dev/framework/front-end-modules.md
+++ b/docs/dev/framework/front-end-modules.md
@@ -61,7 +61,7 @@ DCA configuration.
 ```php
 // contao/dca/tl_module.php
 $GLOBALS['TL_DCA']['tl_module']['palettes']['my_frontend_module'] = 
-    '{type_legend},type;{redirect_legend},jumpTo'
+    '{title_legend},name,type;{redirect_legend},jumpTo'
 ;
 ```
 


### PR DESCRIPTION
Changed {type_legend} to {title_legend} because there is no {type_legend} defined in tl_module.php; also add the dca-field name as default