### PR TITLE
Correct purpose of getArticles hook

### DIFF
--- a/docs/dev/reference/hooks/getArticles.md
+++ b/docs/dev/reference/hooks/getArticles.md
@@ -8,9 +8,9 @@ aliases:
 ---
 
 
-The `getArticles` hook allows you to override the configuration of an article 
-prior to rendering. It passes the page ID and the requested column (e.g. `'main'`)
-as arguments. It expects a `string` as return value or `null`. If a string is
+The `getArticles` hook allows you to replace a column's articles with custom
+content. It passes the page ID and the requested column (e.g. `'main'`) as
+arguments. It expects a `string` as return value or `null`. If a string is
 returned, no further hooks of the same type are executed and that content will
 be shown in the front end.
 


### PR DESCRIPTION
The first sentence was identical to that of the `getArticle` hook description, i. e. it didn't describe the actual purpose of `getArticles`. The rest of the description matches what the hook actually does, so it was probably just a copy-paste error.