### PR TITLE
Add undocumented feature for link insert tag

### DIFF
--- a/docs/manual/article-management/insert-tags.de.md
+++ b/docs/manual/article-management/insert-tags.de.md
@@ -23,10 +23,10 @@ oder den Alias der Zielseite.
 
 | Insert-Tag                | Beschreibung                                                                                                                 |
 |:--------------------------|:-----------------------------------------------------------------------------------------------------------------------------|
-| `{{link::*}}`             | Dieses Tag wird mit einem Link zu einer internen Seite ersetzt (ersetze * mit der ID oder dem Alias).                        |
+| `{{link::*}}`             | Dieses Tag wird mit dem HTML Code für einen Link ersetzt. Der Parameter kann entweder die ID oder der Alias einer Seite sein, oder eine absolute URL. |
 | `{{link::back}}`          | Dieses Tag wird mit einem Link zur der zuletzt besuchte Seite ersetzt. Kann auch als `{{link_open::back}}`, `{{link_url::back}}` und `{{link_title::back}}` verwendet werden.    |
 | `{{link::login}}`         | Dieses Tag wird mit einem Link zur Anmeldeseite des aktuellen Frontend-Benutzers (falls vorhanden) ersetzt.                  |
-| `{{link_open::*}}`        | Wird mit dem öffnenden Tag eines Links zu einer internen Seite ersetzt: `{{link_open::12}}Hier klicken{{link_close}}`.       |
+| `{{link_open::*}}`        | Wird mit dem öffnenden Tag eines Links ersetzt. Der Parameter kann entweder die ID oder der Alias einer Seite sein, oder eine absolute URL: `{{link_open::12}}Hier klicken{{link_close}}`.       |
 | `{{link_url::*}}`         | Dieses Tag wird mit der URL einer internen Seite ersetzt: `<a href="{{link_url::12}}">Hier klicken</a>`.                     |
 | `{{link_target::*}}`      | Dieses Tag wird mit ` target="_blank" rel="noreferrer noopener"` ersetzt, wenn es sich bei der angegebenen Seite um eine externe Weiterleitungsseite handelt, und dort eingestellt ist, dass sich der Link in einem neuen Fenster öffnen soll. |
 | `{{link_title::*}}`       | Dieses Tag wird mit dem Titel einer internen Seite ersetzt: `<a title="{{link_title::12}}">Hier klicken</a>`.                |

--- a/docs/manual/article-management/insert-tags.de.md
+++ b/docs/manual/article-management/insert-tags.de.md
@@ -23,10 +23,10 @@ oder den Alias der Zielseite.
 
 | Insert-Tag                | Beschreibung                                                                                                                 |
 |:--------------------------|:-----------------------------------------------------------------------------------------------------------------------------|
-| `{{link::*}}`             | Dieses Tag wird mit dem HTML Code für einen Link ersetzt. Der Parameter kann entweder die ID oder der Alias einer Seite sein, oder eine absolute URL. |
+| `{{link::*}}`             | Dieses Tag wird mit dem HTML-Code für einen Link ersetzt. Der Parameter kann entweder die ID oder der Alias einer Seite sein, auch eine absolute URL ist möglich. |
 | `{{link::back}}`          | Dieses Tag wird mit einem Link zur der zuletzt besuchte Seite ersetzt. Kann auch als `{{link_open::back}}`, `{{link_url::back}}` und `{{link_title::back}}` verwendet werden.    |
 | `{{link::login}}`         | Dieses Tag wird mit einem Link zur Anmeldeseite des aktuellen Frontend-Benutzers (falls vorhanden) ersetzt.                  |
-| `{{link_open::*}}`        | Wird mit dem öffnenden Tag eines Links ersetzt. Der Parameter kann entweder die ID oder der Alias einer Seite sein, oder eine absolute URL: `{{link_open::12}}Hier klicken{{link_close}}`.       |
+| `{{link_open::*}}`        | Wird mit dem öffnenden Tag eines Links ersetzt. Der Parameter kann entweder die ID oder der Alias einer Seite sein, auch eine absolute URL ist möglich: `{{link_open::12}}Hier klicken{{link_close}}`.       |
 | `{{link_url::*}}`         | Dieses Tag wird mit der URL einer internen Seite ersetzt: `<a href="{{link_url::12}}">Hier klicken</a>`.                     |
 | `{{link_target::*}}`      | Dieses Tag wird mit ` target="_blank" rel="noreferrer noopener"` ersetzt, wenn es sich bei der angegebenen Seite um eine externe Weiterleitungsseite handelt, und dort eingestellt ist, dass sich der Link in einem neuen Fenster öffnen soll. |
 | `{{link_title::*}}`       | Dieses Tag wird mit dem Titel einer internen Seite ersetzt: `<a title="{{link_title::12}}">Hier klicken</a>`.                |

--- a/docs/manual/article-management/insert-tags.en.md
+++ b/docs/manual/article-management/insert-tags.en.md
@@ -20,12 +20,12 @@ With these insert tags you can create links to other pages or articles. You only
 
 | Insert tag | Description |
 | ---------- | ----------- |
-| `{{link::*}}` | This tag is replaced with a link to an internal page (replace \* with the ID or alias). |
+| `{{link::*}}` | This tag is replaced with HTML code for a link. The parameter can be the ID or alias of an internal page or an absolute URL. |
 | `{{link::back}}` | This tag is replaced with a link to the last page visited. Can also be used as `{{link_open::back}}`, `{{link_url::back}}`and `{{link_title::back}}`. |
 | `{{link::login}}` | This tag is replaced with a link to the logon page of the current front-end user (if available). |
-| `{{link_open::*}}` | Is replaced with the opening tag of a link to an internal page: `{{link_open::12}}Hier klicken{{link_close}}`. |
-| `{{link_url::*}}` | This tag is replaced with the URL of an internal page: `<a href="{{link_url::12}}">Hier klicken</a>`. |
-| `{{link_target::*}}` | This tag will be replaced with `target="_blank" rel="noreferrer noopener"`if the specified page is an external redirection page and it is set there that the link should open in a new window. |
+| `{{link_open::*}}` | Is replaced with the opening tag of a link. The parameter can be the ID or alias of an internal page or an absolute URL: `{{link_open::12}}Click here{{link_close}}`. |
+| `{{link_url::*}}` | This tag is replaced with the URL of an internal page: `<a href="{{link_url::12}}">Click here</a>`. |
+| `{{link_target::*}}` | This tag will be replaced with `target="_blank" rel="noreferrer noopener"` if the specified page is an external redirection page and it is set there that the link should open in a new window. |
 | `{{link_title::*}}` | This tag is replaced with the title of an internal page: `<a title="{{link_title::12}}">Hier klicken</a>`. |
 | `{{link_name::*}}` | This tag will be replaced with the name of an internal page: `<a>{{link_name::12}}</a>`. |
 | `{{link_close}}` | Will be replaced with the closing tag of a link to an internal page: `{{link_open::12}}Hier klicken{{link_close}}`. |


### PR DESCRIPTION
I recently learned, that you can also use `{{link::https://example.com/}}` or `{{link_open::https://example.com/}}`.