### PR TITLE
Require ^4.4 (avoid getting Symfony 5.*)

### DIFF
--- a/docs/dev/getting-started/initial-setup/symfony-application.md
+++ b/docs/dev/getting-started/initial-setup/symfony-application.md
@@ -19,7 +19,7 @@ First of all we need a full stack Symfony application installed. You can
 find further information about this subject in the [Symfony documentation](https://symfony.com/doc/current/setup.html).
 
 ```
-$ composer create-project symfony/website-skeleton contao-example
+$ composer create-project symfony/website-skeleton contao-example ^4.4
 ```
 
 This command creates the directory `contao-example`, containing a bare bone


### PR DESCRIPTION
As Contao 4.x is not compatible with Symfony 5.x yet.