### PR TITLE
Add installation intro

### DIFF
--- a/docs/manual/installation/_index.en.md
+++ b/docs/manual/installation/_index.en.md
@@ -1,0 +1,19 @@
+---
+title: "Installation"
+description: "This will teach you anything you need to know in order to install and maintain Contao."
+aliases:
+    - /en/installation/
+weight: 2
+---
+
+This will teach you anything you need to know in order to install and maintain Contao.
+
+The installation of Contao only takes a few minutes, thanks to the Contao Manager, given that the server is configured
+correctly and the minimum system requirements are fulfilled. However, in practice, it has been shown that there often
+can be some misconceptions and problems regarding the server configuration.
+
+Thus this chapter describes all relevant methods of installation, gives detailed tips regarding the relocation of a
+Contao instance from your local development environment to the live web server and it shows how to update an existing
+installation.
+
+{{% children %}}


### PR DESCRIPTION
Without the intro section, the menu will not behave correctly in the English language.

However, the intro currently mentions articles that aren't there yet for the English language. @netzarbeiter should I disable the last paragraph for now?