### PR TITLE
Gedankenstrich anstelle Trennstrich

### DIFF
--- a/docs/manual/extensions/cca-merger2.de.md
+++ b/docs/manual/extensions/cca-merger2.de.md
@@ -17,7 +17,7 @@ Bedingungen für die Anzeige können in beliebig komplexen Regeln aufgestellt we
 Beispiele für den vielfältigen Einsatz sind:
 
 * **Zusammenführen von Inhalten** z. B. um sprachspezifische FE-Module nur anzuzeigen, wenn die entsprechende Sprache
-  im Browser aufgerufen wird - damit können mehrere FE-Module zu einem Modul zusammengefasst und im Layout eingesetzt
+  im Browser aufgerufen wird – damit können mehrere FE-Module zu einem Modul zusammengefasst und im Layout eingesetzt
   werden; das spart mehrere sprachspezifische Layouts anlegen zu müssen
 * Module oder Artikel werden nur **angezeigt, wenn bestimmte Bedingungen vorliegen** wie z. B. eine definierte Tiefe im
   Seitenbaum, in der Mobilanzeige, wenn eine bestimmte Sprache im Browser aufgerufen wird.

--- a/docs/manual/installation/contao-manager.de.md
+++ b/docs/manual/installation/contao-manager.de.md
@@ -10,7 +10,7 @@ Die Entwicklung des Contao Managers wird durch die [Contao Association](https://
 
 ## Aufgabe des Managers
 
-Contao wird - wie mittlerweile die meisten PHP-Projekte - mit [Composer](https://getcomposer.org) installiert und
+Contao wird – wie mittlerweile die meisten PHP-Projekte – mit [Composer](https://getcomposer.org) installiert und
 aktualisiert. Bei Composer handelt es sich um einen Paketmanager der via Kommandozeile bedient wird und auch sonst kann
 Contao komplett von der Kommandozeile aus verwaltet werden.
 Der Contao Manager ist ein Tool, welches eine grafische Oberfläche zur einfacheren Verwaltung einer Contao-Installation 


### PR DESCRIPTION
Bei dieser Gelegenheit: Sollten wir in den englischen Texten auch den dort (zumindest im amerikanischen) üblichen längeren Strich verwenden, der zudem ohne Leerraum gesetzt wird (siehe z.B. https://en.wikipedia.org/wiki/Dash#Em_dash)?