### PR TITLE
Change description of how to specify editable files

### DIFF
--- a/docs/manual/file-manager/file-manager.de.md
+++ b/docs/manual/file-manager/file-manager.de.md
@@ -44,8 +44,8 @@ Konfigurationsdatei [`config/config.yml`](../../system/einstellungen/#config-yml
 festlegen<sup>1</sup>.
 
 {{% notice note %}}
-<sup>1</sup>Bis zur Version 4.6 von Contao konnte dies in den in den System-Einstellungen unter »Dateien und Bilder 
--&gt; Editierbare Dateien« festlegt festlegt werden.
+<sup>1</sup>Bis zur Version 4.6 von Contao konnte dies in den System-Einstellungen unter »Dateien und Bilder 
+-&gt; Editierbare Dateien« festlegt werden.
 {{% /notice %}}
 
 **![Datei oder Verzeichnis verschieben](/de/icons/drag.svg?classes=icon) Verschieben:** Eine Datei bzw. einen Ordner per Drag & Drop verschieben.

--- a/docs/manual/file-manager/file-manager.de.md
+++ b/docs/manual/file-manager/file-manager.de.md
@@ -39,8 +39,9 @@ Datei bzw. des Ordners anzeigen.
 **![Dateien in den Ordner hochladen](/de/icons/new.svg?classes=icon) Hochladen:** Dateien in den Ordner hochladen.
 
 **![Datei bearbeiten](/de/icons/editor.svg?classes=icon) Datei bearbeiten:** Öffnet eine Eingabemaske zur 
-Bearbeitung des Inhalts einer Datei mit einem Texteditor. Welche Dateien editiert werden dürfen, kannst du in den 
-Backend-Einstellungen unter »Editierbare Dateien« festlegen.
+Bearbeitung des Inhalts einer Datei mit einem Texteditor. Welche Dateien editiert werden dürfen, kannst du in der
+Konfigurationsdatei [`config/config.yml`](../../system/einstellungen/#config-yml) unter dem Schlüssel `editable_files`
+festlegen.
 
 **![Datei oder Verzeichnis verschieben](/de/icons/drag.svg?classes=icon) Verschieben:** Eine Datei bzw. einen Ordner per Drag & Drop verschieben.
 

--- a/docs/manual/file-manager/file-manager.de.md
+++ b/docs/manual/file-manager/file-manager.de.md
@@ -41,7 +41,12 @@ Datei bzw. des Ordners anzeigen.
 **![Datei bearbeiten](/de/icons/editor.svg?classes=icon) Datei bearbeiten:** Öffnet eine Eingabemaske zur 
 Bearbeitung des Inhalts einer Datei mit einem Texteditor. Welche Dateien editiert werden dürfen, kannst du in der
 Konfigurationsdatei [`config/config.yml`](../../system/einstellungen/#config-yml) unter dem Schlüssel `editable_files`
-festlegen.
+festlegen<sup>1</sup>.
+
+{{% notice note %}}
+<sup>1</sup>Bis zur Version 4.6 von Contao konnte dies in den in den System-Einstellungen unter »Dateien und Bilder 
+-&gt; Editierbare Dateien« festlegt festlegt werden.
+{{% /notice %}}
 
 **![Datei oder Verzeichnis verschieben](/de/icons/drag.svg?classes=icon) Verschieben:** Eine Datei bzw. einen Ordner per Drag & Drop verschieben.
 


### PR DESCRIPTION
Wenn ich es richtig nachgesehen habe ist das seit `4.7` so. Bliebe also noch die `4.4`, die aktuell noch LTS ist, in der es wie bisher beschrieben funktioniert. Soll ich daher noch einen Hinweis

```
{{% notice note %}}
<sup>1</sup>Bis zur Version 4.6 von Contao konnte dies in den Backend-Einstellungen unter »Editierbare Dateien« festlegt werden.
{{% /notice %}}
```

ergänzen?