### PR TITLE
Remove/change App\Action namespace

### DIFF
--- a/docs/dev/framework/translations.md
+++ b/docs/dev/framework/translations.md
@@ -217,17 +217,17 @@ You can load translations by using the following legacy function:
 Starting with Contao **4.5** you can also use Symfony's Translator service:
 
 ```php
-// src/Action/ExampleAction.php
-namespace App\Action;
+// src/Controller/ExampleController.php
+namespace App\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * @Route("/app/test", name=ExampleAction::class)
+ * @Route("/app/test", name=ExampleController::class)
  */
-class ExampleAction
+class ExampleController
 {
     private $translator;
 

--- a/docs/dev/getting-started/starting-development.md
+++ b/docs/dev/getting-started/starting-development.md
@@ -150,15 +150,15 @@ services:
         resource: ../src
         exclude: ../src/{Entity,Migrations,Resources,Tests}
     
-    App\Action\:
-        resource: ../src/Action
+    App\Controller\:
+        resource: ../src/Controller
         public: true
 ```
 
 ```yaml
 # config/routing.yml
-app.action:
-    resource: ../src/Action
+app.routes:
+    resource: ../src/Controller
     type: annotation
 ```
 
@@ -167,11 +167,6 @@ app.action:
 imports:
     - { resource: services.yml }
 ```
-
-{{% notice note %}}
-The above `services.yml` and `routing.yml` also contain directives for the new ADR 
-(Action Domain Responder) pattern for custom routes as recommended within Symfony.
-{{% /notice %}}
 
 Once this is configured, hooks, callbacks, content elements and front end modules
 for example can be created without having to configure them in separate files by 

--- a/docs/dev/getting-started/starting-development.md
+++ b/docs/dev/getting-started/starting-development.md
@@ -71,6 +71,7 @@ configurations, if present:
 | `config/config_prod.yml` | Configuration for the `prod` environment.                                                     |
 | `config/parameters.yml`  | Parameters like database and SMTP server credentials.<sup>1</sup>                             |
 | `config/routing.yml`     | Definition of application specific routes.                                                    |
+| `config/services.yml`    | Definition of services (Contao **4.9** and up).<sup>2</sup>                                   |
 
 {{% notice note %}}
 <sup>1</sup> Contao still supports the legacy way of defining parameters in a Symfony
@@ -81,8 +82,8 @@ information about the `.env*` files.
 {{% /notice %}}
 
 {{% notice tip %}}
-While Contao does not load a `config/services.yml` automatically, you can still
-import it in your `config/config.yml` via
+<sup>2</sup> While Contao versions prior to **4.9** do not load a `config/services.yml` automatically, 
+you can still import it in your `config/config.yml` via
 
 ```yml
 imports:
@@ -162,11 +163,13 @@ app.routes:
     type: annotation
 ```
 
-```yaml
-# config/config.yml
-imports:
-    - { resource: services.yml }
-```
+{{% notice note %}}
+The above `services.yml` and `routing.yml` also contain configurations for using
+controllers and routes. You will need to create the `src/Controller/` folder, otherwise
+there will be an error during cache warmup. If you do not plan to use any controllers,
+simply remove the `routing.yml` and the the respective service registration from 
+the `services.yml`.
+{{% /notice %}}
 
 Once this is configured, hooks, callbacks, content elements and front end modules
 for example can be created without having to configure them in separate files by 

--- a/docs/dev/guides/namespaces.md
+++ b/docs/dev/guides/namespaces.md
@@ -29,7 +29,6 @@ should also be named with a namespace specific suffix:
 
 | Namespace           | Suffix       | Example                            |
 |:--------------------|--------------|------------------------------------|
-| `App\Action`        | `Action`     | `App\Action\ExampleAction`         |
 | `App\Controller`    | `Controller` | `App\Controller\ExampleController` |
 | `App\Cron`          | `Cron`       | `App\Cron\ExampleCron`             |
 | `App\EventListener` | `Listener`   | `App\EventListener\ExampleListener`|

--- a/docs/dev/reference/services.md
+++ b/docs/dev/reference/services.md
@@ -50,7 +50,7 @@ This service from symfony handles any routing task and can be ued to generate UR
 to routes in your services.
 
 ```php
-use App\Action\ExampleAction;
+use App\Controller\ExampleController;
 use Symfony\Component\Routing\RouterInterface;
 
 class Example
@@ -64,7 +64,7 @@ class Example
 
     public function execute()
     {
-        $url = $this->router->generate(ExampleAction::class, ['id' => 1]);
+        $url = $this->router->generate(ExampleController::class, ['id' => 1]);
     }
 }
 ```


### PR DESCRIPTION
I was under the wrong impression, that the new "Action Domain Responder" pattern within a new `Action` namespace is recommended by Symfony. But as it turns out, it is not (yet) officially recommended and just one way of doing it. The official documentation still uses `App\Controller`, even for ADR routes (see https://symfony.com/doc/current/controller/service.html#invokable-controllers).