### PR TITLE
Add services.yaml for migration example

### DIFF
--- a/docs/dev/framework/migrations.md
+++ b/docs/dev/framework/migrations.md
@@ -108,6 +108,17 @@ class CustomerNameMigration extends AbstractMigration
 }
 ```
 
+The corresponding `services.yaml` looks like this:
+```yaml
+# config/services.yaml
+services:
+    App\Migration\CustomerNameMigration:
+        arguments:
+            - '@database_connection'
+        tags:
+            - { name: contao.migration, priority: 0 }
+```
+
 
 ## Read more
 


### PR DESCRIPTION
This adds also the content of the services.yaml file for the contao:migrate developer example