### PR TITLE
Use markdown code blocks instead of HTML

### DIFF
--- a/docs/manual/installation/contao-manager.de.md
+++ b/docs/manual/installation/contao-manager.de.md
@@ -178,8 +178,11 @@ weiteres Benutzerkonto hinzufügen. In unserem Fall ist das <code>h.lewis</code>
 {{% notice info %}}
 Der Wert für »password« muss hierbei verschlüsselt eingetragen werden. Über [bcrypt-generator.com](https://bcrypt-generator.com/)
 könntest du z. B. den notwendigen Hash-Wert generieren. Alternativ dazu, kann man den Hash-Wert auch mit dem folgenden Konsolenaufruf
-in seiner eigenen Contao-Installation erstellen:<br>
-<code>php vendor/bin/contao-console security:encode-password 'my_1._pA~~w0rd'</code>
+in seiner eigenen Contao-Installation erstellen:
+
+```bash
+php vendor/bin/contao-console security:encode-password 'my_1._pA~~w0rd'
+```
 {{% /notice %}}
 
 

--- a/docs/manual/installation/contao-manager.en.md
+++ b/docs/manual/installation/contao-manager.en.md
@@ -137,8 +137,11 @@ Yes, you have to edit the file `users.json` in the directory `contao-manager` an
 {{% notice info %}}
 The value for "password" must be entered encrypted. You can use services like [bcrypt-generator.com](https://bcrypt-generator.com/)
 for example in order to generate the necessary hashed value. Alternatively, you can generate the hash value with the following console call
-in your own Contao installation:<br>
-<code>php vendor/bin/contao-console security:encode-password 'my_1._pA~~~w0rd'</code>
+in your own Contao installation:
+
+```bash
+php vendor/bin/contao-console security:encode-password 'my_1._pA~~~w0rd'
+```
 {{% /notice %}}
 
 


### PR DESCRIPTION
Instead of using HTML I think we should just use standard markdown code blocks here, like it is done in the rest of the documentation.

![Screenshot_2020-11-22 Über den Contao Manager Contao Handbuch](https://user-images.githubusercontent.com/4970961/99911481-a067e700-2cec-11eb-9c47-073f31be1139.png)