### PR TITLE
Add and use new Shortcode taxonomylist

### DIFF
--- a/docs/manual/guides/add-first-index-page.de.md
+++ b/docs/manual/guides/add-first-index-page.de.md
@@ -6,6 +6,10 @@ aliases:
     - /de/anleitungen/die-erste-startseite/
 weight: 10
 hidden: true
+tags: 
+   - "Theme"
+   - "Seitenlayout"
+   - "Seitenstruktur"
 ---
 
 Du hast die [Contao Installation](../../installation) abgeschlossen und kannst jetzt deine Startseite erstellen. 

--- a/docs/manual/guides/grid-system.de.md
+++ b/docs/manual/guides/grid-system.de.md
@@ -6,6 +6,10 @@ aliases:
     - /de/anleitungen/grid/
 weight: 54
 hidden: true
+tags: 
+   - "Layout"
+   - "Theme"
+   - "Seitenlayout"   
 ---
 
 Ein beliebtes Stilmittel ist die inhaltliche Aufteilung in Spalten. Hierbei hat sich der Einsatz von »Grid-Systemen«

--- a/docs/manual/guides/install-test-versions.de.md
+++ b/docs/manual/guides/install-test-versions.de.md
@@ -6,6 +6,8 @@ aliases:
     - /de/anleitungen/testversionen-installieren/
 weight: 5
 hidden: true
+tags: 
+   - "Installation"
 ---
 
 

--- a/docs/manual/guides/local-installation/_index.de.md
+++ b/docs/manual/guides/local-installation/_index.de.md
@@ -6,6 +6,8 @@ aliases:
     - /de/anleitungen/lokale-installation/
 weight: 900
 hidden: true
+tags: 
+   - "Installation"
 ---
 
 Du kannst dir Contao auch lokal installieren. Hierzu werden Webserver, Datenbank und PHP benötigt. Für die verschiedenen 

--- a/docs/manual/guides/local-installation/devilbox.de.md
+++ b/docs/manual/guides/local-installation/devilbox.de.md
@@ -6,6 +6,8 @@ url: "anleitungen/lokale-installation/devilbox"
 aliases:
     - /de/anleitungen/lokale-installation/devilbox/
 weight: 10
