### PR TITLE
Typo: Form instead of From

### DIFF
--- a/docs/dev/reference/hooks/getPageIdFromUrl.md
+++ b/docs/dev/reference/hooks/getPageIdFromUrl.md
@@ -3,8 +3,9 @@ title: "getPageIdFromUrl"
 description: "getPageIdFromUrl hook"
 tags: ["hook-routing"]
 aliases:
+    - /reference/hooks/getPageIdFormUrl/
+    - /reference/hooks/getpageIdformurl
     - /reference/hooks/getPageIdFromUrl/
-    - /reference/hooks/getpageIdfromurl/
 ---
 
 

--- a/docs/dev/reference/hooks/getPageIdFromUrl.md
+++ b/docs/dev/reference/hooks/getPageIdFromUrl.md
@@ -1,10 +1,10 @@
 ---
-title: "getPageIdFormUrl"
-description: "getPageIdFormUrl hook"
+title: "getPageIdFromUrl"
+description: "getPageIdFromUrl hook"
 tags: ["hook-routing"]
 aliases:
-    - /reference/hooks/getPageIdFormUrl/
-    - /reference/hooks/getpageIdformurl/
+    - /reference/hooks/getPageIdFromUrl/
+    - /reference/hooks/getpageIdfromurl/
 ---
 
 


### PR DESCRIPTION
I think this is a typo, where getPageIdFormUrl was used instead of getPageIdFromUrl.