### PR TITLE
Korrektur Schreibweise

### DIFF
--- a/docs/manual/module-management/website-search.de.md
+++ b/docs/manual/module-management/website-search.de.md
@@ -237,7 +237,8 @@ sieht folgendermaßen aus:
 <!-- indexer::continue -->
 ```
 
-Die Zielseite, die beim Abschicken des Formulars aufgerufen wird, wurde hier über einen Inserttag erfasst, damit das 
+Die Zielseite, die beim Abschicken des Formulars aufgerufen wird, wurde hier über einen
+[Insert-Tag](../../article-management/insert-tags/) erfasst, damit das
 Formular auch dann noch funktioniert, wenn sich der Alias der Zielseite im Laufe der Zeit ändert. Als 
 Übertragungsmethode wurde »GET« ausgewählt, und dem Suchfeld den Feldnamen »keywords« gegeben.
 


### PR DESCRIPTION
zusätzlich: Link gesetzt, da für einen Leser, der das Handbuch "linear" liest das Thema Insert-Tags noch unbekannt ist (kommt erst in der "Artikelverwaltung").