+tags: 
+   - "Installation"
 ---
 
 Das [Devilbox Project](http://devilbox.org/) ist ein fertiges LAMP Stack für [Docker](https://www.docker.com/). 

--- a/docs/manual/guides/sass-less-integration.de.md
+++ b/docs/manual/guides/sass-less-integration.de.md
@@ -6,6 +6,10 @@ aliases:
     - /de/anleitungen/sass-less-integration/
 weight: 30
 hidden: true
+tags: 
+   - "Layout"
+   - "Theme"
+   - "Seitenlayout"   
 ---
 
 

--- a/docs/manual/guides/tinymce-configuration.de.md
+++ b/docs/manual/guides/tinymce-configuration.de.md
@@ -6,6 +6,9 @@ aliases:
     - /de/anleitungen/tinymce-konfiguration/
 weight: 40
 hidden: true
+tags:
+   - "Template"
+   - "Konfiguration"
 ---
 
 

--- a/docs/manual/installation/_index.de.md
+++ b/docs/manual/installation/_index.de.md
@@ -17,3 +17,5 @@ Aus diesem Grund werden dir hier alle wichtigen Installationsvarianten vorgestel
 der lokalen Umgebung auf den Webserver gegeben, sowie das Aktualisieren einer bestehenden Installation erklärt.
 
 {{% children %}}
+
+{{% taxonomylist context="tags" filter="Installation" title="Anleitungen" description=true %}}

--- a/docs/manual/layout/_index.de.md
+++ b/docs/manual/layout/_index.de.md
@@ -10,4 +10,6 @@ weight: 7
 Im [Navigationsbereich](../administrationsbereich/aufruf-und-aufbau-des-backends/#der-navigationsbereich) »Layout« 
 befinden sich alle designrelevanten Module, mit denen du das Aussehen und die Struktur deiner Webseite festlegen kannst.
 
-{{% children depth=2 %}}
+{{% children %}}
+
+{{% taxonomylist context="tags" filter="Seitenstruktur, Theme, Layout, Template" title="Anleitungen" description=true %}}

--- a/docs/manual/layout/site-structure/_index.de.md
+++ b/docs/manual/layout/site-structure/_index.de.md
@@ -15,3 +15,5 @@ verstehst. Eine komprimierte Zusammenfassung dieser Informationen findest du im 
 folgenden Kapiteln werden dir die dort angerissenen Inhalte ausführlich erklärt.
 
 {{% children %}}
+
+{{% taxonomylist context="tags" filter="Seitenstruktur" title="Anleitungen" description=true %}}

--- a/docs/manual/layout/templates/_index.de.md
+++ b/docs/manual/layout/templates/_index.de.md
@@ -27,8 +27,5 @@ Im [Debug-Modus](../../system/debug-modus/) werden die Template-Namen im HTML-Qu
 Man kann hierüber nachvollziehen welches Template zum Einsatz kommt.
 {{% /notice %}}
 
-
-### Weitere Anleitungen
-
-- [Den TinyMce-Editor konfigurieren]({{< ref "tinymce-configuration.de.md" >}})
+{{% taxonomylist context="tags" filter="Template" title="Anleitungen" description=true %}}
 

--- a/docs/manual/layout/theme-manager/_index.de.md
+++ b/docs/manual/layout/theme-manager/_index.de.md
@@ -17,9 +17,4 @@ wird dir nun gezeigt, wie man ein Design erstellt und wie du das Aussehen deiner
 
 {{% children %}}
 
-
-### Weitere Anleitungen
-
-- [Ein Theme mit Seitenlayout anlegen und die erste Seite veröffentlichen]({{< ref "add-first-index-page.de.md" >}})
-- [Sass/Less Integration]({{< ref "sass-less-integration.de.md" >}})
-- [Einführung zur Nutzung eines Grid-Systems]({{< ref "grid-system.de.md" >}})
+{{% taxonomylist context="tags" filter="Theme, Layout, Seitenlayout" title="Anleitungen" description=true %}}

--- a/page/layouts/shortcodes/taxonomylist.html
+++ b/page/layouts/shortcodes/taxonomylist.html
@@ -70,7 +70,7 @@
                         {{ $strTemp := "" }}
                  
                         {{ if $withDescription }}
-                            {{ $strTemp = printf "<li><a href=\"%s\" class=\"highlight\">%s</a></li><p>%s</p>" .RelPermalink .Title .Description }}
+                            {{ $strTemp = printf "<li><a href=\"%s\" class=\"highlight\">%s</a><p>%s</p></li>" .RelPermalink .Title .Description }}
                         {{ else }}
                             {{ $strTemp = printf "<li><a href=\"%s\" class=\"highlight\">%s</a></li>" .RelPermalink .Title  }}
                         {{ end }}

--- a/page/layouts/shortcodes/taxonomylist.html
+++ b/page/layouts/shortcodes/taxonomylist.html
@@ -1,0 +1,95 @@
+{{/*
+   *    Shortcode: taxonomylist
+   *    Version: 1.0.0
+   *
+   *    Create a List with linked Pages matching one or more Taxonomy Terms. 
+   *    The Taxonomic Context could be "categories" or "tags".
+   *
+   *    Declare one or more Taxonomy Terms with Front Matter: 
+   *    tags: 
+   *        - "Tag1"
+   *        - "Tag2"    
+   *
+   *    Or
+   *
+   *    categories: 
+   *        - "Cat1"
+   *        - "Cat2"
+   *    
+   *    Example Shortcode Usage: Context "Categories"
+   *    {{% taxonomylist context="categories" filter="Cat1, Cat2" title="More" description=true %}}
+   *
+   *    Example Shortcode Usage: Context "Tags"
+   *    {{% taxonomylist context="tags" filter="Tag1, Tag2" title="More" description=true %}}
+   *    
+   *    Parameter:
+   *
+   *    context - String
+   *    The Taxonomy Context to use: "categories" or "tags" (default)
+   *    Context sensitive
+   *
+   *    filter -  String (mandatory)
+   *    One or more Taxonomy Terms (Comma separated) for filtering 
+   *    Context sensitive
+   *    
+   *    title - String (optional) 
+   *    Show a Title above the List
+   *    
+   *    description - Boolean (optional)
+   *    Show Page Description below each List Item
+   * 
+*/}}
+ 
+{{ $_hugo_config := `{ "version": 1 }` }}
+ 
+{{ $taxonomyContext := .Get "context" | default "tags" }}
+{{ $taxonomyFilter  := .Get "filter" }}
+{{ $withTitle       := .Get "title" }}
+{{ $withDescription := .Get "description" | default false }}
+ 
+ 
+{{ $scratchAllResults := newScratch }}
+ 
+{{/* ## Render only if Paramater filter provided ## */}} 
+{{ if $taxonomyFilter }} 
+ 
+    {{ range $taxonomyName, $taxonomies := .Site.Taxonomies }}
+ 
+        {{/* ## Use provided Taxonomy Context (categories or tags) ## */}}
+        {{ if eq $taxonomyName $taxonomyContext }}
+ 
+            {{ range $key, $value := $taxonomies }}
+
+                {{/* ## Use provided Terms for filtering ## */}}
+                {{ if in $taxonomyFilter $key }}
+ 
+                    {{/* ## Get Results - If multiple Terms provided possibly with Duplicates  ## */}}
+                    {{ range $value.Pages }}
+ 
+                        {{/* ## Define outside see: https://gohugo.io/templates/introduction/#variables ## */}}
+                        {{ $strTemp := "" }}
+                 
+                        {{ if $withDescription }}
+                            {{ $strTemp = printf "<li><a href=\"%s\" class=\"highlight\">%s</a></li><p>%s</p>" .RelPermalink .Title .Description }}
+                        {{ else }}
+                            {{ $strTemp = printf "<li><a href=\"%s\" class=\"highlight\">%s</a></li>" .RelPermalink .Title  }}
+                        {{ end }}
+ 
+                        {{ $scratchAllResults.Add "Links" (slice $strTemp) }}
+             
+                    {{ end }}
+                {{ end }}
+            {{ end }}            
+        {{ end }}
+    {{ end }}
+ 
+{{/* ## Caution: Render for Markdown - Do not indent here ## */}}    
+{{if $withTitle }}<h3>{{ $withTitle }}</h3>{{ end }}
+<ul class="children children-li">
+{{/* ## Only unique Items ## */}}
+{{ range uniq ($scratchAllResults.Get "Links") }}
+{{ . | safeHTML }}
+{{ end }}
+</ul>
+ 
+{{ end }}


### PR DESCRIPTION
New Shortcode: taxonomylist:
Create a List with linked Pages matching one or more Taxonomy Terms (similar to the shortcode "children"). 

The Taxonomic Context could be "categories" or "tags".
(Here with Front Matter "tags:" - as discussed with @fritzmg on slack) 