### PR TITLE
Change second attribute for getAttributesFromDca

### DIFF
--- a/docs/dev/reference/hooks/getAttributesFromDca.md
+++ b/docs/dev/reference/hooks/getAttributesFromDca.md
@@ -38,7 +38,6 @@ Return the attributes for the widget as an associative array.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Contao\DataContainer;
 use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 class GetAttributesFromDcaListener implements ServiceAnnotationInterface

--- a/docs/dev/reference/hooks/getAttributesFromDca.md
+++ b/docs/dev/reference/hooks/getAttributesFromDca.md
@@ -20,9 +20,9 @@ Note that the DCA object can be optional (`null`).
 
     An array of attributes.
 
-2. *\Contao\DataContainer* `$dc`
+2. `$context`
 
-    The DataContainer object. It can be `null` if no object was passed 
+    A `\Contao\DataContainer` or `\Contao\FrontendModule` object. It can be `null` if no object was passed 
     to the `\Contao\Widget::getAttributesFromDca` method.
 
 
@@ -46,7 +46,7 @@ class GetAttributesFromDcaListener implements ServiceAnnotationInterface
     /**
      * @Hook("getAttributesFromDca")
      */
-    public function onGetAttributesFromDca(array $attributes, DataContainer $dc = null): array
+    public function onGetAttributesFromDca(array $attributes, $context = null): array
     {
         // Modify $attributes here …
 


### PR DESCRIPTION
When using `ModulePersonalData` or `ModuleRegistration`, the second parameter can also be of type `\Contao\FrontendModule`.