### PR TITLE
Field options callback parameter can be null

### DIFF
--- a/docs/dev/reference/dca/callbacks.md
+++ b/docs/dev/reference/dca/callbacks.md
@@ -404,7 +404,7 @@ Allows you to define an individual function to load data into a drop-down menu
 or checkbox list. Useful e.g. for conditional foreinKey-relations.
 
 {{% expand "Parameters" %}}
-* `\Contao\DataContainer` Data Container object
+* `\Contao\DataContainer`/`null` Data Container object
 
 **return:** `array` Array of available options
 {{% /expand %}}


### PR DESCRIPTION
This small change update the field options callback parameter as it can be null.