### PR TITLE
Unified namespace for App\EventListener\DataContainer

### DIFF
--- a/docs/dev/framework/dca/_index.md
+++ b/docs/dev/framework/dca/_index.md
@@ -63,8 +63,8 @@ For a `list.label.group` callback for example your callback might look like
 this:
 
 ```php
-// src/EventListener/Dca/ContentListener.php
-namespace App\EventListener\Dca;
+// src/EventListener/DataContainer/ContentListener.php
+namespace App\EventListener\DataContainer;
 
 use Contao\DataContainer;
 


### PR DESCRIPTION
Always use `App\EventListener\DataContainer` as Namespace for DCA Listener!