### PR TITLE
Add warning about url encoding SMTP credentials and fix some factual errors

### DIFF
--- a/docs/manual/administration-area/list-data-records.en.md
+++ b/docs/manual/administration-area/list-data-records.en.md
@@ -42,7 +42,7 @@ These are data records that are hierarchically dependent on each other and are t
 
 ![The Tree View](/de/administration-area/images/de/der-tree-view.png?classes=shadow)
 
-## Sort and filter records {#sort-and-filter records}
+## Sort and filter records {#sort-and-filter-records}
 
 To keep track of tables with many records, Contao offers you several ways to sort and filter your listings. Most listings can be filtered so that you only see the records that you really need for a specific action.
 

--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -45,8 +45,8 @@ Hier sind einige Beispiele gültiger Datums- und Zeitangaben:
 | g:i      | 12 Stunden ohne führende Nullen sowie Minuten, z. B. `8:36`   |
 
 **Zeitzone:** Die Zeitzone solltest du unbedingt vor dem Erstellen deiner Webseite einstellen, da Contao alle 
-Zeitangaben als [Unix-Zeitstempel](https://www.php.net/time) speichert und PHP diese Zeitstempel bei einer Änderung der 
-Zeitzone nicht automatisch anpasst.
+Zeitangaben als [Unix-Zeitstempel](https://www.php.net/time) speichert und Contao diese Zeitstempel bei einer Änderung 
+der Zeitzone nicht automatisch anpasst.
 
 
 ### Backend-Einstellungen
@@ -73,6 +73,14 @@ Seitenhierarchie vorhandenen Aliase in den Alias mit übernommen z. B. die Seite
 **Leere URLs nicht umleiten:** Bei einer leeren URL die Webseite anzeigen anstatt auf den Startpunkt der Sprache 
 weiterzuleiten _(nicht empfohlen)_.
 
+**Den Command-Scheduler deaktivieren:** Hier kannst du den Periodic Command Scheduler deaktivieren und die 
+`_contao/cron`-Route mittels eines echten Cronjobs (den du selbst einrichten musst) ausführen. Seit Contao **4.9** kann
+auch folgendes Kommando benutzt werden:
+
+```
+php vendor/bin/contao-console contao:cron
+```
+
 
 ### Sicherheitseinstellungen
 
@@ -89,11 +97,13 @@ HTML-Tags festlegen.
 **Erlaubte Download-Dateitypen:** Hier kannst du festlegen, welche Dateitypen von deinem Server heruntergeladen werden 
 dürfen (Download).
 
-**Maximale GD-Bildbreite**: Hier kannst du festlegen, wie breit Bilder und andere Medien im Frontend maximal sein 
-dürfen. Bei einer Überschreitung dieses Werts wird das entsprechende Objekt automatisch verkleinert.
+**Maximale GD-Bildbreite:** Hier kannst du festlegen, wie breit Bilder sein dürfen, damit sie von der GD 
+Bildbearbeitungs-Bibliothek noch verarbeitet werden können. Jegliche Bilder, die diesen Wert übersteigen, werden nicht
+verarbeitet.
 
-**Maximale GD-Bildhöhe**: Hier kannst du festlegen, wie hoch Bilder und andere Medien im Frontend maximal sein 
-dürfen. Bei einer Überschreitung dieses Werts wird das entsprechende Objekt automatisch verkleinert.
+**Maximale GD-Bildhöhe:** Hier kannst du festlegen, wie hoch Bilder sein dürften, damit sie von der GD 
+Bildbearbeitungs-Bibliothek noch verarbeitet werden können. Jegliche Bilder, die diesen Wert übersteigen, werden nicht
+verarbeitet.
 
 
 ### Datei-Uploads
@@ -111,12 +121,6 @@ verkleinert.
 
 **Maximale Bildhöhe:** Beim Upload von Bildern prüft die Dateiverwaltung automatisch deren Höhe und vergleicht diese Werte 
 mit deiner hier festgelegten Vorgabe. Überschreitet ein Bild die maximale Höhe, wird es automatisch verkleinert.
-
-
-### Cronjob-Einstellungen
-
-**Den Command-Scheduler deaktivieren:** Hier kannst du den Periodic Command Scheduler deaktivieren und die 
-`_contao/cron`-Route mittels eines echten Cronjobs (den du selbst einrichten musst) ausführen.
 
 
 ### Website-Suche
@@ -446,6 +450,13 @@ smtp://<BENUTZERNAME>:<PASSWORT>@<HOSTNAME>:<PORT>
 
 Man ersetzt die `<PLATZHALTER>` mit den Angaben des verwendeten SMTP-Servers, oder entfernt sie dementsprechend. Siehe 
 dazu auch die Informationen in der offiziellen [Symfony Dokumentation][SymfonyMailer].
+
+{{% notice warning %}}
+Falls der Benutzername oder das Passwort Sonderzeichen verwendet, müssen diese "URL enkodiert" werden. Es gibt
+verschiedene Online-Services, mit denen man auf einfache Weise eine beliebige Zeichenfolgen URL-encoden kann, z. B.
+[urlencoder.org](https://www.urlencoder.org/). Enkodiere den Benutzernamen und das Passwort separat, nicht gemeinsam
+mit dem Doppelpunkt.
+{{% /notice %}}
 
 {{% notice tip %}}
 Anstatt `smtp://` kann auch `smtps://` verwendet werden, um automatisch SSL Verschlüsselung über Port `465` zu verwenden.

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -5,25 +5,31 @@ aliases:
 weight: 10
 ---
 
-{{% notice warning %}}
-This article is machine translated.
-{{% /notice %}}
 
-The system settings slowly but surely leave the backend. Basic system settings influence Contao as an application and therefore there is a chance that a wrong setting will render the system non-functional. If this happens, you will not be able to undo the settings and restore the system because you will not be able to log in anymore. For this reason, most settings outside of Contao are or can be `config.yml`done through the Contao Manager.
+The system settings slowly but surely leave the backend. Basic system settings influence Contao as an application and 
+therefore there is a chance that a wrong setting will render the system non-functional. If this happens, you will not 
+be able to undo the settings and restore the system because you will not be able to log in anymore. For this reason, 
+most settings are configured outside of Contao via the `config.yml`, or can be configured via the Contao Manager in the future.
+
 
 ## Settings
 
-### Global settings
 
-**System administrator's e-mail address:** This is the address to which notifications about locked accounts or newly registered users are sent, for example. You can also use the following notation to add a name to the email address:
+### Global configuration
+
+**E-mail address of the system administrator:** This is the address to which notifications about e.g. locked accounts or 
+newly registered users are sent. You can also use the following notation to add a name to the email address:
 
 ```text
 Kevin Jones [kevin.jones@example.com]
 ```
 
+
 ### Date and time
 
-**Date and time format:** All date and time formats must be entered as in thePHP function [date](https://www.php.net/manual/de/function.date.php). Contao processes only numeric formats in the backend, i.e. the letters j, d, m, n, y, Y, g, G, h, H, i and s.
+**Date and time format:** All date and time formats must be entered as used with the PHP 
+[date](https://www.php.net/manual/de/function.date.php) function. Contao processes only numeric formats in the backend, 
+i.e. the letters j, d, m, n, y, Y, g, G, h, H, i and s.
 
 Here are some examples of valid date and time specifications:
 
@@ -33,62 +39,93 @@ Here are some examples of valid date and time specifications:
 | m/d/Y | MM/DD/YYYY, English format, for example `01/28/2005` |
 | d.m.Y | DD.MM.YYYY, German format, for example `28.01.2005` |
 | y-n-j | YY-M-D, without leading zeros, e.g. `05-1-28` |
-| Ymd | YYYYMMDD, timestamp, for example `20050128` |
+| Ymd | YYYYMMDD, Unix timestamp, for example `20050128` |
 | H:i:s | 24 hours, minutes and seconds, e.g. `20:36:59` |
 | g:i | 12 hours without leading zeros and minutes, e.g. `8:36` |
 
-**Timezone:** You should set the timezone before you create your website because Contao stores all [timestamps](https://www.php.net/time) as [Unix timestamps](https://www.php.net/time) and PHP does not automatically adjust these timestamps when the timezone changes.
+**Time zone:** You should set the timezone before you create your website because Contao stores all dates as 
+[Unix timestamps](https://www.php.net/time) and Contao will not adjust these, if the timezone is changed.
 
-### Backend settings
 
-**Do not shorten elements:** In the "Parent View", Contao displays the elements in a shortened form for clarity reasons. Individual elements can be unfolded using a navigation icon if needed. Select this option to disable the feature completely.
+### Back end configuration
 
-**elements per page:** In the [Listing Records](../../administrationsbereich/datensaetze-auflisten/#datensaetze-sortieren-und-filtern) section, you learned that Contao limits the number of records per page to 30 by default. You can change this value here. Higher values mean a longer loading time.
+**Do not collapse elements:** In the "Parent View", Contao displays the elements in a shortened form for clarity 
+reasons. Individual elements can be unfolded using a navigation icon if needed. Select this option to disable the 
+feature completely.
 
-**Maximum number of records per page:** To prevent an inexperienced user from displaying 5000 records at once and thus exceeding the PHP memory limit, you can specify the maximum number of records that can be displayed per page.
+**Items per page:** In the [Listing Records](/en/administration-area/list-data-records/#sort-and-filter-records) 
+section, you learned that Contao limits the number of records per page to 30 by default. You can change this value here. 
+Higher values mean a longer loading time.
 
-### Frontend settings
+**Maximum items per page:** To prevent an inexperienced user from displaying 5000 records at once and thus 
+exceeding the PHP memory limit, you can specify the maximum number of records that can be displayed per page.
 
-**Use folder URLs:** Here you can activate folder structures in page aliases. This will add the aliases that exist in the page hierarchy to the alias, e.g. the page "Download" in the page path "Docs &gt; Install" `docs/install/download.html`instead of just .
 
-**Do not redirect empty URLs:** If the URL is empty, display the web page instead of redirecting to the starting point of the language redirection *(not recommended)*.
+### Front end configuration
+
+**Enable folder URLs:** Here you can activate folder structures in page aliases. This will add the aliases that exist in 
+the page hierarchy to the alias, e.g. the page "Download" in the page path "Docs &gt; Install" will use the alias 
+`docs/install/download.html` instead of just `download.html`.
+
+**Do not redirect empty URLs:** If the URL is empty, display the web page instead of redirecting to the starting point 
+of the language redirection *(not recommended)*.
+
+**Deactivate the command scheduler:** Here you can disable the Periodic Command Scheduler and run the route 
+`_contao/cron` using a real cron job (which you have to set up yourself). Starting with Contao **4.9** you can also
+use the following command:
+
+```
+php vendor/bin/contao-console contao:cron
+```
+
 
 ### Security settings
 
-**Disable request tokens:** Here you can activate that the request tokens are not checked when submitting a form *(insecure!)*.
+**Disable request tokens:** Here you can activate that the request tokens are not checked when submitting a form 
+*(insecure!)*.
 
-**Allowed HTML tags:** By default, Contao does not allow HTML tags in forms and removes them automatically when saving. For input fields where the use of HTML is desired, you can specify a list of allowed HTML tags here.
+**Allowed HTML tags:** By default, Contao does not allow HTML tags in forms and removes them automatically when saving. 
+For input fields where the use of HTML is desired, you can specify a list of allowed HTML tags here.
+
 
 ### Files and images
 
-**Allowed download file types:** Here you can define which file types may be downloaded from your server (Download).
+**Download file types:** Here you can define which file types may be downloaded from your server.
 
-**Maximum GD image width**: Here you can define the maximum width of images and other media in the frontend. If this value is exceeded, the corresponding object is automatically resized.
+**Maximum GD image width:** Here you can define the maximum width of images that can still be processed via the GD image
+process library. Any image exceeding this value will not be processed.
 
-**Maximum GD image height**: Here you can define the maximum height of images and other media in the frontend. If this value is exceeded, the corresponding object is automatically reduced in size.
+**Maximum GD image height:** Here you can define the maximum height of images that can still be processed via the GD image
+process library. Any image exceeding this value will not be processed.
 
-### File Uploads
 
-**Permitted upload file types:** Here you can define which file types can be transferred to your server (upload).
+### Upload settings
 
-**Maximum upload file size:** Here you can define the maximum size of a file that can be uploaded to your server using the file manager. The entry is in bytes (1 MiB = 1024 KiB = 1,048,567 bytes). Larger files will be rejected.
+**Upload file types:** Here you can define which file types can be uploaded to your server.
 
-**Maximum image width:** When uploading images, the file manager automatically checks the width of the image and compares it with the width you set here. If an image exceeds the maximum width, it will be reduced automatically.
+**Maximum upload file size:** Here you can define the maximum size of a file that can be uploaded to your server using 
+the file manager. The entry is in bytes (1 MiB = 1024 KiB = 1,048,567 bytes). Larger files will be rejected.
 
-**Maximum image height:** When uploading images, the file manager automatically checks their height and compares it with your default value. If an image exceeds the maximum height, it will be resized automatically.
+**Maximum image width:** When uploading images, the file manager automatically checks the width of the image and 
+compares it with the width you set here. If an image exceeds the maximum width, it will be reduced automatically.
 
-### Cronjob settings
+**Maximum image height:** When uploading images, the file manager automatically checks their height and compares it with 
+your default value. If an image exceeds the maximum height, it will be resized automatically.
 
-**Deactivate the command scheduler:** Here you can disable the Periodic Command Scheduler and run the route`_contao/cron` using a real cron job (which you have to set up yourself).
 
-### Website search
+### Search engine settings
 
-**Activate search:** If you select this option, Contao indexes the finished pages of your website and creates a search index from them. With the frontend module "[search engine](../../modulverwaltung/website-suche/#konfiguration-des-suchmoduls)", you can search this index.
+**Enable searching:** If you select this option, Contao indexes the finished pages of your website and creates a search 
+index from them. With the frontend module 
+"[search engine](/en/layout/module-management/website-search/#configuration-of-the-search-module)", you can search this 
+index.
 
-**Index protected pages:** Select this option to index protected pages for your search. Use this feature with care and make sure to exclude personalized pages from the search.
+**Index protected pages:** Select this option to index protected pages for your search. Use this feature with care and 
+make sure to exclude personalized pages from the search.
 
 {{% notice note %}}
-From version **4.9** a new search indexer is used. The settings **Enable Search** and **Index** Protected **Pages** are now `config/config.yml`configured via the
+Starting with version **4.9** a new search indexer is used. The settings **Enable searching** and 
+**Index protected pages** are now configured via the `config/config.yml`.
 
 ```yml
 contao:
@@ -97,28 +134,34 @@ contao:
             enable: true
         index_protected: false
 ```
-
 {{% /notice %}}
 
-### Standard access rights
 
-**Default Owner:** Here you can specify the default owner of the pages for which no access rights have been defined. For more information, see the Access Rights section.
+### Default6 access rights
 
-**Default group**: Here you can define to which group the pages for which no access rights are defined belong by default. For more information, see the Access Rights section.
+**Default page owner:** Here you can specify the default owner of the pages for which no access rights have been 
+defined. For more information, see the Access Rights section.
 
-**Default access rights:** Here you can set the default access rights for the pages for which no special access rights are defined. For more information, see the Access Rights section.
+**Default page group**: Here you can define to which group the pages for which no access rights are defined belong by 
+default. For more information, see the Access Rights section.
+
+**Default access rights:** Here you can set the default access rights for the pages for which no special access rights 
+are defined. For more information, see the Access Rights section.
+
 
 ## parameters.yml
 
-In the Contao Managed Edition, the parameters (e.g. database data) are `parameters.yml`stored in the file that is used by the Contao installation tool. This file is usually excluded from the versioning process and can also contain additional entries such as the information for sending e-mails via SMTP.
+In the Contao Managed Edition, the parameters (e.g. database credentials) are stored in the `parameters.yml` file that 
+is generated by the Contao installation tool. This file is usually excluded from the versioning process and can also 
+contain additional entries such as the credentials for sending e-mails via SMTP.
 
-The file `parameters.yml`is located in the folder `app/config/`and is created automatically when you install Contao.
+The file `parameters.yml` is located in the folder `app/config/` and is created automatically when you install Contao.
 
 {{% notice note %}}
 From version **4.8** of Contao, the file is located directly in the root directory of the installation under `config/`.
 {{% /notice %}}
 
-The `parameters.yml`ones after installing Contao:
+The `parameters.yml` contains the following after installing Contao:
 
 ```yaml
 # This file has been auto-generated during installation
@@ -131,11 +174,16 @@ parameters:
     secret: …
 ```
 
+
 ## config.yml
 
-The normal Bundle Config belongs in `config.yml`and is located in the folder `app/config/`.if the file does not exist yet, it must be created. Contao automatically loads the or `config_prod.yml``config_dev.yml`and if not available the `config.yml`.
+The bundle configuration belongs in the `config.yml` and is located in the folder `app/config/`. If the file does not 
+exist yet, it must be created. Contao automatically loads the `config_prod.yml` or `config_dev.yml` and if not available 
+the `config.yml`.
 
-This allows you to realize different configurations for your test- or production environment (dev/prod) (e.g. more logging in debug mode). In addition, you can commit the `config.yml`configuration files `parameters.yml`in your repository. You can use a repository to store your project versions, for example, with Git.
+This allows you to realize different configurations for your test or production environment (dev/prod) (e.g. more 
+logging in debug mode). In addition, you can commit the `config.yml` configuration files to your repository, if your
+project is versioned via Git for example.
 
 {{% notice note %}}
 From version **4.8** of Contao, the file is located directly in the root directory of the installation under `config/`.
@@ -317,6 +365,7 @@ contao:
         default_http_client_options: []
 ```
 
+
 ## E-Mail sending configuration
 
 To set up the sending of e-mails via an SMTP server, you need the following information from your host:
@@ -327,7 +376,7 @@ To set up the sending of e-mails via an SMTP server, you need the following info
 - The **port number of** the SMTP server (587 / 465)
 - The **encryption method** for the SMTP server (tls / ssl)
 
-You will then insert this below the existing data in the`parameters.yml`
+You will then insert this below the existing data in the `parameters.yml`
 
 ```yaml
 # This file has been auto-generated during installation
@@ -341,14 +390,13 @@ parameters:
     mailer_encryption: ssl
 ```
 
-**{{% notice warning %}}
-Empty cacheTo**  
- make the changes active, the application cache must be emptied at the end of the application using the Contao Manager ("System maintenance" &gt; "Refresh product cache") or alternatively via the command line. To do this, you have to be in the Contao installation directory.
+{{% notice warning %}}
+**Clear cache** 
+In order to enable these changes, the application cache must be rebuilt using the Contao Manager ("Maintenance" &gt; "Rebuild Production Cache") or alternatively via the command line. To do the latter you have to execute the following in the Contao installation directory:
 
 ```bash
 php vendor/bin/contao-console cache:clear --env=prod --no-warmup
 ```
-
 {{% /notice %}}
 
 After that you can test the mail dispatch on the command line.
@@ -361,24 +409,37 @@ php vendor/bin/contao-console swiftmailer:email:send --from=absender@example.com
 This command is no longer available in Contao **4.10** and later.
 {{% /notice %}}
 
+
 ### Different e-mail configurations and sender addresses
 
 {{< version "4.10" >}}
 
-In many cases, SMTP servers do not allow sending from any sender address. In most cases, the sender address must match the SMTP server access data used. Especially in multi-domain installations of Contao it might be important that the sender address of the emails that Contao sends matches the domain.
+In many cases, SMTP servers do not allow sending from any sender address. In most cases, the sender address must match 
+the SMTP server access data used. Especially in multi-domain installations of Contao it might be important that the 
+sender address of the emails that Contao sends matches the domain.
 
-Since Contao **4.10**, it is possible to use multiple email configurations in Contao. These configurations can be selected per website start point, per form and per newsletter channel. For each e-mail configuration, you can also set the sender that will be used for each e-mail sent by the selected e-mail configuration.
+Since Contao **4.10**, it is possible to use multiple email configurations in Contao. These configurations can be 
+selected per website root, per form and per newsletter channel. For each e-mail configuration, you can also set the 
+sender that will be used for each e-mail sent by the selected e-mail configuration.
 
-The configuration requires two steps. First, the available e-mail sending methods have to be set in the Symfony framework configuration in the `config.yml`so-called "Transports". For example, one or moreSMTP servers can be defined using the so-called "DSN" syntax. This syntax is basically very simple:
+The configuration requires two steps. First, the available e-mail sending methods have to be set in the Symfony 
+framework configuration in the `config.yml` so-called. One or more SMTP servers can be defined using the so-called "DSN" syntax:
 
 ```
-smtp://<BENUTZERNAME>:<PASSWORT>@<HOSTNAME>:<PORT>
+smtp://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>
 ```
 
-Replace them `<PLATZHALTER>`with the information of the SMTP server used, or remove them accordingly. See also the information in the official [Symfony documentation](https://symfony.com/doc/4.4/mailer.html#transport-setup).
+Replace the `<PLACEHOLDER>` with the information of the SMTP server used, or remove them accordingly. See also the 
+information in the official [Symfony documentation](https://symfony.com/doc/4.4/mailer.html#transport-setup).
+
+{{% notice warning %}}
+If your username or password contains special characters, they need to be "url encoded". There are several online
+services you can use to quickly url encode any string, e.g. [urlencoder.org](https://www.urlencoder.org/). Make sure to
+encode the username and password separately (not together with the colon).
+{{% /notice %}}
 
 {{% notice tip %}}
-Instead `smtp://`of using this, you can also `smtps://`use to automatically use SSL encryption over port`465`.
+Instead of using `smtp://` you can also `smtps://` to automatically use SSL encryption over port `465`.
 {{% /notice %}}
 
 ```yml
@@ -391,7 +452,8 @@ framework:
             website2: smtps://email@example.de:foobar@example.de
 ```
 
-In the second step, the configured transports can be made available in the back end via the Contao framework configuration. In the following example, the transports `website1`and `website2`are made available:
+In the second step, the configured transports can be made available in the back end via the Contao framework 
+configuration. In the following example, the transports `website1` and `website2` are made available:
 
 ```yml
 # config/config.yml
@@ -402,10 +464,13 @@ contao:
             website2: ~
 ```
 
-If the symfony application cache has been refreshed afterwards, these email configurations will be available for selection in the Contao back end.
+If the symfony application cache has been refreshed afterwards, these email configurations will be available for 
+selection in the Contao back end.
 
 {{% notice note %}}
-If no transport is configured, the information from the `parameters.yml`. If a transport is configured but no transport is selected in the Contao back end, the first defined transport is used automatically.
+If no transport is configured, the information from the `parameters.yml`. If a transport is configured but no transport 
+is selected in the Contao back end, the first defined transport is used automatically.
+{{% /notice %}}
 
 Optionally, you can now overwrite the sender address for each transport:
 
@@ -420,7 +485,7 @@ contao:
                 from: Lorem Ipsum <email@example.de>
 ```
 
-It is also possible to define language for the descriptions of the selection options in the back end via Translations per language:
+It is also possible to define translations for the descriptions of the options in the back end:
 
 ```yml
 # translations/mailer_transports.en.yml
@@ -434,12 +499,13 @@ website1: 'SMTP für Webseite 1'
 website2: 'SMTP für Webseite 2'
 ```
 
-**{{% notice warning %}}
-Empty cacheTo**  
- make the changes visible in the back end, you have to empty the application cache at the end of the application using the Contao Manager ("System maintenance" &gt; "Refresh product cache") or alternatively on the command line. To do this, you have to be in the Contao installation directory.
+{{% notice warning %}}
+**Clear cache** 
+In order to enable these changes, the application cache must be rebuilt using the Contao Manager ("Maintenance" &gt; 
+"Rebuild Production Cache") or alternatively via the command line. To do the latter you have to execute the following in 
+the Contao installation directory:
 
 ```bash
 php vendor/bin/contao-console cache:clear --env=prod --no-warmup
 ```
-
 {{% /notice %}}


### PR DESCRIPTION
This PR does the following:

* Adds warning about having to URL encode special characters in the DSN of configured transports.
* Fixes some factual errors.
* Also revises the machine translated content of `settings.en.md`.