### PR TITLE
"Standardlayout" entfernt

### DIFF
--- a/docs/manual/site-structure/configure-pages.de.md
+++ b/docs/manual/site-structure/configure-pages.de.md
@@ -138,8 +138,7 @@ Zwei-Faktor-Authentifizierung einrichten.
 ## Layout-Einstellungen
 
 Ein Seitenlayout ist Voraussetzung dafür, dass Contao eine Seite überhaupt im Frontend anzeigen kann. Ist kein 
-Seitenlayout zugewiesen oder vererbt worden, wird stattdessen das Standardlayout geladen. Ist auch kein Standardlayout 
-verfügbar, quittiert Contao mit einem kurzen »No layout specified« den Dienst.
+Seitenlayout zugewiesen oder vererbt worden, quittiert Contao mit einem kurzen »No layout specified« den Dienst.
 
 **Ein Layout zuweisen:** Hier kannst du einer Seite ein Seitenlayout zuweisen. Die Zuweisung gilt automatisch auch für 
 alle untergeordneten Seiten ohne eigenes Seitenlayout.


### PR DESCRIPTION
Die Bezeichnung "Standardlayout" legt nahe, daß es in Contao eine Option gäbe, ein Seitenlayout zum Standard (Fallback) zu erklären. Nach meinem Verständnis gibt es nur die Vererbung und spätestens wenn im Startpunkt der Webseite kein Layout angegeben ist, erscheint die Fehlermeldung "no layout specified".

Der Fix entspricht der bereits existierenden Formulierung beim [Theme-Manager -> Seitenlayouts verwalten](https://github.com/contao/docs/blame/master/docs/manual/theme-manager/manage-page-layouts.de.md#L13-L15).