### PR TITLE
Update contao-manager.de.md

### DIFF
--- a/docs/manual/installation/contao-manager.de.md
+++ b/docs/manual/installation/contao-manager.de.md
@@ -60,6 +60,7 @@ des Hosting-Providers auf diesen Unterordner.
 Pro Contao-Installation wird deshalb eine eigene (Sub)Domain benötigt.
 {{% /notice %}}
 
+Lege eine Datenbank für diese Contao Installation an.
 
 ### Download und Installation
 


### PR DESCRIPTION
Es fehlte bisher der Hinweis, dass man vor der Installation eine DB anlegen muss.