### PR TITLE
Remove service annotation interface

### DIFF
--- a/docs/dev/framework/cron.md
+++ b/docs/dev/framework/cron.md
@@ -138,12 +138,11 @@ to tag the service accordingly.
 namespace App\Cron;
 
 use Contao\CoreBundle\ServiceAnnotation\CronJob;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 /**
  * @CronJob("hourly")
  */
-class ExampleCron implements ServiceAnnotationInterface
+class ExampleCron
 {
     public function __invoke(): void
     {

--- a/docs/dev/framework/dca/_index.md
+++ b/docs/dev/framework/dca/_index.md
@@ -122,9 +122,8 @@ namespace App\EventListener\DataContainer;
 
 use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class NewsOnsubmitCallbackListener implements ServiceAnnotationInterface
+class NewsOnsubmitCallbackListener
 {
     /**
      * @Callback(table="tl_news", target="config.onsubmit")
@@ -147,12 +146,11 @@ namespace App\EventListener\DataContainer;
 
 use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 /**
  * @Callback(table="tl_news", target="config.onsubmit")
  */
-class NewsOnsubmitCallbackListener implements ServiceAnnotationInterface
+class NewsOnsubmitCallbackListener
 {
     public function __invoke(DataContainer $dc): void
     {

--- a/docs/dev/framework/search-indexing.md
+++ b/docs/dev/framework/search-indexing.md
@@ -166,14 +166,14 @@ There are multiple ways to achieve this. One way is to use the [generatePage][ge
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
+use Contao\PageModel;
 
 /**
  * @Hook("generatePage")
  */
-class GeneratePageListener implements ServiceAnnotationInterface
+class GeneratePageListener
 {
-    public function __invoke(\Contao\PageModel $pageModel): void
+    public function __invoke(PageModel $pageModel): void
     {
         if (/* … */) {
             $pageModel->noSearch = true;

--- a/docs/dev/getting-started/hooks.md
+++ b/docs/dev/getting-started/hooks.md
@@ -35,14 +35,13 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\FrontendTemplate;
 use Contao\Module;
 use Contao\UserModel;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ParseArticlesListener implements ServiceAnnotationInterface
+/**
+ * @Hook("parseArticles")
+ */
+class ParseArticlesListener
 {
-    /**
-     * @Hook("parseArticles")
-     */
-    public function onParseArticles(FrontendTemplate $template, array $newsEntry, Module $module): void
+    public function __invoke(FrontendTemplate $template, array $newsEntry, Module $module): void
     {
         // Fetch the news entry's author
         $author = UserModel::findByPk($newsEntry['author']);
@@ -93,9 +92,8 @@ use App\ExternalMembers\ExternalMemberService;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 use Contao\FrontendUser;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class UpdatePersonalDataListener implements ServiceAnnotationInterface
+class UpdatePersonalDataListener
 {
     private $externalMemberService;
 

--- a/docs/dev/guides/adding-back-end-assets.md
+++ b/docs/dev/guides/adding-back-end-assets.md
@@ -76,12 +76,11 @@ the `onload` [DCA callback][DcaCallbacks] for the specific DCA.
 namespace App\EventListener\DataContainer;
 
 use Contao\CoreBundle\ServiceAnnotation\Callback;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 /**
  * @Callback(target="config.onload", table="tl_content")
  */
-class FilesOnLoadCallbackListener implements ServiceAnnotationInterface
+class FilesOnLoadCallbackListener
 {
     public function __invoke(): void
     {

--- a/docs/dev/guides/fragment-controllers.md
+++ b/docs/dev/guides/fragment-controllers.md
@@ -90,12 +90,11 @@ use Contao\CoreBundle\ServiceAnnotation\FrontendModule;
 use Contao\ModuleModel;
 use Contao\ModuleNewsList;
 use Symfony\Component\HttpFoundation\Response;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 /**
  * @FrontendModule(category="news")
  */
-class AppExampleController extends ModuleNewsList implements ServiceAnnotationInterface
+class AppExampleController extends ModuleNewsList
 {
     public function __construct() {}
 
@@ -119,12 +118,11 @@ use Contao\ContentGallery;
 use Contao\ContentModel;
 use Contao\CoreBundle\ServiceAnnotation\ContentElement;
 use Symfony\Component\HttpFoundation\Response;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 /**
  * @ContentElement(category="news")
  */
-class AppExampleController extends ContentGallery implements ServiceAnnotationInterface
+class AppExampleController extends ContentGallery
 {
     public function __construct() {}
 

--- a/docs/dev/reference/events.md
+++ b/docs/dev/reference/events.md
@@ -35,12 +35,11 @@ namespace App\EventListener;
 use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\MenuEvent;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 /**
  * @ServiceTag("kernel.event_listener", event=ContaoCoreEvents::BACKEND_MENU_BUILD)
  */
-class BackendMenuBuildListener implements ServiceAnnotationInterface
+class BackendMenuBuildListener
 {
     public function __invoke(MenuEvent $event): void
     {
@@ -93,12 +92,11 @@ namespace App\EventListener;
 use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\GenerateSymlinksEvent;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 /**
  * @ServiceTag("kernel.event_listener", event=ContaoCoreEvents::GENERATE_SYMLINKS)
  */
-class GenerateSymlinksListener implements ServiceAnnotationInterface
+class GenerateSymlinksListener
 {
     public function __invoke(GenerateSymlinksEvent $event): void
     {
@@ -132,12 +130,11 @@ namespace App\EventListener;
 use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\ImageSizesEvent;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 /**
  * @ServiceTag("kernel.event_listener", event=ContaoCoreEvents::IMAGE_SIZES_ALL)
  */
-class ImageSizesAllListener implements ServiceAnnotationInterface
+class ImageSizesAllListener
 {
     public function __invoke(ImageSizesEvent $event): void
     {
@@ -169,12 +166,11 @@ namespace App\EventListener;
 use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\ImageSizesEvent;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 /**
  * @ServiceTag("kernel.event_listener", event=ContaoCoreEvents::IMAGE_SIZES_USER)
  */
-class ImageSizesUserListener implements ServiceAnnotationInterface
+class ImageSizesUserListener
 {
     public function __invoke(ImageSizesEvent $event): void
     {
@@ -206,12 +202,11 @@ namespace App\EventListener;
 use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\PreviewUrlCreateEvent;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 /**
  * @ServiceTag("kernel.event_listener", event=ContaoCoreEvents::PREVIEW_URL_CREATE)
  */
-class PreviewUrlCreateListener implements ServiceAnnotationInterface
+class PreviewUrlCreateListener
 {
     public function __invoke(PreviewUrlCreateEvent $event): void
     {
@@ -244,12 +239,11 @@ namespace App\EventListener;
 use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\PreviewUrlConvertEvent;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 /**
  * @ServiceTag("kernel.event_listener", event=ContaoCoreEvents::PREVIEW_URL_CONVERT)
  */
-class PreviewUrlConvertListener implements ServiceAnnotationInterface
+class PreviewUrlConvertListener
 {
     public function __invoke(PreviewUrlConvertEvent $event): void
     {
@@ -285,7 +279,7 @@ namespace App\EventListener;
 use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\RobotsTxtEvent;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
+
 use webignition\RobotsTxt\Directive\Directive;
 use webignition\RobotsTxt\Directive\UserAgentDirective;
 use webignition\RobotsTxt\Inspector\Inspector;
@@ -294,7 +288,7 @@ use webignition\RobotsTxt\Record\Record;
 /**
  * @ServiceTag("kernel.event_listener", event=ContaoCoreEvents::ROBOTS_TXT)
  */
-class RobotsTxtListener implements ServiceAnnotationInterface
+class RobotsTxtListener
 {
     public function __invoke(RobotsTxtEvent $event): void
     {
@@ -343,12 +337,11 @@ namespace App\EventListener;
 use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\SlugValidCharactersEvent;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 /**
  * @ServiceTag("kernel.event_listener", event=ContaoCoreEvents::SLUG_VALID_CHARACTERS)
  */
-class SlugValidCharactersListener implements ServiceAnnotationInterface
+class SlugValidCharactersListener
 {
     public function __invoke(SlugValidCharactersEvent $event): void
     {

--- a/docs/dev/reference/hooks/_index.md
+++ b/docs/dev/reference/hooks/_index.md
@@ -4,6 +4,27 @@ description: "Developer Reference for Contao Hooks."
 ---
 
 
-This is the reference for [Hooks](../../framework/hooks/) explaining all the available hooks of the Contao core and their parameters.
+This is the reference for [Hooks](HooksFramework) explaining all the available hooks 
+of the Contao core and their parameters. The examples in this reference implement 
+Hooks using [_Service Annotation_][HooksServiceAnnotation] and [_Invokable Services_][HooksInvokableServices]. 
+These examples will work out of the box within a Contao **4.9+** installation. 
+
+However, if you need to implement a Hook for Contao **4.4**, you still need to use the 
+[PHP Array Configuration][HooksArrayConfig]. In case you want to use an invokable
+service here as well, you can still reference the `__invoke` function:
+
+```php
+// app/Resources/contao/config/config.php
+use App\EventListener\GetArticlesListener;
+
+$GLOBALS['TL_HOOKS']['getArticles'][] = [GetArticlesListener::class, '__invoke'];
+```
+
+
+[HooksFramework]: /framework/hooks/
+[HooksServiceAnnotation]: /framework/hooks/#using-annotations
+[HooksInvokableServices]: /framework/hooks/#invokable-services
+[HooksArrayConfig]: /framework/hooks/#using-the-php-array-configuration
+
 
 {{% children depth="999" %}}

--- a/docs/dev/reference/hooks/activateAccount.md
+++ b/docs/dev/reference/hooks/activateAccount.md
@@ -34,12 +34,12 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 use Contao\MemberModel;
 
+/**
+ * @Hook("activateAccount")
+ */
 class ActivateAccountListener
 {
-    /**
-     * @Hook("activateAccount")
-     */
-    public function onActivateAccount(MemberModel $member, Module $module): void
+    public function __invoke(MemberModel $member, Module $module): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/activateAccount.md
+++ b/docs/dev/reference/hooks/activateAccount.md
@@ -33,9 +33,8 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 use Contao\MemberModel;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ActivateAccountListener implements ServiceAnnotationInterface
+class ActivateAccountListener
 {
     /**
      * @Hook("activateAccount")

--- a/docs/dev/reference/hooks/activateRecipient.md
+++ b/docs/dev/reference/hooks/activateRecipient.md
@@ -36,12 +36,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("activateRecipient")
+ */
 class ActivateRecipientListener
 {
-    /**
-     * @Hook("activateRecipient")
-     */
-    public function onActivateRecipient(string $email, array $recipientIds, array $channelIds): void
+    public function __invoke(string $email, array $recipientIds, array $channelIds): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/activateRecipient.md
+++ b/docs/dev/reference/hooks/activateRecipient.md
@@ -35,9 +35,8 @@ and does not expect a return value.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ActivateRecipientListener implements ServiceAnnotationInterface
+class ActivateRecipientListener
 {
     /**
      * @Hook("activateRecipient")

--- a/docs/dev/reference/hooks/addComment.md
+++ b/docs/dev/reference/hooks/addComment.md
@@ -36,12 +36,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Comments;
 
+/**
+ * @Hook("addComment")
+ */
 class AddCommentListener
 {
-    /**
-     * @Hook("addComment")
-     */
-    public function onAddComment(int $commentId, array $commentData, Comments $comments): void
+    public function __invoke(int $commentId, array $commentData, Comments $comments): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/addComment.md
+++ b/docs/dev/reference/hooks/addComment.md
@@ -35,9 +35,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Comments;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class AddCommentListener implements ServiceAnnotationInterface
+class AddCommentListener
 {
     /**
      * @Hook("addComment")

--- a/docs/dev/reference/hooks/addCustomRegexp.md
+++ b/docs/dev/reference/hooks/addCustomRegexp.md
@@ -55,12 +55,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Widget;
 
+/**
+ * @Hook("addCustomRegexp")
+ */
 class AddCustomRegexpListener
 {
-    /**
-     * @Hook("addCustomRegexp")
-     */
-    public function onAddCustomRegexp(string $regexp, $input, Widget $widget): bool
+    public function __invoke(string $regexp, $input, Widget $widget): bool
     {
         if ('plz' === $regexp) {
             $exp = '\b((?:0[1-46-9]\d{3})|(?:[1-357-9]\d{4})|(?:[4][0-24-9]\d{3})|(?:[6][013-9]\d{3}))\b';

--- a/docs/dev/reference/hooks/addCustomRegexp.md
+++ b/docs/dev/reference/hooks/addCustomRegexp.md
@@ -54,9 +54,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Widget;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class AddCustomRegexpListener implements ServiceAnnotationInterface
+class AddCustomRegexpListener
 {
     /**
      * @Hook("addCustomRegexp")

--- a/docs/dev/reference/hooks/addLogEntry.md
+++ b/docs/dev/reference/hooks/addLogEntry.md
@@ -50,9 +50,8 @@ Using the `addLogEntry` hook has been deprecated and will no longer work in Cont
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class AddLogEntryListener implements ServiceAnnotationInterface
+class AddLogEntryListener
 {
     /**
      * @Hook("addLogEntry")

--- a/docs/dev/reference/hooks/addLogEntry.md
+++ b/docs/dev/reference/hooks/addLogEntry.md
@@ -51,12 +51,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("addLogEntry")
+ */
 class AddLogEntryListener
 {
-    /**
-     * @Hook("addLogEntry")
-     */
-    public function onAddLogEntry(string $message, string $func, string $action): void
+    public function __invoke(string $message, string $func, string $action): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/checkCredentials.md
+++ b/docs/dev/reference/hooks/checkCredentials.md
@@ -48,12 +48,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\User;
 
+/**
+ * @Hook("checkCredentials")
+ */
 class CheckCredentialsListener
 {
-    /**
-     * @Hook("checkCredentials")
-     */
-    public function onCheckCredentials(string $username, string $credentials, User $user): bool
+    public function __invoke(string $username, string $credentials, User $user): bool
     {
         // Custom method of checking credentials (e.g. external service)
         if ($this->customCredentialsCheck($username, $credentials)) {

--- a/docs/dev/reference/hooks/checkCredentials.md
+++ b/docs/dev/reference/hooks/checkCredentials.md
@@ -47,9 +47,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\User;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class CheckCredentialsListener implements ServiceAnnotationInterface
+class CheckCredentialsListener
 {
     /**
      * @Hook("checkCredentials")

--- a/docs/dev/reference/hooks/closeAccount.md
+++ b/docs/dev/reference/hooks/closeAccount.md
@@ -40,12 +40,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 
+/**
+ * @Hook("closeAccount")
+ */
 class CloseAccountListener
 {
-    /**
-     * @Hook("closeAccount")
-     */
-    public function onCloseAccount(int $userId, string $mode, Module $module): void
+    public function __invoke(int $userId, string $mode, Module $module): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/closeAccount.md
+++ b/docs/dev/reference/hooks/closeAccount.md
@@ -39,9 +39,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class CloseAccountListener implements ServiceAnnotationInterface
+class CloseAccountListener
 {
     /**
      * @Hook("closeAccount")

--- a/docs/dev/reference/hooks/colorizeLogEntries.md
+++ b/docs/dev/reference/hooks/colorizeLogEntries.md
@@ -36,9 +36,8 @@ Return the processed `$label` string.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ColorizeLogEntriesListener implements ServiceAnnotationInterface
+class ColorizeLogEntriesListener
 {
     /**
      * @Hook("colorizeLogEntries")

--- a/docs/dev/reference/hooks/colorizeLogEntries.md
+++ b/docs/dev/reference/hooks/colorizeLogEntries.md
@@ -37,12 +37,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("colorizeLogEntries")
+ */
 class ColorizeLogEntriesListener
 {
-    /**
-     * @Hook("colorizeLogEntries")
-     */
-    public function onColorizeLogEntries(array $row, string $label): string
+    public function __invoke(array $row, string $label): string
     {
         // Wrap the label with a span containing a custom CSS class or style attributes
         if (…) {

--- a/docs/dev/reference/hooks/compareThemeFiles.md
+++ b/docs/dev/reference/hooks/compareThemeFiles.md
@@ -39,9 +39,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\ZipReader;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class CompareThemeFilesListener implements ServiceAnnotationInterface
+class CompareThemeFilesListener
 {
     /**
      * @Hook("compareThemeFiles")

--- a/docs/dev/reference/hooks/compareThemeFiles.md
+++ b/docs/dev/reference/hooks/compareThemeFiles.md
@@ -40,12 +40,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\ZipReader;
 
+/**
+ * @Hook("compareThemeFiles")
+ */
 class CompareThemeFilesListener
 {
-    /**
-     * @Hook("compareThemeFiles")
-     */
-    public function onCompareThemeFiles(\DOMDocument $xml, ZipReader $zip): string
+    public function __invoke(\DOMDocument $xml, ZipReader $zip): string
     {
         // Execute your custom theme comparison
         if ($this->doCustomComparison()) {

--- a/docs/dev/reference/hooks/compileArticle.md
+++ b/docs/dev/reference/hooks/compileArticle.md
@@ -38,9 +38,8 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 use Contao\FrontendTemplate;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class CompileArticleListener implements ServiceAnnotationInterface
+class CompileArticleListener
 {
     /**
      * @Hook("compileArticle")

--- a/docs/dev/reference/hooks/compileArticle.md
+++ b/docs/dev/reference/hooks/compileArticle.md
@@ -39,12 +39,12 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 use Contao\FrontendTemplate;
 
+/**
+ * @Hook("compileArticle")
+ */
 class CompileArticleListener
 {
-    /**
-     * @Hook("compileArticle")
-     */
-    public function onCompileArticle(FrontendTemplate $template, array $data, Module $module): void
+    public function __invoke(FrontendTemplate $template, array $data, Module $module): void
     {
         $template->customContent = '<p>This will be available in mod_article.html5 via $this->customContent</p>';
     }

--- a/docs/dev/reference/hooks/compileDefinition.md
+++ b/docs/dev/reference/hooks/compileDefinition.md
@@ -45,9 +45,8 @@ definition should be used.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class CompileDefinitionListener implements ServiceAnnotationInterface
+class CompileDefinitionListener
 {
     /**
      * @Hook("compileDefinition")

--- a/docs/dev/reference/hooks/compileDefinition.md
+++ b/docs/dev/reference/hooks/compileDefinition.md
@@ -46,12 +46,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("compileDefinition")
+ */
 class CompileDefinitionListener
 {
-    /**
-     * @Hook("compileDefinition")
-     */
-    public function onCompileDefinition(array $row, bool $writeToFile, array $vars, array $parent): string
+    public function __invoke(array $row, bool $writeToFile, array $vars, array $parent): string
     {
         if (isset($row['border-radius'])) {
             return "\nborder-radius:" . $arrRow['border-radius'] . ";";

--- a/docs/dev/reference/hooks/compileFormFields.md
+++ b/docs/dev/reference/hooks/compileFormFields.md
@@ -43,12 +43,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Form;
 
+/**
+ * @Hook("compileFormFields")
+ */
 class CompileFormFieldsListener
 {
-    /**
-     * @Hook("compileFormFields")
-     */
-    public function onCompileFormFields(array $fields, string $formId, Form $form): array
+    public function __invoke(array $fields, string $formId, Form $form): array
     {
         // Modify $fields as needed
 

--- a/docs/dev/reference/hooks/compileFormFields.md
+++ b/docs/dev/reference/hooks/compileFormFields.md
@@ -42,9 +42,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Form;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class CompileFormFieldsListener implements ServiceAnnotationInterface
+class CompileFormFieldsListener
 {
     /**
      * @Hook("compileFormFields")

--- a/docs/dev/reference/hooks/createDefinition.md
+++ b/docs/dev/reference/hooks/createDefinition.md
@@ -45,9 +45,8 @@ as value or null to keep the default behaviour.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class CreateDefinitionListener implements ServiceAnnotationInterface
+class CreateDefinitionListener
 {
     /**
      * @Hook("createDefinition")

--- a/docs/dev/reference/hooks/createDefinition.md
+++ b/docs/dev/reference/hooks/createDefinition.md
@@ -46,12 +46,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("createDefinition")
+ */
 class CreateDefinitionListener
 {
-    /**
-     * @Hook("createDefinition")
-     */
-    public function onCreateDefinition(string $key, string $value, string $definition, array &$dataSet): ?array
+    public function __invoke(string $key, string $value, string $definition, array &$dataSet): ?array
     {
         if ('border-radius' === $key) {
             return ['border-radius' => $value];

--- a/docs/dev/reference/hooks/createNewUser.md
+++ b/docs/dev/reference/hooks/createNewUser.md
@@ -38,12 +38,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 
+/**
+ * @Hook("createNewUser")
+ */
 class CreateNewUserListener
 {
-    /**
-     * @Hook("createNewUser")
-     */
-    public function onCreateNewUser(int $userId, array $userData, Module $module): void
+    public function __invoke(int $userId, array $userData, Module $module): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/createNewUser.md
+++ b/docs/dev/reference/hooks/createNewUser.md
@@ -37,9 +37,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class CreateNewUserListener implements ServiceAnnotationInterface
+class CreateNewUserListener
 {
     /**
      * @Hook("createNewUser")

--- a/docs/dev/reference/hooks/customizeSearch.md
+++ b/docs/dev/reference/hooks/customizeSearch.md
@@ -47,12 +47,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 
+/**
+ * @Hook("customizeSearch")
+ */
 class CustomizeSearchListener
 {
-    /**
-     * @Hook("customizeSearch")
-     */
-    public function onCustomizeSearch(array &$pageIds, string $keywords, string $queryType, bool $fuzzy, Module $module): void
+    public function __invoke(array &$pageIds, string $keywords, string $queryType, bool $fuzzy, Module $module): void
     {
         // Change the $pageIds array here or do some other adjustments …
     }

--- a/docs/dev/reference/hooks/customizeSearch.md
+++ b/docs/dev/reference/hooks/customizeSearch.md
@@ -46,9 +46,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class CustomizeSearchListener implements ServiceAnnotationInterface
+class CustomizeSearchListener
 {
     /**
      * @Hook("customizeSearch")

--- a/docs/dev/reference/hooks/executePostActions.md
+++ b/docs/dev/reference/hooks/executePostActions.md
@@ -33,12 +33,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\DataContainer;
 
+/**
+ * @Hook("executePostActions")
+ */
 class ExecutePostActionsListener
 {
-    /**
-     * @Hook("executePostActions")
-     */
-    public function onExecutePostActions(string $action, DataContainer $dc): void
+    public function __invoke(string $action, DataContainer $dc): void
     {
         if ('update' === $action) {
             // Do something …

--- a/docs/dev/reference/hooks/executePostActions.md
+++ b/docs/dev/reference/hooks/executePostActions.md
@@ -32,9 +32,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\DataContainer;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ExecutePostActionsListener implements ServiceAnnotationInterface
+class ExecutePostActionsListener
 {
     /**
      * @Hook("executePostActions")

--- a/docs/dev/reference/hooks/executePreActions.md
+++ b/docs/dev/reference/hooks/executePreActions.md
@@ -28,12 +28,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("executePreActions")
+ */
 class ExecutePreActionsListener
 {
-    /**
-     * @Hook("executePreActions")
-     */
-    public function onExecutePreActions(string $action): void
+    public function __invoke(string $action): void
     {
         if ('update' === $action) {
             // Do something …

--- a/docs/dev/reference/hooks/executePreActions.md
+++ b/docs/dev/reference/hooks/executePreActions.md
@@ -27,9 +27,8 @@ a return value.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ExecutePreActionsListener implements ServiceAnnotationInterface
+class ExecutePreActionsListener
 {
     /**
      * @Hook("executePreActions")

--- a/docs/dev/reference/hooks/executeResize.md
+++ b/docs/dev/reference/hooks/executeResize.md
@@ -40,12 +40,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Image;
 
+/**
+ * @Hook("executeResize")
+ */
 class ExecuteResizeListener
 {
-    /**
-     * @Hook("executeResize")
-     */
-    public function onExecuteResize(Image $image): ?string
+    public function __invoke(Image $image): ?string
     {
         if (…) {
             // Do something and return the path to the resized image

--- a/docs/dev/reference/hooks/executeResize.md
+++ b/docs/dev/reference/hooks/executeResize.md
@@ -39,9 +39,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Image;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ExecuteResizeListener implements ServiceAnnotationInterface
+class ExecuteResizeListener
 {
     /**
      * @Hook("executeResize")

--- a/docs/dev/reference/hooks/exportTheme.md
+++ b/docs/dev/reference/hooks/exportTheme.md
@@ -38,12 +38,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\ZipWriter;
 
+/**
+ * @Hook("exportTheme")
+ */
 class ExportThemeListener
 {
-    /**
-     * @Hook("exportTheme")
-     */
-    public function onExportTheme(\DOMDocument $xml, ZipWriter $zipArchive, int $themeId): void
+    public function __invoke(\DOMDocument $xml, ZipWriter $zipArchive, int $themeId): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/exportTheme.md
+++ b/docs/dev/reference/hooks/exportTheme.md
@@ -37,9 +37,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\ZipWriter;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ExportThemeListener implements ServiceAnnotationInterface
+class ExportThemeListener
 {
     /**
      * @Hook("exportTheme")

--- a/docs/dev/reference/hooks/extractThemeFiles.md
+++ b/docs/dev/reference/hooks/extractThemeFiles.md
@@ -42,9 +42,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\ZipReader;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ExtractThemeFilesListener implements ServiceAnnotationInterface
+class ExtractThemeFilesListener
 {
     /**
      * @Hook("extractThemeFiles")

--- a/docs/dev/reference/hooks/extractThemeFiles.md
+++ b/docs/dev/reference/hooks/extractThemeFiles.md
@@ -43,12 +43,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\ZipReader;
 
+/**
+ * @Hook("extractThemeFiles")
+ */
 class ExtractThemeFilesListener
 {
-    /**
-     * @Hook("extractThemeFiles")
-     */
-    public function onExtractThemeFiles(\DOMDocument $xml, ZipReader $zipArchive, int $themeId, array $mapper): void
+    public function __invoke(\DOMDocument $xml, ZipReader $zipArchive, int $themeId, array $mapper): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/generateBreadcrumb.md
+++ b/docs/dev/reference/hooks/generateBreadcrumb.md
@@ -48,12 +48,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 
+/**
+ * @Hook("generateBreadcrumb")
+ */
 class GenerateBreadcrumbListener
 {
-    /**
-     * @Hook("generateBreadcrumb")
-     */
-    public function onGenerateBreadcrumb(array $items, Module $module): array
+    public function __invoke(array $items, Module $module): array
     {
         // Modify $items …
 

--- a/docs/dev/reference/hooks/generateBreadcrumb.md
+++ b/docs/dev/reference/hooks/generateBreadcrumb.md
@@ -47,9 +47,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GenerateBreadcrumbListener implements ServiceAnnotationInterface
+class GenerateBreadcrumbListener
 {
     /**
      * @Hook("generateBreadcrumb")

--- a/docs/dev/reference/hooks/generateFrontendUrl.md
+++ b/docs/dev/reference/hooks/generateFrontendUrl.md
@@ -45,12 +45,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("generateFrontendUrl")
+ */
 class GenerateFrontendUrlListener
 {
-    /**
-     * @Hook("generateFrontendUrl")
-     */
-    public function onGenerateFrontendUrl(array $page, string $params, string $url): string
+    public function __invoke(array $page, string $params, string $url): string
     {
         // Create or modify $url …
 

--- a/docs/dev/reference/hooks/generateFrontendUrl.md
+++ b/docs/dev/reference/hooks/generateFrontendUrl.md
@@ -44,9 +44,8 @@ A string containing the new (or previous) URL.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GenerateFrontendUrlListener implements ServiceAnnotationInterface
+class GenerateFrontendUrlListener
 {
     /**
      * @Hook("generateFrontendUrl")

--- a/docs/dev/reference/hooks/generatePage.md
+++ b/docs/dev/reference/hooks/generatePage.md
@@ -38,9 +38,8 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\PageRegular;
 use Contao\LayoutModel;
 use Contao\PageModel;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GeneratePageListener implements ServiceAnnotationInterface
+class GeneratePageListener
 {
     /**
      * @Hook("generatePage")

--- a/docs/dev/reference/hooks/generatePage.md
+++ b/docs/dev/reference/hooks/generatePage.md
@@ -39,12 +39,12 @@ use Contao\PageRegular;
 use Contao\LayoutModel;
 use Contao\PageModel;
 
+/**
+ * @Hook("generatePage")
+ */
 class GeneratePageListener
 {
-    /**
-     * @Hook("generatePage")
-     */
-    public function onGeneratePage(PageModel $pageModel, LayoutModel $layout, PageRegular $pageRegular): void
+    public function __invoke(PageModel $pageModel, LayoutModel $layout, PageRegular $pageRegular): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/generateXmlFiles.md
+++ b/docs/dev/reference/hooks/generateXmlFiles.md
@@ -20,9 +20,8 @@ It has no parameters and does not expect a return value.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GenerateXmlFilesListener implements ServiceAnnotationInterface
+class GenerateXmlFilesListener
 {
     /**
      * @Hook("generateXmlFiles")

--- a/docs/dev/reference/hooks/generateXmlFiles.md
+++ b/docs/dev/reference/hooks/generateXmlFiles.md
@@ -21,12 +21,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("generateXmlFiles")
+ */
 class GenerateXmlFilesListener
 {
-    /**
-     * @Hook("generateXmlFiles")
-     */
-    public function onGenerateXmlFiles(): void
+    public function __invoke(): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/getAllEvents.md
+++ b/docs/dev/reference/hooks/getAllEvents.md
@@ -53,12 +53,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 
+/**
+ * @Hook("getAllEvents")
+ */
 class GetAllEventsListener
 {
-    /**
-     * @Hook("getAllEvents")
-     */
-    public function onGetAllEvents(array $events, array $calendars, int $timeStart, int $timeEnd, Module $module): array
+    public function __invoke(array $events, array $calendars, int $timeStart, int $timeEnd, Module $module): array
     {
         // Add events to $events or modify the array …
 

--- a/docs/dev/reference/hooks/getAllEvents.md
+++ b/docs/dev/reference/hooks/getAllEvents.md
@@ -52,9 +52,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetAllEventsListener implements ServiceAnnotationInterface
+class GetAllEventsListener
 {
     /**
      * @Hook("getAllEvents")

--- a/docs/dev/reference/hooks/getArticle.md
+++ b/docs/dev/reference/hooks/getArticle.md
@@ -27,9 +27,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\ArticleModel;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetArticleListener implements ServiceAnnotationInterface
+class GetArticleListener
 {
     /**
      * @Hook("getArticle")

--- a/docs/dev/reference/hooks/getArticle.md
+++ b/docs/dev/reference/hooks/getArticle.md
@@ -28,12 +28,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\ArticleModel;
 
+/**
+ * @Hook("getArticle")
+ */
 class GetArticleListener
 {
-    /**
-     * @Hook("getArticle")
-     */
-    public function onGetArticle(ArticleModel $article): void
+    public function __invoke(ArticleModel $article): void
     {
         // Modify $article here …
     }

--- a/docs/dev/reference/hooks/getArticles.md
+++ b/docs/dev/reference/hooks/getArticles.md
@@ -38,9 +38,8 @@ Return a `string` with the article's new content or `null` to keep the default.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetArticlesListener implements ServiceAnnotationInterface
+class GetArticlesListener
 {
     /**
      * @Hook("getArticles")

--- a/docs/dev/reference/hooks/getArticles.md
+++ b/docs/dev/reference/hooks/getArticles.md
@@ -39,12 +39,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("getArticles")
+ */
 class GetArticlesListener
 {
-    /**
-     * @Hook("getArticles")
-     */
-    public function onGetArticles(int $pageId, string $column): ?string
+    public function __invoke(int $pageId, string $column): ?string
     {
         if (10 === (int) $pageId && 'main' === $column) {
             // Generate your custom articles content here

--- a/docs/dev/reference/hooks/getAttributesFromDca.md
+++ b/docs/dev/reference/hooks/getAttributesFromDca.md
@@ -39,12 +39,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("getAttributesFromDca")
+ */
 class GetAttributesFromDcaListener
 {
-    /**
-     * @Hook("getAttributesFromDca")
-     */
-    public function onGetAttributesFromDca(array $attributes, $context = null): array
+    public function __invoke(array $attributes, $context = null): array
     {
         // Modify $attributes here …
 

--- a/docs/dev/reference/hooks/getAttributesFromDca.md
+++ b/docs/dev/reference/hooks/getAttributesFromDca.md
@@ -38,9 +38,8 @@ Return the attributes for the widget as an associative array.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetAttributesFromDcaListener implements ServiceAnnotationInterface
+class GetAttributesFromDcaListener
 {
     /**
      * @Hook("getAttributesFromDca")

--- a/docs/dev/reference/hooks/getCombinedFile.md
+++ b/docs/dev/reference/hooks/getCombinedFile.md
@@ -46,12 +46,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("getCombinedFile")
+ */
 class GetCombinedFileListener
 {
-    /**
-     * @Hook("getCombinedFile")
-     */
-    public function onGetCombinedFile(string $content, string $key, string $mode, array $file): string
+    public function __invoke(string $content, string $key, string $mode, array $file): string
     {
         // Modify $content here …
 

--- a/docs/dev/reference/hooks/getCombinedFile.md
+++ b/docs/dev/reference/hooks/getCombinedFile.md
@@ -45,9 +45,8 @@ The contents of the combined file as a string.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetCombinedFileListener implements ServiceAnnotationInterface
+class GetCombinedFileListener
 {
     /**
      * @Hook("getCombinedFile")

--- a/docs/dev/reference/hooks/getContentElement.md
+++ b/docs/dev/reference/hooks/getContentElement.md
@@ -45,12 +45,12 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\ContentElement;
 use Contao\ContentModel;
 
+/**
+ * @Hook("getContentElement")
+ */
 class GetContentElementListener
 {
-    /**
-     * @Hook("getContentElement")
-     */
-    public function onGetContentElement(ContentModel $contentModel, string $buffer, $element): string
+    public function __invoke(ContentModel $contentModel, string $buffer, $element): string
     {
         // Modify or create new $buffer here …
 

--- a/docs/dev/reference/hooks/getContentElement.md
+++ b/docs/dev/reference/hooks/getContentElement.md
@@ -44,9 +44,8 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\ContentElement;
 use Contao\ContentModel;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetContentElementListener implements ServiceAnnotationInterface
+class GetContentElementListener
 {
     /**
      * @Hook("getContentElement")

--- a/docs/dev/reference/hooks/getCountries.md
+++ b/docs/dev/reference/hooks/getCountries.md
@@ -32,12 +32,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("getCountries")
+ */
 class GetCountriesListener
 {
-    /**
-     * @Hook("getCountries")
-     */
-    public function onGetCountries(array &$translatedCountries, array $allCountries): void
+    public function __invoke(array &$translatedCountries, array $allCountries): void
     {
         // Codes for the european countries
         $europeanCountryCodes = ['de', 'at', 'ch' /*, … */];

--- a/docs/dev/reference/hooks/getCountries.md
+++ b/docs/dev/reference/hooks/getCountries.md
@@ -31,9 +31,8 @@ The `getCountries` hook allows to modify the system's list of countries.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetCountriesListener implements ServiceAnnotationInterface
+class GetCountriesListener
 {
     /**
      * @Hook("getCountries")

--- a/docs/dev/reference/hooks/getForm.md
+++ b/docs/dev/reference/hooks/getForm.md
@@ -38,12 +38,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\FormModel;
 
+/**
+ * @Hook("getForm")
+ */
 class GetFormListener
 {
-    /**
-     * @Hook("getForm")
-     */
-    public function onGetForm(FormModel $form, string $buffer): string
+    public function __invoke(FormModel $form, string $buffer): string
     {
         if (2 === (int) $form->id) {
             // Do something …

--- a/docs/dev/reference/hooks/getForm.md
+++ b/docs/dev/reference/hooks/getForm.md
@@ -37,9 +37,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\FormModel;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetFormListener implements ServiceAnnotationInterface
+class GetFormListener
 {
     /**
      * @Hook("getForm")

--- a/docs/dev/reference/hooks/getFrontendModule.md
+++ b/docs/dev/reference/hooks/getFrontendModule.md
@@ -41,9 +41,8 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 use Contao\ModuleModel;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetFrontendModuleListener implements ServiceAnnotationInterface
+class GetFrontendModuleListener
 {
     /**
      * @Hook("getFrontendModule")

--- a/docs/dev/reference/hooks/getFrontendModule.md
+++ b/docs/dev/reference/hooks/getFrontendModule.md
@@ -42,12 +42,12 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 use Contao\ModuleModel;
 
+/**
+ * @Hook("getFrontendModule")
+ */
 class GetFrontendModuleListener
 {
-    /**
-     * @Hook("getFrontendModule")
-     */
-    public function onGetFrontendModule(ModuleModel $model, string $buffer, Module $module): string
+    public function __invoke(ModuleModel $model, string $buffer, Module $module): string
     {
         // Wrap a specific module in an additional wrapper div
         if (2 === (int) $model->id) {

--- a/docs/dev/reference/hooks/getImage.md
+++ b/docs/dev/reference/hooks/getImage.md
@@ -72,12 +72,12 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Image;
 use Contao\File;
 
+/**
+ * @Hook("getImage")
+ */
 class GetImageListener
 {
-    /**
-     * @Hook("getImage")
-     */
-    public function onGetImage(
+    public function __invoke(
         string $originalPath, 
         int $width, 
         int $height, 

--- a/docs/dev/reference/hooks/getImage.md
+++ b/docs/dev/reference/hooks/getImage.md
@@ -71,9 +71,8 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Image;
 use Contao\File;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetImageListener implements ServiceAnnotationInterface
+class GetImageListener
 {
     /**
      * @Hook("getImage")

--- a/docs/dev/reference/hooks/getLanguages.md
+++ b/docs/dev/reference/hooks/getLanguages.md
@@ -42,9 +42,8 @@ The `getLanguages` hook allows to modify the system's list of languages.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetLanguagesListener implements ServiceAnnotationInterface
+class GetLanguagesListener
 {
     /**
      * @Hook("getLanguages")

--- a/docs/dev/reference/hooks/getLanguages.md
+++ b/docs/dev/reference/hooks/getLanguages.md
@@ -43,12 +43,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("getLanguages")
+ */
 class GetLanguagesListener
 {
-    /**
-     * @Hook("getLanguages")
-     */
-    public function onGetLanguages(array &$compiledLanguages, array $languages, array $langsNative, bool $installedOnly): void
+    public function __invoke(array &$compiledLanguages, array $languages, array $langsNative, bool $installedOnly): void
     {
         // Make your changes to $compiledLanguages
     }

--- a/docs/dev/reference/hooks/getPageIdFromUrl.md
+++ b/docs/dev/reference/hooks/getPageIdFromUrl.md
@@ -40,9 +40,8 @@ Return the (modified) array of URL fragments.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetPageIdFromUrlListener implements ServiceAnnotationInterface
+class GetPageIdFromUrlListener
 {
     /**
      * @Hook("getPageIdFromUrl")

--- a/docs/dev/reference/hooks/getPageIdFromUrl.md
+++ b/docs/dev/reference/hooks/getPageIdFromUrl.md
@@ -41,12 +41,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("getPageIdFromUrl")
+ */
 class GetPageIdFromUrlListener
 {
-    /**
-     * @Hook("getPageIdFromUrl")
-     */
-    public function onGetPageIdFromUrl(array $fragments): array
+    public function __invoke(array $fragments): array
     {
         // Analyze the fragments
         if (…) {

--- a/docs/dev/reference/hooks/getPageLayout.md
+++ b/docs/dev/reference/hooks/getPageLayout.md
@@ -40,12 +40,12 @@ use Contao\PageRegular;
 use Contao\LayoutModel;
 use Contao\PageModel;
 
+/**
+ * @Hook("getPageLayout")
+ */
 class GetPageLayoutListener
 {
-    /**
-     * @Hook("getPageLayout")
-     */
-    public function onGetPageLayout(PageModel $pageModel, LayoutModel $layout, PageRegular $pageRegular): void
+    public function __invoke(PageModel $pageModel, LayoutModel $layout, PageRegular $pageRegular): void
     {
         // Modify the page or layout object
     }

--- a/docs/dev/reference/hooks/getPageLayout.md
+++ b/docs/dev/reference/hooks/getPageLayout.md
@@ -39,9 +39,8 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\PageRegular;
 use Contao\LayoutModel;
 use Contao\PageModel;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetPageLayoutListener implements ServiceAnnotationInterface
+class GetPageLayoutListener
 {
     /**
      * @Hook("getPageLayout")

--- a/docs/dev/reference/hooks/getPageStatusIcon.md
+++ b/docs/dev/reference/hooks/getPageStatusIcon.md
@@ -38,9 +38,8 @@ the unchanged second parameter.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetPageStatusIconListener implements ServiceAnnotationInterface
+class GetPageStatusIconListener
 {
     /**
      * @Hook("getPageStatusIcon")

--- a/docs/dev/reference/hooks/getPageStatusIcon.md
+++ b/docs/dev/reference/hooks/getPageStatusIcon.md
@@ -39,12 +39,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("getPageStatusIcon")
+ */
 class GetPageStatusIconListener
 {
-    /**
-     * @Hook("getPageStatusIcon")
-     */
-    public function onGetPageStatusIcon($page, string $image): string
+    public function __invoke($page, string $image): string
     {
         if ('my_page' === $page->type) {
             return 'path/to/custom_icon.svg';

--- a/docs/dev/reference/hooks/getRootPageFromUrl.md
+++ b/docs/dev/reference/hooks/getRootPageFromUrl.md
@@ -27,12 +27,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("getRootPageFromUrl")
+ */
 class GetRootPageFromUrlListener
 {
-    /**
-     * @Hook("getRootPageFromUrl")
-     */
-    public function onGetRootPageFromUrl(): ?\Contao\PageModel
+    public function __invoke(): ?\Contao\PageModel
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/getRootPageFromUrl.md
+++ b/docs/dev/reference/hooks/getRootPageFromUrl.md
@@ -26,9 +26,8 @@ for searching the root page.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetRootPageFromUrlListener implements ServiceAnnotationInterface
+class GetRootPageFromUrlListener
 {
     /**
      * @Hook("getRootPageFromUrl")

--- a/docs/dev/reference/hooks/getSearchablePages.md
+++ b/docs/dev/reference/hooks/getSearchablePages.md
@@ -48,9 +48,8 @@ sitemap or only for the search index.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetSearchablePagesListener implements ServiceAnnotationInterface
+class GetSearchablePagesListener
 {
     /**
      * @Hook("getSearchablePages")

--- a/docs/dev/reference/hooks/getSearchablePages.md
+++ b/docs/dev/reference/hooks/getSearchablePages.md
@@ -49,12 +49,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("getSearchablePages")
+ */
 class GetSearchablePagesListener
 {
-    /**
-     * @Hook("getSearchablePages")
-     */
-    public function onGetSearchablePages(array $pages, int $rootId = null, bool $isSitemap = false, string $language = null): array
+    public function __invoke(array $pages, int $rootId = null, bool $isSitemap = false, string $language = null): array
     {
         // Modify the $pages array …
 

--- a/docs/dev/reference/hooks/getSystemMessages.md
+++ b/docs/dev/reference/hooks/getSystemMessages.md
@@ -25,9 +25,8 @@ HTML markup) or an empty string.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetSystemMessagesListener implements ServiceAnnotationInterface
+class GetSystemMessagesListener
 {
     /**
      * @Hook("getSystemMessages")

--- a/docs/dev/reference/hooks/getSystemMessages.md
+++ b/docs/dev/reference/hooks/getSystemMessages.md
@@ -26,12 +26,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("getSystemMessages")
+ */
 class GetSystemMessagesListener
 {
-    /**
-     * @Hook("getSystemMessages")
-     */
-    public function onGetSystemMessages(): string
+    public function __invoke(): string
     {
         // Display a warning if the system admin's email is not set
         if (empty($GLOBALS['TL_ADMIN_EMAIL'])) {

--- a/docs/dev/reference/hooks/getUserNavigation.md
+++ b/docs/dev/reference/hooks/getUserNavigation.md
@@ -36,9 +36,8 @@ Add your custom modules to the list and return the array of back end modules.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class GetUserNavigationListener implements ServiceAnnotationInterface
+class GetUserNavigationListener
 {
     /**
      * @Hook("getUserNavigation")

--- a/docs/dev/reference/hooks/getUserNavigation.md
+++ b/docs/dev/reference/hooks/getUserNavigation.md
@@ -37,12 +37,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("getUserNavigation")
+ */
 class GetUserNavigationListener
 {
-    /**
-     * @Hook("getUserNavigation")
-     */
-    public function onGetUserNavigation(array $modules, bool $showAll): array
+    public function __invoke(array $modules, bool $showAll): array
     {
         // Add custom navigation item to the Contao website
         $modules['system']['modules']['contao'] = [

--- a/docs/dev/reference/hooks/importUser.md
+++ b/docs/dev/reference/hooks/importUser.md
@@ -46,9 +46,8 @@ you added the user to the respective table, or `false` if not.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ImportUserListener implements ServiceAnnotationInterface
+class ImportUserListener
 {
     /**
      * @Hook("importUser")

--- a/docs/dev/reference/hooks/importUser.md
+++ b/docs/dev/reference/hooks/importUser.md
@@ -47,12 +47,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("importUser")
+ */
 class ImportUserListener
 {
-    /**
-     * @Hook("importUser")
-     */
-    public function onImportUser(string $username, string $password, string $table): bool
+    public function __invoke(string $username, string $password, string $table): bool
     {
         if ('tl_member' === $table) {
             // Import user from an LDAP server

--- a/docs/dev/reference/hooks/indexPage.md
+++ b/docs/dev/reference/hooks/indexPage.md
@@ -35,9 +35,8 @@ and does not expect a return value.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class IndexPageListener implements ServiceAnnotationInterface
+class IndexPageListener
 {
     /**
      * @Hook("indexPage")

--- a/docs/dev/reference/hooks/indexPage.md
+++ b/docs/dev/reference/hooks/indexPage.md
@@ -36,12 +36,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("indexPage")
+ */
 class IndexPageListener
 {
-    /**
-     * @Hook("indexPage")
-     */
-    public function onIndexPage(string $content, array $pageData, array &$indexData): void
+    public function __invoke(string $content, array $pageData, array &$indexData): void
     {
         // Modify $indexData which will eventually be stored in tl_search
     }

--- a/docs/dev/reference/hooks/initializeSystem.md
+++ b/docs/dev/reference/hooks/initializeSystem.md
@@ -20,12 +20,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("initializeSystem")
+ */
 class InitializeSystemListener
 {
-    /**
-     * @Hook("initializeSystem")
-     */
-    public function onInitializeSystem(): void
+    public function __invoke(): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/initializeSystem.md
+++ b/docs/dev/reference/hooks/initializeSystem.md
@@ -19,9 +19,8 @@ process is finished and before the request processing is started.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class InitializeSystemListener implements ServiceAnnotationInterface
+class InitializeSystemListener
 {
     /**
      * @Hook("initializeSystem")

--- a/docs/dev/reference/hooks/insertTagFlags.md
+++ b/docs/dev/reference/hooks/insertTagFlags.md
@@ -69,9 +69,8 @@ how to handle the `date` insert tag and the `utf8_strtoupper` flag. The unknown
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class InsertTagFlagsListener implements ServiceAnnotationInterface
+class InsertTagFlagsListener
 {
     /**
      * @Hook("insertTagFlags")

--- a/docs/dev/reference/hooks/insertTagFlags.md
+++ b/docs/dev/reference/hooks/insertTagFlags.md
@@ -70,12 +70,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("insertTagFlags")
+ */
 class InsertTagFlagsListener
 {
-    /**
-     * @Hook("insertTagFlags")
-     */
-    public function onInsertTagFlags(
+    public function __invoke(
         string $flag, 
         string $tag, 
         string $cachedValue, 

--- a/docs/dev/reference/hooks/isAllowedToEditComment.md
+++ b/docs/dev/reference/hooks/isAllowedToEditComment.md
@@ -38,9 +38,8 @@ is prohibited or your function is not responsible for this comment.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class IsAllowedToEditCommentListener implements ServiceAnnotationInterface
+class IsAllowedToEditCommentListener
 {
     /**
      * @Hook("isAllowedToEditComment")

--- a/docs/dev/reference/hooks/isAllowedToEditComment.md
+++ b/docs/dev/reference/hooks/isAllowedToEditComment.md
@@ -39,12 +39,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("isAllowedToEditComment")
+ */
 class IsAllowedToEditCommentListener
 {
-    /**
-     * @Hook("isAllowedToEditComment")
-     */
-    public function onIsAllowedToEditComment(int $parentId, string $parentTable): bool
+    public function __invoke(int $parentId, string $parentTable): bool
     {
         // Check the access to your custom module
         if (\Contao\BackendUser::getInstance()->hasAccess('custom', 'modules')) {

--- a/docs/dev/reference/hooks/isVisibleElement.md
+++ b/docs/dev/reference/hooks/isVisibleElement.md
@@ -42,9 +42,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Model;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class IsVisibleElementListener implements ServiceAnnotationInterface
+class IsVisibleElementListener
 {
     /**
      * @Hook("isVisibleElement")

--- a/docs/dev/reference/hooks/isVisibleElement.md
+++ b/docs/dev/reference/hooks/isVisibleElement.md
@@ -43,12 +43,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Model;
 
+/**
+ * @Hook("isVisibleElement")
+ */
 class IsVisibleElementListener
 {
-    /**
-     * @Hook("isVisibleElement")
-     */
-    public function onIsVisibleElement(Model $element, bool $isVisible): bool
+    public function __invoke(Model $element, bool $isVisible): bool
     {
         if ($element instanceof \Contao\ContentModel) {
             // Check if this content element can be shown

--- a/docs/dev/reference/hooks/listComments.md
+++ b/docs/dev/reference/hooks/listComments.md
@@ -33,9 +33,8 @@ responsible for the source table.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ListCommentsListener implements ServiceAnnotationInterface
+class ListCommentsListener
 {
     /**
      * @Hook("listComments")

--- a/docs/dev/reference/hooks/listComments.md
+++ b/docs/dev/reference/hooks/listComments.md
@@ -34,12 +34,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("listComments")
+ */
 class ListCommentsListener
 {
-    /**
-     * @Hook("listComments")
-     */
-    public function onListComments(array $comment): string
+    public function __invoke(array $comment): string
     {
         if ('tl_mytable' === $comment['source']) {
             return '<a href="contao/main.php?do=…">' . $comment['title'] . '</a>';

--- a/docs/dev/reference/hooks/loadDataContainer.md
+++ b/docs/dev/reference/hooks/loadDataContainer.md
@@ -26,9 +26,8 @@ the file name as argument and does not expect a return value.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class LoadDataContainerListener implements ServiceAnnotationInterface
+class LoadDataContainerListener
 {
     /**
      * @Hook("loadDataContainer")

--- a/docs/dev/reference/hooks/loadDataContainer.md
+++ b/docs/dev/reference/hooks/loadDataContainer.md
@@ -27,12 +27,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("loadDataContainer")
+ */
 class LoadDataContainerListener
 {
-    /**
-     * @Hook("loadDataContainer")
-     */
-    public function onLoadDataContainer(string $table): void
+    public function __invoke(string $table): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/loadFormField.md
+++ b/docs/dev/reference/hooks/loadFormField.md
@@ -50,12 +50,12 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Form;
 use Contao\Widget;
 
+/**
+ * @Hook("loadFormField")
+ */
 class LoadFormFieldListener
 {
-    /**
-     * @Hook("loadFormField")
-     */
-    public function onLoadFormField(Widget $widget, string $formId, array $formData, Form $form): Widget
+    public function __invoke(Widget $widget, string $formId, array $formData, Form $form): Widget
     {
         if ('myForm' === $formId) {
             $widget->class.= ' myclass';

--- a/docs/dev/reference/hooks/loadFormField.md
+++ b/docs/dev/reference/hooks/loadFormField.md
@@ -49,9 +49,8 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Form;
 use Contao\Widget;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class LoadFormFieldListener implements ServiceAnnotationInterface
+class LoadFormFieldListener
 {
     /**
      * @Hook("loadFormField")

--- a/docs/dev/reference/hooks/loadLanguageFile.md
+++ b/docs/dev/reference/hooks/loadLanguageFile.md
@@ -37,12 +37,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("loadLanguageFile")
+ */
 class LoadLanguageFileListener
 {
-    /**
-     * @Hook("loadLanguageFile")
-     */
-    public function onLoadLanguageFile(string $name, string $currentLanguage, string $cacheKey): void
+    public function __invoke(string $name, string $currentLanguage, string $cacheKey): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/loadLanguageFile.md
+++ b/docs/dev/reference/hooks/loadLanguageFile.md
@@ -36,9 +36,8 @@ return value.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class LoadLanguageFileListener implements ServiceAnnotationInterface
+class LoadLanguageFileListener
 {
     /**
      * @Hook("loadLanguageFile")

--- a/docs/dev/reference/hooks/loadPageDetails.md
+++ b/docs/dev/reference/hooks/loadPageDetails.md
@@ -33,12 +33,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\PageModel;
 
+/**
+ * @Hook("loadPageDetails")
+ */
 class LoadPageDetailsListener
 {
-    /**
-     * @Hook("loadPageDetails")
-     */
-    public function onLoadPageDetails(array $parentModels, PageModel $page): void
+    public function __invoke(array $parentModels, PageModel $page): void
     {
         // Add some additional date from the root page to the processed page
         if (count($parentModels) > 0) {

--- a/docs/dev/reference/hooks/loadPageDetails.md
+++ b/docs/dev/reference/hooks/loadPageDetails.md
@@ -32,9 +32,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\PageModel;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class LoadPageDetailsListener implements ServiceAnnotationInterface
+class LoadPageDetailsListener
 {
     /**
      * @Hook("loadPageDetails")

--- a/docs/dev/reference/hooks/modifyFrontendPage.md
+++ b/docs/dev/reference/hooks/modifyFrontendPage.md
@@ -43,9 +43,8 @@ Return the original `$buffer` or override with your custom modification.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ModifyFrontendPageListener implements ServiceAnnotationInterface
+class ModifyFrontendPageListener
 {
     /**
      * @Hook("modifyFrontendPage")

--- a/docs/dev/reference/hooks/modifyFrontendPage.md
+++ b/docs/dev/reference/hooks/modifyFrontendPage.md
@@ -44,12 +44,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("modifyFrontendPage")
+ */
 class ModifyFrontendPageListener
 {
-    /**
-     * @Hook("modifyFrontendPage")
-     */
-    public function onModifyFrontendPage(string $buffer, string $templateName): string
+    public function __invoke(string $buffer, string $templateName): string
     {
         if ('fe_page' === $templateName) {
             // Modify $buffer

--- a/docs/dev/reference/hooks/newsListCountItems.md
+++ b/docs/dev/reference/hooks/newsListCountItems.md
@@ -42,9 +42,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class NewsListCountItemsListener implements ServiceAnnotationInterface
+class NewsListCountItemsListener
 {
     /**
      * @Hook("newsListCountItems")

--- a/docs/dev/reference/hooks/newsListCountItems.md
+++ b/docs/dev/reference/hooks/newsListCountItems.md
@@ -43,12 +43,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 
+/**
+ * @Hook("newsListCountItems")
+ */
 class NewsListCountItemsListener
 {
-    /**
-     * @Hook("newsListCountItems")
-     */
-    public function onNewsListCountItems(array $newsArchives, bool $featuredOnly, Module $module)
+    public function __invoke(array $newsArchives, bool $featuredOnly, Module $module)
     {
         if (…) {
             // Query the database and return the number of records

--- a/docs/dev/reference/hooks/newsListFetchItems.md
+++ b/docs/dev/reference/hooks/newsListFetchItems.md
@@ -50,9 +50,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class NewsListFetchItemsListener implements ServiceAnnotationInterface
+class NewsListFetchItemsListener
 {
     /**
      * @Hook("newsListFetchItems")

--- a/docs/dev/reference/hooks/newsListFetchItems.md
+++ b/docs/dev/reference/hooks/newsListFetchItems.md
@@ -51,12 +51,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 
+/**
+ * @Hook("newsListFetchItems")
+ */
 class NewsListFetchItemsListener
 {
-    /**
-     * @Hook("newsListFetchItems")
-     */
-    public function onNewsListFetchItems(array $newsArchives, ?bool $featuredOnly, int $limit, int $offset, Module $module)
+    public function __invoke(array $newsArchives, ?bool $featuredOnly, int $limit, int $offset, Module $module)
     {
         if (…) {
             // Query the database and return the records

--- a/docs/dev/reference/hooks/outputBackendTemplate.md
+++ b/docs/dev/reference/hooks/outputBackendTemplate.md
@@ -36,9 +36,8 @@ Return the original `$buffer` or return your custom modification.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class OutputBackendTemplateListener implements ServiceAnnotationInterface
+class OutputBackendTemplateListener
 {
     /**
      * @Hook("outputBackendTemplate")

--- a/docs/dev/reference/hooks/outputBackendTemplate.md
+++ b/docs/dev/reference/hooks/outputBackendTemplate.md
@@ -37,12 +37,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("outputBackendTemplate")
+ */
 class OutputBackendTemplateListener
 {
-    /**
-     * @Hook("outputBackendTemplate")
-     */
-    public function onOutputBackendTemplate(string $buffer, string $template): string
+    public function __invoke(string $buffer, string $template): string
     {
         if ($template === 'be_main') {
             // Modify $buffer

--- a/docs/dev/reference/hooks/outputFrontendTemplate.md
+++ b/docs/dev/reference/hooks/outputFrontendTemplate.md
@@ -42,9 +42,8 @@ Return the original `$buffer` or override with your custom modification.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class OutputFrontendTemplateListener implements ServiceAnnotationInterface
+class OutputFrontendTemplateListener
 {
     /**
      * @Hook("outputFrontendTemplate")

--- a/docs/dev/reference/hooks/outputFrontendTemplate.md
+++ b/docs/dev/reference/hooks/outputFrontendTemplate.md
@@ -43,12 +43,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("outputFrontendTemplate")
+ */
 class OutputFrontendTemplateListener
 {
-    /**
-     * @Hook("outputFrontendTemplate")
-     */
-    public function onOutputFrontendTemplate(string $buffer, string $template): string
+    public function __invoke(string $buffer, string $template): string
     {
         if ($template === 'fe_page') {
             // Modify $buffer

--- a/docs/dev/reference/hooks/parseArticles.md
+++ b/docs/dev/reference/hooks/parseArticles.md
@@ -39,12 +39,12 @@ use Contao\FrontendTemplate;
 use Contao\Module;
 use Contao\UserModel;
 
+/**
+ * @Hook("parseArticles")
+ */
 class ParseArticlesListener
 {
-    /**
-     * @Hook("parseArticles")
-     */
-    public function onParseArticles(FrontendTemplate $template, array $newsEntry, Module $module): void
+    public function __invoke(FrontendTemplate $template, array $newsEntry, Module $module): void
     {
         // Remove the default "by …" from Contao
         $template->author = UserModel::findByPk($newsEntry['author'])->name;

--- a/docs/dev/reference/hooks/parseArticles.md
+++ b/docs/dev/reference/hooks/parseArticles.md
@@ -38,9 +38,8 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\FrontendTemplate;
 use Contao\Module;
 use Contao\UserModel;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ParseArticlesListener implements ServiceAnnotationInterface
+class ParseArticlesListener
 {
     /**
      * @Hook("parseArticles")

--- a/docs/dev/reference/hooks/parseBackendTemplate.md
+++ b/docs/dev/reference/hooks/parseBackendTemplate.md
@@ -36,9 +36,8 @@ Return the original `$buffer` or override with your custom modification.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ParseBackendTemplateListener implements ServiceAnnotationInterface
+class ParseBackendTemplateListener
 {
     /**
      * @Hook("parseBackendTemplate")

--- a/docs/dev/reference/hooks/parseBackendTemplate.md
+++ b/docs/dev/reference/hooks/parseBackendTemplate.md
@@ -37,12 +37,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("parseBackendTemplate")
+ */
 class ParseBackendTemplateListener
 {
-    /**
-     * @Hook("parseBackendTemplate")
-     */
-    public function onParseBackendTemplate(string $buffer, string $template): string
+    public function __invoke(string $buffer, string $template): string
     {
         if ('be_main' === $template) {
             // Modify $buffer

--- a/docs/dev/reference/hooks/parseDate.md
+++ b/docs/dev/reference/hooks/parseDate.md
@@ -40,12 +40,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("parseDate")
+ */
 class ParseDateListener
 {
-    /**
-     * @Hook("parseDate")
-     */
-    public function onParseDate(string $formattedDate, string $format, ?int $timestamp): string
+    public function __invoke(string $formattedDate, string $format, ?int $timestamp): string
     {
         // Modify or create your own formatted date …
 

--- a/docs/dev/reference/hooks/parseDate.md
+++ b/docs/dev/reference/hooks/parseDate.md
@@ -39,9 +39,8 @@ A string containing the formatted date.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ParseDateListener implements ServiceAnnotationInterface
+class ParseDateListener
 {
     /**
      * @Hook("parseDate")

--- a/docs/dev/reference/hooks/parseFrontendTemplate.md
+++ b/docs/dev/reference/hooks/parseFrontendTemplate.md
@@ -37,9 +37,8 @@ modification.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ParseFrontendTemplateListener implements ServiceAnnotationInterface
+class ParseFrontendTemplateListener
 {
     /**
      * @Hook("parseFrontendTemplate")

--- a/docs/dev/reference/hooks/parseFrontendTemplate.md
+++ b/docs/dev/reference/hooks/parseFrontendTemplate.md
@@ -38,12 +38,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("parseFrontendTemplate")
+ */
 class ParseFrontendTemplateListener
 {
-    /**
-     * @Hook("parseFrontendTemplate")
-     */
-    public function onParseFrontendTemplate(string $buffer, string $template): string
+    public function __invoke(string $buffer, string $template): string
     {
         if ('ce_text' === $template) {
             // Modify $buffer

--- a/docs/dev/reference/hooks/parseTemplate.md
+++ b/docs/dev/reference/hooks/parseTemplate.md
@@ -28,12 +28,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Template;
 
+/**
+ * @Hook("parseTemplate")
+ */
 class ParseTemplateListener
 {
-    /**
-     * @Hook("parseTemplate")
-     */
-    public function onParseTemplate(Template $template): void
+    public function __invoke(Template $template): void
     {
         if ('fe_page' === $template->getName()) {
             // Do something …

--- a/docs/dev/reference/hooks/parseTemplate.md
+++ b/docs/dev/reference/hooks/parseTemplate.md
@@ -27,9 +27,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Template;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ParseTemplateListener implements ServiceAnnotationInterface
+class ParseTemplateListener
 {
     /**
      * @Hook("parseTemplate")

--- a/docs/dev/reference/hooks/parseWidget.md
+++ b/docs/dev/reference/hooks/parseWidget.md
@@ -36,9 +36,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Widget;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ParseWidgetListener implements ServiceAnnotationInterface
+class ParseWidgetListener
 {
     /**
      * @Hook("parseWidget")

--- a/docs/dev/reference/hooks/parseWidget.md
+++ b/docs/dev/reference/hooks/parseWidget.md
@@ -37,12 +37,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Widget;
 
+/**
+ * @Hook("parseWidget")
+ */
 class ParseWidgetListener
 {
-    /**
-     * @Hook("parseWidget")
-     */
-    public function onParseWidget(string $buffer, Widget $widget): string
+    public function __invoke(string $buffer, Widget $widget): string
     {
         // Do something …
         

--- a/docs/dev/reference/hooks/postAuthenticate.md
+++ b/docs/dev/reference/hooks/postAuthenticate.md
@@ -35,12 +35,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\User;
 
+/**
+ * @Hook("postAuthenticate")
+ */
 class PostAuthenticateListener
 {
-    /**
-     * @Hook("postAuthenticate")
-     */
-    public function onPostAuthenticate(User $user): void
+    public function __invoke(User $user): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/postAuthenticate.md
+++ b/docs/dev/reference/hooks/postAuthenticate.md
@@ -34,9 +34,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\User;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class PostAuthenticateListener implements ServiceAnnotationInterface
+class PostAuthenticateListener
 {
     /**
      * @Hook("postAuthenticate")

--- a/docs/dev/reference/hooks/postDownload.md
+++ b/docs/dev/reference/hooks/postDownload.md
@@ -27,9 +27,8 @@ not expect a return value.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class PostDownloadListener implements ServiceAnnotationInterface
+class PostDownloadListener
 {
     /**
      * @Hook("postDownload")

--- a/docs/dev/reference/hooks/postDownload.md
+++ b/docs/dev/reference/hooks/postDownload.md
@@ -28,12 +28,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("postDownload")
+ */
 class PostDownloadListener
 {
-    /**
-     * @Hook("postDownload")
-     */
-    public function onPostDownload(string $file): void
+    public function __invoke(string $file): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/postLogin.md
+++ b/docs/dev/reference/hooks/postLogin.md
@@ -35,12 +35,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\User;
 
+/**
+ * @Hook("postLogin")
+ */
 class PostLoginListener
 {
-    /**
-     * @Hook("postLogin")
-     */
-    public function onPostLogin(User $user): void
+    public function __invoke(User $user): void
     {
         if ($user instanceof \Contao\FrontendUser) {
             // Do something with the front end user $user  

--- a/docs/dev/reference/hooks/postLogin.md
+++ b/docs/dev/reference/hooks/postLogin.md
@@ -34,9 +34,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\User;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class PostLoginListener implements ServiceAnnotationInterface
+class PostLoginListener
 {
     /**
      * @Hook("postLogin")

--- a/docs/dev/reference/hooks/postLogout.md
+++ b/docs/dev/reference/hooks/postLogout.md
@@ -31,9 +31,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\User;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class PostLogoutListener implements ServiceAnnotationInterface
+class PostLogoutListener
 {
     /**
      * @Hook("postLogout")

--- a/docs/dev/reference/hooks/postLogout.md
+++ b/docs/dev/reference/hooks/postLogout.md
@@ -32,12 +32,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\User;
 
+/**
+ * @Hook("postLogout")
+ */
 class PostLogoutListener
 {
-    /**
-     * @Hook("postLogout")
-     */
-    public function onPostLogout(User $user): void
+    public function __invoke(User $user): void
     {
         if ($user instanceof \Contao\FrontendUser) {
             // Do something with the front end user $user  

--- a/docs/dev/reference/hooks/postUpload.md
+++ b/docs/dev/reference/hooks/postUpload.md
@@ -34,12 +34,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("postUpload")
+ */
 class PostUploadListener
 {
-    /**
-     * @Hook("postUpload")
-     */
-    public function onPostUpload(array $files): void
+    public function __invoke(array $files): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/postUpload.md
+++ b/docs/dev/reference/hooks/postUpload.md
@@ -33,9 +33,8 @@ This hook can also be implemented as an anonymous function.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class PostUploadListener implements ServiceAnnotationInterface
+class PostUploadListener
 {
     /**
      * @Hook("postUpload")

--- a/docs/dev/reference/hooks/prepareFormData.md
+++ b/docs/dev/reference/hooks/prepareFormData.md
@@ -43,12 +43,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Form;
 
+/**
+ * @Hook("prepareFormData")
+ */
 class PrepareFormDataListener
 {
-    /**
-     * @Hook("prepareFormData")
-     */
-    public function onPrepareFormData(array &$submittedData, array $labels, array $fields, Form $form): void
+    public function __invoke(array &$submittedData, array $labels, array $fields, Form $form): void
     {
         // This calculates a deadline from a given timestamp
         // and stores it as deadline in $submittedData.

--- a/docs/dev/reference/hooks/prepareFormData.md
+++ b/docs/dev/reference/hooks/prepareFormData.md
@@ -42,9 +42,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Form;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class PrepareFormDataListener implements ServiceAnnotationInterface
+class PrepareFormDataListener
 {
     /**
      * @Hook("prepareFormData")

--- a/docs/dev/reference/hooks/printArticleAsPdf.md
+++ b/docs/dev/reference/hooks/printArticleAsPdf.md
@@ -33,9 +33,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\ModuleArticle;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class PrintArticleAsPdfListener implements ServiceAnnotationInterface
+class PrintArticleAsPdfListener
 {
     /**
      * @Hook("printArticleAsPdf")

--- a/docs/dev/reference/hooks/printArticleAsPdf.md
+++ b/docs/dev/reference/hooks/printArticleAsPdf.md
@@ -34,12 +34,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\ModuleArticle;
 
+/**
+ * @Hook("printArticleAsPdf")
+ */
 class PrintArticleAsPdfListener
 {
-    /**
-     * @Hook("printArticleAsPdf")
-     */
-    public function onPrintArticleAsPdf(string $articleContent, ModuleArticle $module): void
+    public function __invoke(string $articleContent, ModuleArticle $module): void
     {
         // Trigger your own PDF engine and exit
         exit;

--- a/docs/dev/reference/hooks/processFormData.md
+++ b/docs/dev/reference/hooks/processFormData.md
@@ -45,12 +45,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Form;
 
+/**
+ * @Hook("processFormData")
+ */
 class ProcessFormDataListener
 {
-    /**
-     * @Hook("processFormData")
-     */
-    public function onProcessFormData(
+    public function __invoke(
         array $submittedData, 
         array $formData, 
         ?array $files, 

--- a/docs/dev/reference/hooks/processFormData.md
+++ b/docs/dev/reference/hooks/processFormData.md
@@ -44,9 +44,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Form;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ProcessFormDataListener implements ServiceAnnotationInterface
+class ProcessFormDataListener
 {
     /**
      * @Hook("processFormData")

--- a/docs/dev/reference/hooks/removeOldFeeds.md
+++ b/docs/dev/reference/hooks/removeOldFeeds.md
@@ -27,9 +27,8 @@ nothing to keep.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class RemoveOldFeedsListener implements ServiceAnnotationInterface
+class RemoveOldFeedsListener
 {
     /**
      * @Hook("removeOldFeeds")

--- a/docs/dev/reference/hooks/removeOldFeeds.md
+++ b/docs/dev/reference/hooks/removeOldFeeds.md
@@ -28,12 +28,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("removeOldFeeds")
+ */
 class RemoveOldFeedsListener
 {
-    /**
-     * @Hook("removeOldFeeds")
-     */
-    public function onRemoveOldFeeds(): array
+    public function __invoke(): array
     {
         // Return the names of your custom feeds which should not be removed
         return ['custom'];

--- a/docs/dev/reference/hooks/removeRecipient.md
+++ b/docs/dev/reference/hooks/removeRecipient.md
@@ -32,12 +32,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("removeRecipient")
+ */
 class RemoveRecipientListener
 {
-    /**
-     * @Hook("removeRecipient")
-     */
-    public function onRemoveRecipient(string $email, array $channels): void
+    public function __invoke(string $email, array $channels): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/removeRecipient.md
+++ b/docs/dev/reference/hooks/removeRecipient.md
@@ -31,9 +31,8 @@ a return value.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class RemoveRecipientListener implements ServiceAnnotationInterface
+class RemoveRecipientListener
 {
     /**
      * @Hook("removeRecipient")

--- a/docs/dev/reference/hooks/replaceDynamicScriptTags.md
+++ b/docs/dev/reference/hooks/replaceDynamicScriptTags.md
@@ -43,9 +43,8 @@ A string containing the (modified) bufffer content.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ReplaceDynamicScriptTagsListener implements ServiceAnnotationInterface
+class ReplaceDynamicScriptTagsListener
 {
     /**
      * @Hook("replaceDynamicScriptTags")

--- a/docs/dev/reference/hooks/replaceDynamicScriptTags.md
+++ b/docs/dev/reference/hooks/replaceDynamicScriptTags.md
@@ -44,12 +44,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("replaceDynamicScriptTags")
+ */
 class ReplaceDynamicScriptTagsListener
 {
-    /**
-     * @Hook("replaceDynamicScriptTags")
-     */
-    public function onReplaceDynamicScriptTags(string $buffer): string
+    public function __invoke(string $buffer): string
     {
         // Modify $buffer here …
 

--- a/docs/dev/reference/hooks/replaceInsertTags.md
+++ b/docs/dev/reference/hooks/replaceInsertTags.md
@@ -64,9 +64,8 @@ If your function is not responsible for this insert tag, you **must** return
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ReplaceInsertTagsListener implements ServiceAnnotationInterface
+class ReplaceInsertTagsListener
 {
     /**
      * @Hook("replaceInsertTags")

--- a/docs/dev/reference/hooks/replaceInsertTags.md
+++ b/docs/dev/reference/hooks/replaceInsertTags.md
@@ -65,12 +65,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("replaceInsertTags")
+ */
 class ReplaceInsertTagsListener
 {
-    /**
-     * @Hook("replaceInsertTags")
-     */
-    public function onReplaceInsertTags(
+    public function __invoke(
         string $insertTag,
         bool $useCache,
         string $cachedValue,

--- a/docs/dev/reference/hooks/reviseTable.md
+++ b/docs/dev/reference/hooks/reviseTable.md
@@ -51,9 +51,8 @@ Return `true` if the current page should be reloaded. Otherwise return `false` o
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ReviseTableListener implements ServiceAnnotationInterface
+class ReviseTableListener
 {
     /**
      * @Hook("reviseTable")

--- a/docs/dev/reference/hooks/reviseTable.md
+++ b/docs/dev/reference/hooks/reviseTable.md
@@ -52,12 +52,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("reviseTable")
+ */
 class ReviseTableListener
 {
-    /**
-     * @Hook("reviseTable")
-     */
-    public function onReviseTable(string $table, array $newRecords, ?string $parentTable, ?array $childTables): ?bool
+    public function __invoke(string $table, array $newRecords, ?string $parentTable, ?array $childTables): ?bool
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/sendNewsletter.md
+++ b/docs/dev/reference/hooks/sendNewsletter.md
@@ -44,12 +44,12 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Database\Result;
 use Contao\Email;
 
+/**
+ * @Hook("sendNewsletter")
+ */
 class SendNewsletterListener
 {
-    /**
-     * @Hook("sendNewsletter")
-     */
-    public function onSendNewsletter(Email $email, Result $newsletter, array $recipient, string $text, string $html): void
+    public function __invoke(Email $email, Result $newsletter, array $recipient, string $text, string $html): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/sendNewsletter.md
+++ b/docs/dev/reference/hooks/sendNewsletter.md
@@ -43,9 +43,8 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Database\Result;
 use Contao\Email;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class SendNewsletterListener implements ServiceAnnotationInterface
+class SendNewsletterListener
 {
     /**
      * @Hook("sendNewsletter")

--- a/docs/dev/reference/hooks/setCookie.md
+++ b/docs/dev/reference/hooks/setCookie.md
@@ -40,12 +40,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("setCookie")
+ */
 class SetCookieListener
 {
-    /**
-     * @Hook("setCookie")
-     */
-    public function onSetCookie($cookie)
+    public function __invoke($cookie)
     {
         // Make sure the cookie is also valid for the whole domain
         $cookie->strPath = '/';

--- a/docs/dev/reference/hooks/setCookie.md
+++ b/docs/dev/reference/hooks/setCookie.md
@@ -39,9 +39,8 @@ Return `$cookie` or a custom object with all properties.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class SetCookieListener implements ServiceAnnotationInterface
+class SetCookieListener
 {
     /**
      * @Hook("setCookie")

--- a/docs/dev/reference/hooks/setNewPassword.md
+++ b/docs/dev/reference/hooks/setNewPassword.md
@@ -37,9 +37,8 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class SetNewPasswordListener implements ServiceAnnotationInterface
+class SetNewPasswordListener
 {
     /**
      * @Hook("setNewPassword")

--- a/docs/dev/reference/hooks/setNewPassword.md
+++ b/docs/dev/reference/hooks/setNewPassword.md
@@ -38,12 +38,12 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 
+/**
+ * @Hook("setNewPassword")
+ */
 class SetNewPasswordListener
 {
-    /**
-     * @Hook("setNewPassword")
-     */
-    public function onSetNewPassword($member, string $password, Module $module = null): void
+    public function __invoke($member, string $password, Module $module = null): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/sqlCompileCommands.md
+++ b/docs/dev/reference/hooks/sqlCompileCommands.md
@@ -32,12 +32,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("sqlCompileCommands")
+ */
 class SqlCompileCommandsListener
 {
-    /**
-     * @Hook("sqlCompileCommands")
-     */
-    public function onSqlCompileCommands(array $sql): array
+    public function __invoke(array $sql): array
     {
         // Modify the array of SQL statements
 

--- a/docs/dev/reference/hooks/sqlCompileCommands.md
+++ b/docs/dev/reference/hooks/sqlCompileCommands.md
@@ -31,9 +31,8 @@ Return the array of changes that should be applied to the database.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class SqlCompileCommandsListener implements ServiceAnnotationInterface
+class SqlCompileCommandsListener
 {
     /**
      * @Hook("sqlCompileCommands")

--- a/docs/dev/reference/hooks/sqlGetFromDB.md
+++ b/docs/dev/reference/hooks/sqlGetFromDB.md
@@ -33,12 +33,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("sqlGetFromDB")
+ */
 class SqlGetFromDBListener
 {
-    /**
-     * @Hook("sqlGetFromDB")
-     */
-    public function onSqlGetFromDB(array $sql): array
+    public function __invoke(array $sql): array
     {
         // Modify the array of SQL statements
 

--- a/docs/dev/reference/hooks/sqlGetFromDB.md
+++ b/docs/dev/reference/hooks/sqlGetFromDB.md
@@ -32,9 +32,8 @@ Return `$sql` after adding your custom definitions.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class SqlGetFromDBListener implements ServiceAnnotationInterface
+class SqlGetFromDBListener
 {
     /**
      * @Hook("sqlGetFromDB")

--- a/docs/dev/reference/hooks/sqlGetFromDca.md
+++ b/docs/dev/reference/hooks/sqlGetFromDca.md
@@ -32,12 +32,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("sqlGetFromDca")
+ */
 class SqlGetFromDcaListener
 {
-    /**
-     * @Hook("sqlGetFromDca")
-     */
-    public function onSqlGetFromDca(array $sql): array
+    public function __invoke(array $sql): array
     {
         // Modify the array of SQL statements
 

--- a/docs/dev/reference/hooks/sqlGetFromDca.md
+++ b/docs/dev/reference/hooks/sqlGetFromDca.md
@@ -31,9 +31,8 @@ Return `$sql` after adding your custom definitions.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class SqlGetFromDcaListener implements ServiceAnnotationInterface
+class SqlGetFromDcaListener
 {
     /**
      * @Hook("sqlGetFromDca")

--- a/docs/dev/reference/hooks/sqlGetFromFile.md
+++ b/docs/dev/reference/hooks/sqlGetFromFile.md
@@ -31,9 +31,8 @@ Return `$sql` after adding your custom definitions.
 namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class SqlGetFromFileListener implements ServiceAnnotationInterface
+class SqlGetFromFileListener
 {
     /**
      * @Hook("sqlGetFromFile")

--- a/docs/dev/reference/hooks/sqlGetFromFile.md
+++ b/docs/dev/reference/hooks/sqlGetFromFile.md
@@ -32,12 +32,12 @@ namespace App\EventListener;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
+/**
+ * @Hook("sqlGetFromFile")
+ */
 class SqlGetFromFileListener
 {
-    /**
-     * @Hook("sqlGetFromFile")
-     */
-    public function onSqlGetFromFile(array $sql): array
+    public function __invoke(array $sql): array
     {
         // Modify the array of SQL statements
 

--- a/docs/dev/reference/hooks/storeFormData.md
+++ b/docs/dev/reference/hooks/storeFormData.md
@@ -42,6 +42,9 @@ use Contao\FrontendUser;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Security\Core\Security;
 
+/**
+ * @Hook("storeFormData")
+ */
 class StoreFormDataListener
 {
     /**
@@ -59,11 +62,7 @@ class StoreFormDataListener
         $this->connection = $connection;
         $this->security = $security;
     }
-
-    /**
-     * @Hook("storeFormData")
-     */
-    public function onStoreFormData(array $data, Form $form): array
+    public function __invoke(array $data, Form $form): array
     {
         $data['member'] = 0;
 

--- a/docs/dev/reference/hooks/storeFormData.md
+++ b/docs/dev/reference/hooks/storeFormData.md
@@ -41,9 +41,8 @@ use Contao\Form;
 use Contao\FrontendUser;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Security\Core\Security;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class StoreFormDataListener implements ServiceAnnotationInterface
+class StoreFormDataListener
 {
     /**
      * @var Connection

--- a/docs/dev/reference/hooks/updatePersonalData.md
+++ b/docs/dev/reference/hooks/updatePersonalData.md
@@ -40,9 +40,8 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 use Contao\FrontendUser;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class UpdatePersonalDataListener implements ServiceAnnotationInterface
+class UpdatePersonalDataListener
 {
     /**
      * @Hook("updatePersonalData")

--- a/docs/dev/reference/hooks/updatePersonalData.md
+++ b/docs/dev/reference/hooks/updatePersonalData.md
@@ -41,12 +41,12 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Module;
 use Contao\FrontendUser;
 
+/**
+ * @Hook("updatePersonalData")
+ */
 class UpdatePersonalDataListener
 {
-    /**
-     * @Hook("updatePersonalData")
-     */
-    public function onUpdatePersonalData(FrontendUser $member, array $data, Module $module): void
+    public function __invoke(FrontendUser $member, array $data, Module $module): void
     {
         // Do something …
     }

--- a/docs/dev/reference/hooks/validateFormField.md
+++ b/docs/dev/reference/hooks/validateFormField.md
@@ -46,9 +46,8 @@ namespace App\EventListener;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Form;
 use Contao\Widget;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class ValidateFormFieldListener implements ServiceAnnotationInterface
+class ValidateFormFieldListener
 {
     /**
      * @Hook("validateFormField")

--- a/docs/dev/reference/hooks/validateFormField.md
+++ b/docs/dev/reference/hooks/validateFormField.md
@@ -47,12 +47,12 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Form;
 use Contao\Widget;
 
+/**
+ * @Hook("validateFormField")
+ */
 class ValidateFormFieldListener
 {
-    /**
-     * @Hook("validateFormField")
-     */
-    public function onValidateFormField(Widget $widget, string $formId, array $formData, Form $form): Widget
+    public function __invoke(Widget $widget, string $formId, array $formData, Form $form): Widget
     {
         if ('myform' === $formId && $widget instanceof \Contao\FormTextField && 'mywidget' === $widget->name) {
             // Do your custom validation and add an error if widget does not validate


### PR DESCRIPTION
Closes #498 

This PR removes the usage of the `ServiceAnnotationInterface` everywhere and also switches all hook examples to _invokable services_. I have also added more information in the introduction of `docs/dev/reference/hooks/_index.md`, explaining how you can use the same class from the examples in Contao 4.4.