### PR TITLE
remove object return type

### DIFF
--- a/docs/dev/reference/hooks/setCookie.md
+++ b/docs/dev/reference/hooks/setCookie.md
@@ -46,7 +46,7 @@ class SetCookieListener implements ServiceAnnotationInterface
     /**
      * @Hook("setCookie")
      */
-    public function onSetCookie($cookie): object
+    public function onSetCookie($cookie)
     {
         // Make sure the cookie is also valid for the whole domain
         $cookie->strPath = '/';


### PR DESCRIPTION
Object return type is available from PHP 7.2 
Contao 4.9 requires minimum 7.1