### PR TITLE
Bugfix?

### DIFF
--- a/docs/manual/administration-area/back-end-keyboard-shortcuts.de.md
+++ b/docs/manual/administration-area/back-end-keyboard-shortcuts.de.md
@@ -66,7 +66,7 @@ Im Modus »Mehrere bearbeiten« kommen weitere Kürzel hinzu:
 ## Tastaturkürzel unter Windows, Linux und Mac {#tastaturkuerzel-unter-windows-linux-und-mac}
 
 Die beschriebenen Tastaturkürzel funktionieren in dieser Form nur unter Windows und Linux. Mac-Nutzer müssen anstatt der
-`[Alt]`-Taste `[Ctrl]+[⌥ Opt]` in Verbindung mit dem jeweiligen Kürzel verwenden.
+`[Alt]`-Taste `[Ctrl]+[⌥]` in Verbindung mit dem jeweiligen Kürzel verwenden.
 
 Zudem weicht Firefox unter Windows leider vom gewohnten Standard ab, dort musst du `[Alt]+[Umsch]` in Verbindung mit
 dem gewünschten Kürzel drücken.

--- a/docs/manual/administration-area/back-end-keyboard-shortcuts.en.md
+++ b/docs/manual/administration-area/back-end-keyboard-shortcuts.en.md
@@ -64,7 +64,7 @@ Further abbreviations are added in "Edit multiple" mode:
 
 ## Keyboard shortcuts under Windows, Linux and Mac
 
-The described shortcuts work in this form only under Windows and Linux. Mac users have to use `[Ctrl]+[⌥ Opt]` instead of `[Alt]` 
+The described shortcuts work in this form only under Windows and Linux. Mac users have to use `[Ctrl]+[⌥]` instead of `[Alt]` 
 together with the keyboard shortcut.
 
 In addition, Firefox on Windows deviates from the standard: you have to press `[Alt]+[Shift]` and the keyboard shortcut.


### PR DESCRIPTION
I just saw this 

> Die beschriebenen Tastaturkürzel funktionieren in dieser Form nur unter Windows. Mac-Nutzer müssen anstatt der [Alt]-Taste [Ctrl]+[⌥ Opt] in Verbindung mit dem jeweiligen Kürzel verwenden. 

in the manual. The ` Opt` is not part of the keyboard-shortcut, is it?

See PR if it needs to be removed.

I did not find other occurences of `⌥` in the docs, so this should be the only place affected.