### PR TITLE
Fix composer requirements errors

### DIFF
--- a/docs/dev/getting-started/initial-setup/symfony-application.md
+++ b/docs/dev/getting-started/initial-setup/symfony-application.md
@@ -42,12 +42,14 @@ you can proceed to the second step, the installation of Contao itself.
 ```
 $ composer require \
     doctrine/dbal:^2.8 \
+    doctrine/doctrine-bundle ^1.8 \
     doctrine/migrations:^2.0 \
     contao/conflicts:@dev \
     contao/core-bundle \
     contao/installation-bundle \
     php-http/guzzle6-adapter \
-    toflar/psr6-symfony-http-cache-store
+    toflar/psr6-symfony-http-cache-store \
+    twig/twig ^2.7
 ```
 
 If the installation request fails, try to check for conflicting packages in


### PR DESCRIPTION
Avoid composer `Your requirements could not be resolved to an installable set of packages` errors.