### PR TITLE
Add clarification about readers and the reader setting in list modules

### DIFF
--- a/docs/manual/core-extensions/calendar/frontend-modules.de.md
+++ b/docs/manual/core-extensions/calendar/frontend-modules.de.md
@@ -119,6 +119,12 @@ Das Schlüsselwort des Eventlesers lautet *event* und teilt dem Modul mit, dass
 ausgeben soll. Existiert der gesuchte Eintrag nicht, gibt der Eventleser eine Fehlermeldung und den HTTP-Status-Code 
 »404 Not found« zurück. Der Status-Code ist wichtig für die Suchmaschinenoptimierung.
 
+{{% notice info %}}
+Auf einer einzelnen Seite darf sich immer nur ein »Lesermodul« befinden, egal welchen Typs. Andernfalls würde das eine 
+oder andere Modul eine 404 Seite auslösen, da zum Beispiel der Alias einer Nachricht nicht in einem Kalender gefunden 
+wird, oder umgekehrt der Alias eines Events in einem Nachrichtenarchiv.
+{{% /notice %}}
+
 
 ### Modul-Konfiguration
 
@@ -207,8 +213,15 @@ auswählst, wird die Darstellung verkürzt, und das Event erscheint nur einmal 
 
 **Sortierreihenfolge:** Hier kannst du die Sortierreihenfolge der Events ändern.
 
-**Eventleser:** Hier kannst du festlegen ob automatisch zum Eventleser gewechselt werden soll, wenn ein Event 
-ausgewählt wurde.
+**Eventleser:** Hier kannst du festlegen ob automatisch das ausgewählte Eventleser-Modul anstatt dem Eventlisten-Modul angezeigt
+werden soll, wenn ein Event ausgewählt wurde. Dadurch ist es möglich die Eventliste und den Eventleser auf der selben Seite
+mit nur einem Modul unterzubringen, anstatt eine eigene Seite für den Eventleser zu haben.
+
+{{% notice info %}}
+**Vorsicht:** in den meisten Fällen sollte diese Funktionalität nicht für Eventlisten benutzt werden, die im Seitenlayout
+platziert werden. Andernfalls hätte man dann auf jeder Seite des Seitenlayouts automatisch auch einen Eventleser an der 
+jeweiligen Stelle im Layout. Dies würde die Funktionalität anderer »Lesermodule« auf der selben Seite verhindern.
+{{% /notice %}}
 
 **Anzahl an Events:** Wenn du hier einen Wert größer 0 eingibst, wird die Anzahl der Events der Eventliste automatisch 
 auf diesen Wert limitiert.

--- a/docs/manual/core-extensions/faq/frontend-modules.de.md
+++ b/docs/manual/core-extensions/faq/frontend-modules.de.md
@@ -64,6 +64,12 @@ Das Schlüsselwort des FAQ-Lesers lautet *frage* und teilt dem Modul mit, dass 
 ausgeben soll. Existiert die gesuchte Frage nicht, gibt der FAQ-Leser eine Fehlermeldung und den HTTP-Status-Code 
 »404 Not found« zurück. Der Status-Code ist wichtig für die Suchmaschinenoptimierung.
 
+{{% notice info %}}
+Auf einer einzelnen Seite darf sich immer nur ein »Lesermodul« befinden, egal welchen Typs. Andernfalls würde das eine 
+oder andere Modul eine 404 Seite auslösen, da zum Beispiel der Alias einer FAQ nicht in einem Kalender gefunden 
+wird, oder umgekehrt der Alias eines Events in einer FAQ-Kategorie.
+{{% /notice %}}
+
 
 ### Modul-Konfiguration
 

--- a/docs/manual/core-extensions/news/frontend-modules.de.md
+++ b/docs/manual/core-extensions/news/frontend-modules.de.md
@@ -30,6 +30,12 @@ werden standardmäßig absteigend nach Datum sortiert.
 **Nachrichtenleser:** Hier kannst du festlegen ob automatisch zum Nachrichtenleser gewechselt werden soll, wenn ein 
 Beitrag ausgewählt wurde.
 
+{{% notice info %}}
+**Vorsicht:** in den meisten Fällen sollte diese Funktionalität nicht für Nachrichtenlisten benutzt werden, die im Seitenlayout
+platziert werden. Andernfalls hätte man dann auf jeder Seite des Seitenlayouts automatisch auch einen Nachrichtenleser an 
+der jeweiligen Stelle im Layout. Dies würde die Funktionalität anderer »Lesermodule« auf der selben Seite verhindern.
+{{% /notice %}}
+
 **Gesamtzahl der Beiträge:** Wenn du hier einen Wert größer 0 eingibst, wird die Anzahl der Nachrichten bzw. 
 Blog-Beiträge automatisch auf diesen Wert limitiert.
 
@@ -110,6 +116,12 @@ Beitrags bezieht das Modul über die URL, sodass Nachrichten mit sogenannten
 In diesem Beispiel wird die Nachricht mit dem Alias »form-folgt-funktion« über die Seite »nachricht« aufgerufen. 
 Existiert die gesuchte Nachricht nicht, gibt der Nachrichtenleser eine Fehlermeldung und den HTTP-Status-Code »404 Not
 found« zurück. Der Status-Code ist wichtig für die Suchmaschinenoptimierung.
+
+{{% notice info %}}
+Auf einer einzelnen Seite darf sich immer nur ein »Lesermodul« befinden, egal welchen Typs. Andernfalls würde das eine 
+oder andere Modul eine 404 Seite auslösen, da zum Beispiel der Alias einer Nachricht nicht in einem Kalender gefunden 
+wird, oder umgekehrt der Alias eines Events in einem Nachrichtenarchiv.
+{{% /notice %}}
 
 
 ### Modul-Konfiguration

--- a/docs/manual/core-extensions/newsletter/frontend-modules.de.md
+++ b/docs/manual/core-extensions/newsletter/frontend-modules.de.md
@@ -228,6 +228,12 @@ Der *newsletteralias* teilt dem »Newsletterleser« mit, dass er einen bestimmte
 ausgeben soll. Existiert der gesuchte Eintrag nicht, gibt das Modul eine Fehlermeldung und den HTTP-Status-Code 
 »404 Not found« zurück. Der Status-Code ist wichtig für die Suchmaschinenoptimierung.
 
+{{% notice info %}}
+Auf einer einzelnen Seite darf sich immer nur ein »Lesermodul« befinden, egal welchen Typs. Andernfalls würde das eine 
+oder andere Modul eine 404 Seite auslösen, da zum Beispiel der Alias eines Newsletters nicht in einem Kalender gefunden 
+wird, oder umgekehrt der Alias eines Events in einem Newsletterarchiv.
+{{% /notice %}}
+
 
 ### Modul-Konfiguration
 


### PR DESCRIPTION
This is something that people in the community get frequently wrong. They select an eventreader in the eventlist module (or in recent Contao versions also a newsreader in the newslist module), mostly without really knowing what kind of effect this actually has. Doing so might incapacitate your reader pages, if  the list module is placed in the page layout (and thus on every page).

This PR adds some clarification about that and also mentions that you can't have more than one reader module on the same page.