### PR TITLE
Dev/label process improvements

### DIFF
--- a/docs/dev/internals/issue-workflow.md
+++ b/docs/dev/internals/issue-workflow.md
@@ -26,50 +26,58 @@ description: "How Contao developers are supposed to handle issues and PRs on Git
     }
 </style>
 
-## Handling new issues
+This article describes the issue workflow used on the [official monorepository of Contao on GitHub](https://github.com/contao/contao).
 
-After reading a new issue, please label it either as <span class="label-bug">bug</span> or as
+## Handling of new issues
+
+After you have submitted a new issue, one of the maintainers will label it either as <span class="label-bug">bug</span> or as
 <span class="label-feature">feature</span>.
 
-If it is a bug, please also assign the ticket to the milestone of the version in which the bug needs to be fixed (e.g.
-`4.4`). Do not assign feature requests to a milestone. 
+If it is a bug, they will assign your issue to the milestone of the minor version in which the bug needs to be fixed (e.g.
+`4.4`). Maintainers will not assign feature requests to any milestone.
 
 New issues do not get an assignee by default.
 
-## Handling new PRs
+## Handling of new Pull Requests
 
-After reading a new PR, please label it either as <span class="label-bug">bug</span> or as
+After you have submitted a new Pull Request, one of the maintainers will label it either as <span class="label-bug">bug</span> or as
 <span class="label-feature">feature</span>.
 
-If the PR is targeted against an active version branch (e.g. `4.4`), please assign it to the corresponding milestone.
-Do not assign PRs targeted against the `master` branch to a milestone.
+If the Pull Request targets a currently actively supported version branch (e.g. `4.4`) (bugs only), the maintainer will assign
+it to the corresponding milestone.
+For Pull Requests that target the `master` branch (usually features), the maintainers will not assign any milestone.
 
-Please assign new PRs to their creator.
+If you are the creator of a Pull Request, the maintainer will assign it to you.
 
 ## Reviewing bug reports
 
-If you cannot reproduce the bug, please add the <span class="label-status">unconfirmed</span> label to the ticket. If
-it is unclear how to fix the bug, please add the <span class="label-discuss">up for discussion</span> label.
+If a maintainer cannot reproduce the bug, they will add the <span class="label-status">unconfirmed</span> label to the issue.
+If it is unclear how to fix the bug, they will add the <span class="label-discuss">up for discussion</span> label which
+means they will discuss possible solutions during periodical phone calls on Mumble which is often a lot more efficient.
 
-If you want to work on the bug yourself, self-assign the ticket.
+If any maintainer wants to work on a bug, they self-assign the issue.
 
-If nobody assigns themselves a ticket, it will get the <span class="label-help">help wanted</span> label to indicate
+If no maintainer assigns themselves an issue, it will get the <span class="label-help">help wanted</span> label to indicate
 that we are looking for volunteers to complete it.
 
-If the bug cannot be fixed without breaking backwards compatibility, please add the
-<span class="label-status">incompatible</span> label. 
+If the bug cannot be fixed without breaking backwards compatibility, it becomes a "known limitation" for the current
+version, and it gets the <span class="label-status">incompatible</span> label. These issues will be addressed in the
+next major version.
  
 ## Reviewing feature requests
 
-If it is unclear how to implement the feature, please add the <span class="label-discuss">up for discussion</span>
-label to the ticket. If the feature cannot be implemented without breaking backwards compatibility, please add the
+If it is unclear how to implement the feature, a maintainer adds the <span class="label-discuss">up for discussion</span>
+label to the issue. If the feature cannot be implemented without breaking backwards compatibility, they add the
 <span class="label-status">incompatible</span> label. 
 
-## Stale tickets
+## Stale issues
 
-Tickets are considered stale after 60 days if they
+Issues will turn stale after 60 days if they
 
 * have no label or
 * are labeled as <span class="label-bug">bug</span> and are not labeled as
   <span class="label-discuss">up for discussion</span>, <span class="label-help">help wanted</span> or
   <span class="label-status">incompatible</span>.
+
+Stale issues will be automatically closed after another 7 days of no activity in order to help the maintainers keep
+the number of issues to a comprehensible level.

--- a/docs/dev/internals/issue-workflow.md
+++ b/docs/dev/internals/issue-workflow.md
@@ -60,6 +60,10 @@ If any maintainer wants to work on a bug, they self-assign the issue.
 If no maintainer assigns themselves an issue, it will get the <span class="label-help">help wanted</span> label to indicate
 that we are looking for volunteers to complete it.
 
+{{% notice note %}}
+FIXME: How is this process supposed to work? When do we know all of the core devs do not have any plans to work on a bug?
+{{% /notice %}}
+
 If the bug cannot be fixed without breaking backwards compatibility, it becomes a "known limitation" for the current
 version, and it gets the <span class="label-status">incompatible</span> label. These issues will be addressed in the
 next major version.


### PR DESCRIPTION
While trying to improve the wording so that the public is addressed (and doing some other stuff like replacing "ticket" by "issue") I found an issue in the process itself. That's added as a FIXME in a separate commit.