### PR TITLE
[RFC] link to developer documentation's section on environment variables

### DIFF
--- a/docs/manual/system/debug-mode.de.md
+++ b/docs/manual/system/debug-mode.de.md
@@ -110,6 +110,11 @@ Diese Datei auf _keinen Fall_ auf den Live Server kopieren! Das würde ein groß
 Sicherheitsrisiko darstellen.
 {{% /notice %}}
 
+{{% notice info %}}
+Auf gleichem Weg können weitere Umgebungsvariablen gesetzt werden. Eine Beschreibung der 
+Variablen findet sich in der [Entwicklerdokumentation](/../dev/reference/config/#environment-variables-for-the-contao-managed-edition).
+{{% /notice %}}
+
 
 #### Backend Einstellung
 

--- a/docs/manual/system/debug-mode.en.md
+++ b/docs/manual/system/debug-mode.en.md
@@ -106,6 +106,10 @@ Do _not_ deploy this file with the enabled debug mode to your live server! It wo
 pose a major security risk.
 {{% /notice %}}
 
+{{% notice info %}}
+Further environment variables can be set this way. A description can be found in the [Developer Documentation](/../dev/reference/config/#environment-variables-for-the-contao-managed-edition).
+{{% /notice %}}
+
 
 #### Back End Setting
 


### PR DESCRIPTION
As suggested by @Toflar in Slack, here is an attempt to include the information provided by https://docs.contao.org/dev/reference/config/#environment-variables-for-the-contao-managed-edition in the User Manual also.

To be solved:

* Does that make sense? If so: what is missing?
* I'm not sure how to properly link from the User Manual to the Developer Documentation.
