### PR TITLE
Add documentation for contao.localconfig

### DIFF
--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -223,7 +223,7 @@ contao:
     csrf_token_name:      contao_csrf_token
     encryption_key:       '%kernel.secret%'
 
-    # The error reporting level set when the framework is initialized. Defaults to E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED.
+    # The error reporting level set when the framework is initialized.
     error_level:          8183
 
     # Allows to set TL_CONFIG variables, overriding settings stored in localconfig.php. Changes in the Contao back end will not have any effect.
@@ -246,6 +246,7 @@ contao:
         - pl
         - pt
         - ru
+        - sl
         - sr
         - zh
 
@@ -379,6 +380,74 @@ contao:
         # Allows to configure the default HttpClient options (useful for proxy settings, SSL certificate validation and more).
         default_http_client_options: []
 ```
+
+
+### localconfig
+
+Wie bereits in der oben stehenden referenz erlaubt `contao.localconfig` jegliche Variablen einzustellen, die über
+`$GLOBALS['TL_CONFIG']` definiert sind. Diese Werte können teilweise über das Contao Backend in den Systemeinstellungen
+überschrieben und in der `system/config/localconfig.php` gespeichert werden. Allerdings wird diese Art der Speicherung
+Schritt für Schritt aus Contao entfernt. Einige der Einstellungen haben bereits ein Pendant in der Bundle Konfiguration
+während andere Einstellungen nun bspw. in den Benutzereinstellungen oder in den Website Startpunkten vorgenommen werden
+können.
+
+Je nach Contao Version werden aber immer noch Einstellungen aus der localconfig benutzt. Daher kann es nütlich sein zu
+wissen, wie man diese Einstellungen über die Applikationskonfiguration (also die `config.yml`) überschreiben könnte, 
+anstatt die veraltete `localconfig.php` dafür zu benutzen. Dies kann für den eigenen Deployment-Flow wichtig sein, aber
+auch weil es gewisse Einstellungen gibt, die _nur_ manuell gesetzt werden können, weil diese weder eine Bundle Einstellung
+noch eine andere Einstellungsmöglichkeit im Backend haben.
+
+Das folgende Beispiel zeigt, wie man die Administrator E-Mail Adresse über eine Umgebungsvariable definieren und die
+Wiederherstellungsperiode auf 60 Tage verlängern könnte:
+
+```yaml
+# config/config.yaml
+contao:
+    localconfig:
+        adminEmail: '%env(ADMIN_EMAIL)%'
+        undoPeriod: 5184000
+```
+
+Im Folgenden befindet sich eine vollständige Liste an localconfig Konfigurationen, die noch benutzt werden, und deren
+Beschreibung.
+
+| Key | Description |
+| --- | --- |
+| `adminEmail` | [E-Mail-Adresse des Systemadministrators](#globale-einstellungen). |
+| `allowedDownload` | [Erlaubte Download-Dateitypen](#dateien-und-bilder). |
+| `allowedTags` | [Erlaubte HTML-Tags](#sicherheitseinstellungen). |
+| `characterSet` | Der von Contao benutzte Zeichensatz. Standard: `utf-8` |
+| `dateFormat` | [Datumsformat](#datum-und-zeit). |
+| `datimFormat` | [Datums- und Zeitformat](#datum-und-zeit). |
+| `defaultChmod` | [Standard-Zugriffsrechte](#standard-zugriffsrechte). |
+| `defaultGroup` | [Standardgruppe](#standard-zugriffsrechte). |
+| `defaultUser` | [Standardbesitzer](#standard-zugriffsrechte). |
+| `disableCron` | [Den Command-Scheduler deaktivieren](#frontend-einstellungen). |
+| `disableInsertTags` | Erlaubt es das Ersetzen von [Insert-Tags][InsertTags] global zu deaktivieren. |
+| `disableRefererCheck` | Erlaubt es die [Request Token Überprüfung][RequestTokens] komplett zu deaktivieren _(deprecated)_. |
+| `doNotCollapse` | [Elemente nicht verkürzen](#backend-einstellungen). |
+| `folderUrl` | [Ordner-URLs verwenden](#frontend-einstellungen). |
+| `gdMaxImgHeight` | [Maximale GD-Bildhöhe](#dateien-und-bilder). |
+| `gdMaxImgWidth` | [Maximale GD-Bildbreite](#dateien-und-bilder). |
+| `imageHeight` | [Maximale Bildhöhe](#datei-uploads). |
+| `imageWidth` | [Maximale Bildbreite](#datei-uploads). |
+| `installPassword` | Speichert den Hash-Wert des Contao Installtool Passworts. |
+| `licenseAccepted` | Speichert ob die Lizenz im Contao Installtool bereits akzeptiert wurde. |
+| `logPeriod` | Zeitspanne in Sekunden wie lange Einträge im Backend Systemlog behalten werden sollen. Standard: `604800`. |
+| `maxFileSize` | [Maximale Upload-Dateigröße](#datei-uploads). |
+| `maxImageWidth` | Erlaubt es eine maximale Bildbreite für das Frontend zu setzen _(deprecated)_. |
+| `maxPaginationLinks` | Erlaubt es die Anzahl an Links in den automatisch generierten Blätternavigationen zu ändern. Standard: `7`. |
+| `maxResultsPerPage` | [Maximum Datensätze pro Seite](#backend-einstellungen). |
+| `minPasswordLength` | Erlaubt es die minimale Passwortlänge für Frontend-Mitglieder und Backend-Nutzer zu ändern. Standard: `8`. |
+| `requestTokenWhitelist` | Erlaubt es die [Request Token Überprüfung][RequestTokens] für Anfragen von den definierten Hosts zu deaktivieren _(deprecated)_. |
+| `resultsPerPage` | [Elemente pro Seite](#backend-einstellungen). |
+| `sessionTimeout` | Zeitspanne in Sekunden wie lange eine Nutzer-Session (Frontend und Backend) gültig bleiben soll. Falls dieser Wert erhöht wird müssen ggf. auch die [Session-Einstellungen][PhpSessionSettings] von PHP geändert werden (`session.cookie_lifetime` und `session.gc_maxlifetime`). Standard: `3600`. |
+| `timeFormat` | [Zeitformat](#datum-und-zeit). |
+| `timeZone` | [Zeitzone](#datum-und-zeit). |
+| `undoPeriod` | Zeitspanne in Sekunden wie lange gelöschte Einträge wiederhergestellt werden können. Standard: `2592000`. |
+| `uploadTypes` | [Upload file types](#datei-uploads). |
+| `useAutoItem` | Erlaubt es das sogenannte »Auto Item« zu deaktivieren _(nicht empfohlen)_. |
+| `versionPeriod` | Zeitspanne in Sekunden wie lange ältere Versionen von geänderten Einträgen behalten werden sollen. Standard: `7776000`. |
 
 
 ## E-Mail Versand Konfiguration
@@ -532,4 +601,9 @@ php vendor/bin/contao-console cache:clear --env=prod --no-warmup
 ```
 {{% /notice %}}
 
+
 [SymfonyMailer]: https://symfony.com/doc/4.4/mailer.html#transport-setup
+[InsertTags]: /artikelverwaltung/insert-tags/
+[RequestTokens]: https://docs.contao.org/dev/framework/request-tokens/
+[LegacyRouting]: /layout/seitenstruktur/seiten-konfigurieren/#legacy-routing-modus
+[PhpSessionSettings]: http://docs.php.net/manual/de/session.configuration.php

--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -385,19 +385,19 @@ contao:
 ### localconfig
 
 Wie bereits in der oben stehenden Referenz erwähnt erlaubt `contao.localconfig` jegliche Variablen einzustellen, die über
-`$GLOBALS['TL_CONFIG']` definiert sind. Diese Werte können teilweise über das Contao Backend in den Systemeinstellungen
+`$GLOBALS['TL_CONFIG']` definiert sind. Diese Werte können teilweise über das Contao-Backend in den Systemeinstellungen
 überschrieben und in der `system/config/localconfig.php` gespeichert werden. Allerdings wird diese Art der Speicherung
 Schritt für Schritt aus Contao entfernt. Einige der Einstellungen haben bereits ein Pendant in der Bundle Konfiguration
-während andere Einstellungen nun bspw. in den Benutzereinstellungen oder in den Website Startpunkten vorgenommen werden
+während andere Einstellungen nun bspw. in den Benutzereinstellungen oder im Startpunkt einer Webseite vorgenommen werden
 können.
 
-Je nach Contao Version werden aber immer noch Einstellungen aus der localconfig benutzt. Daher kann es nützlich sein zu
+Je nach Contao-Version werden aber immer noch Einstellungen aus der `localconfig` benutzt. Daher kann es nützlich sein zu
 wissen, wie man diese Einstellungen über die Applikationskonfiguration (also die `config.yml`) überschreiben könnte, 
 anstatt die veraltete `localconfig.php` dafür zu benutzen. Dies kann für den eigenen Deployment-Flow wichtig sein, aber
 auch weil es gewisse Einstellungen gibt, die _nur_ manuell gesetzt werden können, weil diese weder eine Bundle Einstellung
 noch eine andere Einstellungsmöglichkeit im Backend haben.
 
-Das folgende Beispiel zeigt, wie man die Administrator E-Mail Adresse über eine Umgebungsvariable definieren und die
+Das folgende Beispiel zeigt, wie man die E-Mail-Adresse des Systemadministrators über eine Umgebungsvariable definieren und die
 Wiederherstellungsperiode auf 60 Tage verlängern könnte:
 
 ```yaml
@@ -431,21 +431,21 @@ Beschreibung.
 | `gdMaxImgWidth` | [Maximale GD-Bildbreite](#dateien-und-bilder). |
 | `imageHeight` | [Maximale Bildhöhe](#datei-uploads). |
 | `imageWidth` | [Maximale Bildbreite](#datei-uploads). |
-| `installPassword` | Speichert den Hash-Wert des Contao Installtool Passworts. |
-| `licenseAccepted` | Speichert ob die Lizenz im Contao Installtool bereits akzeptiert wurde. |
-| `logPeriod` | Zeitspanne in Sekunden wie lange Einträge im Backend Systemlog behalten werden sollen. Standard: `604800`. |
+| `installPassword` | Speichert den Hash-Wert des Passwortes für das Contao-Installtool. |
+| `licenseAccepted` | Speichert ob die Lizenz im Contao-Installtool bereits akzeptiert wurde. |
+| `logPeriod` | Zeitspanne in Sekunden wie lange Einträge im System-Log behalten werden sollen. Standard: `604800`. |
 | `maxFileSize` | [Maximale Upload-Dateigröße](#datei-uploads). |
-| `maxImageWidth` | Erlaubt es eine maximale Bildbreite für das Frontend zu setzen _(deprecated)_. |
+| `maxImageWidth` | Erlaubt es eine maximale Bildbreite für das Frontend zu setzen _(veraltet)_. |
 | `maxPaginationLinks` | Erlaubt es die Anzahl an Links in den automatisch generierten Blätternavigationen zu ändern. Standard: `7`. |
 | `maxResultsPerPage` | [Maximum Datensätze pro Seite](#backend-einstellungen). |
 | `minPasswordLength` | Erlaubt es die minimale Passwortlänge für Frontend-Mitglieder und Backend-Nutzer zu ändern. Standard: `8`. |
-| `requestTokenWhitelist` | Erlaubt es die [Request Token Überprüfung][RequestTokens] für Anfragen von den definierten Hosts zu deaktivieren _(deprecated)_. |
+| `requestTokenWhitelist` | Erlaubt es die [Request Token Überprüfung][RequestTokens] für Anfragen von den definierten Hosts zu deaktivieren _(veraltet)_. |
 | `resultsPerPage` | [Elemente pro Seite](#backend-einstellungen). |
 | `sessionTimeout` | Zeitspanne in Sekunden wie lange eine Nutzer-Session (Frontend und Backend) gültig bleiben soll. Falls dieser Wert erhöht wird müssen ggf. auch die [Session-Einstellungen][PhpSessionSettings] von PHP geändert werden (`session.cookie_lifetime` und `session.gc_maxlifetime`). Standard: `3600`. |
 | `timeFormat` | [Zeitformat](#datum-und-zeit). |
 | `timeZone` | [Zeitzone](#datum-und-zeit). |
 | `undoPeriod` | Zeitspanne in Sekunden wie lange gelöschte Einträge wiederhergestellt werden können. Standard: `2592000`. |
-| `uploadTypes` | [Upload file types](#datei-uploads). |
+| `uploadTypes` | [Upload-Dateitypen](#datei-uploads). |
 | `useAutoItem` | Erlaubt es das sogenannte »Auto Item« zu deaktivieren _(nicht empfohlen)_. |
 | `versionPeriod` | Zeitspanne in Sekunden wie lange ältere Versionen von geänderten Einträgen behalten werden sollen. Standard: `7776000`. |
 

--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -384,14 +384,14 @@ contao:
 
 ### localconfig
 
-Wie bereits in der oben stehenden referenz erlaubt `contao.localconfig` jegliche Variablen einzustellen, die über
+Wie bereits in der oben stehenden Referenz erwähnt erlaubt `contao.localconfig` jegliche Variablen einzustellen, die über
 `$GLOBALS['TL_CONFIG']` definiert sind. Diese Werte können teilweise über das Contao Backend in den Systemeinstellungen
 überschrieben und in der `system/config/localconfig.php` gespeichert werden. Allerdings wird diese Art der Speicherung
 Schritt für Schritt aus Contao entfernt. Einige der Einstellungen haben bereits ein Pendant in der Bundle Konfiguration
 während andere Einstellungen nun bspw. in den Benutzereinstellungen oder in den Website Startpunkten vorgenommen werden
 können.
 
-Je nach Contao Version werden aber immer noch Einstellungen aus der localconfig benutzt. Daher kann es nütlich sein zu
+Je nach Contao Version werden aber immer noch Einstellungen aus der localconfig benutzt. Daher kann es nützlich sein zu
 wissen, wie man diese Einstellungen über die Applikationskonfiguration (also die `config.yml`) überschreiben könnte, 
 anstatt die veraltete `localconfig.php` dafür zu benutzen. Dies kann für den eigenen Deployment-Flow wichtig sein, aber
 auch weil es gewisse Einstellungen gibt, die _nur_ manuell gesetzt werden können, weil diese weder eine Bundle Einstellung

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -67,8 +67,9 @@ exceeding the PHP memory limit, you can specify the maximum number of records th
 the page hierarchy to the alias, e.g. the page "Download" in the page path "Docs &gt; Install" will use the alias 
 `docs/install/download.html` instead of just `download.html`.
 
-**Do not redirect empty URLs:** If the URL is empty, display the web page instead of redirecting to the starting point 
-of the language redirection *(not recommended)*.
+**Do not redirect empty URLs:** Allows you to disable the redirect of the "empty URL" to the start page of the browser's 
+language respective website root when using the [legacy routing mode][LegacyRouting] without `contao.prepend_locale: true` 
+*(not recommended)*.
 
 **Deactivate the command scheduler:** Here you can disable the Periodic Command Scheduler and run the route 
 `_contao/cron` using a real cron job (which you have to set up yourself). Starting with Contao **4.9** you can also
@@ -208,7 +209,7 @@ contao:
     csrf_token_name:      contao_csrf_token
     encryption_key:       '%kernel.secret%'
 
-    # The error reporting level set when the framework is initialized. Defaults to E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED.
+    # The error reporting level set when the framework is initialized.
     error_level:          8183
 
     # Allows to set TL_CONFIG variables, overriding settings stored in localconfig.php. Changes in the Contao back end will not have any effect.
@@ -231,6 +232,7 @@ contao:
         - pl
         - pt
         - ru
+        - sl
         - sr
         - zh
 
@@ -366,6 +368,73 @@ contao:
 ```
 
 
+### localconfig
+
+As mentioned in the config reference above the configuration key `contao.localconfig` allows you to set any configuration
+that is defined via `$GLOBALS['TL_CONFIG']`, the default values of which can be overwritten via the 
+`system/config/localconfig.php`. This is where Contao stores any settings that have been customised in the back end, i.e.
+under _System_ » _Settings_. This form of storing settings is being phased out step by step. Some of the settings now
+have a counterpart in the bundle configuration, others are e.g. set in the website root or within the back end user's
+settings. 
+
+However depending on the Contao version you are using there are still settings being used from the localconfig. Thus it 
+can be useful to define them directly in your applications configuration (i.e. the `config.yml`) rather than the legacy 
+`localconfig.php`. Not only because you might need it for your deployment flow, but also because some settings can _only_ 
+be set manually - because they neither have a bundle configuration counterpart, nor is there another mean of setting them 
+via the back end.
+
+The following example defines the administrator's e-mail address via an environment variable and increases the undo period
+to 60 days:
+
+```yaml
+# config/config.yaml
+contao:
+    localconfig:
+        adminEmail: '%env(ADMIN_EMAIL)%'
+        undoPeriod: 5184000
+```
+
+The following is a comprehensive list of localconfig configurations still in use and their description.
+
+| Key | Description |
+| --- | --- |
+| `adminEmail` | [E-mail address of the system administrator](#global-configuration). |
+| `allowedDownload` | [Download file types](#files-and-images). |
+| `allowedTags` | [Allowed HTML tags](#security-settings). |
+| `characterSet` | Character set used by Contao. Default: `utf-8` |
+| `dateFormat` | [Date format](#date-and-time). |
+| `datimFormat` | [Date and time format](#date-and-time). |
+| `defaultChmod` | [Default access rights](#default-access-rights). |
+| `defaultGroup` | [Default page group](#default-access-rights). |
+| `defaultUser` | [Default page owner](#default-access-rights). |
+| `disableCron` | [Deactivate the command scheduler](#front-end-configuration). |
+| `disableInsertTags` | Allows you to disable the replacement of [insert tags][InsertTags] globally. |
+| `disableRefererCheck` | Allows you to disable the [request token check][RequestTokens] entirely _(deprecated)_. |
+| `doNotCollapse` | [Do not collapse elements](#back-end-configuration). |
+| `folderUrl` | [Enable folder URLs](#front-end-configuration). |
+| `gdMaxImgHeight` | [Maximum GD image height](#files-and-images). |
+| `gdMaxImgWidth` | [Maximum GD image width](#files-and-images). |
+| `imageHeight` | [Maximum image height](#upload-settings). |
+| `imageWidth` | [Maximum image width](#upload-settings). |
+| `installPassword` | Stores the hashed value of the Contao Install Tool password. |
+| `licenseAccepted` | Stores whether the license in the Contao Install Tool has been accepted. |
+| `logPeriod` | Duration in seconds for how long entries in the Contao back end system log should be kept. Default: `604800`. |
+| `maxFileSize` | [Maximum upload file size](#upload-settings). |
+| `maxImageWidth` | Allows you to define a maximum image width for the front end _(deprecated)_. |
+| `maxPaginationLinks` | Allows you define the number links shown in the automatically generated front end paginations. Default: `7`. |
+| `maxResultsPerPage` | [Maximum items per page](#back-end-configuration). |
+| `minPasswordLength` | Allows you to define the minimum password length for front end members and back end users. Default: `8`. |
+| `requestTokenWhitelist` | Allows you to disable the [request token check][RequestTokens] for requests coming from the the hosts in this array _(deprecated)_. |
+| `resultsPerPage` | [Items per page](#back-end-configuration). |
+| `sessionTimeout` | Duration in seconds for how long a user session (front and back end) should stay valid. If you increase this value, you also might need to increase PHP's [session timeouts][PhpSessionSettings] (`session.cookie_lifetime` and `session.gc_maxlifetime`). Default: `3600`. |
+| `timeFormat` | [Time format](#date-and-time). |
+| `timeZone` | [Time zone](#date-and-time). |
+| `undoPeriod` | Duration in seconds for how long deleted entries can still be restored. Default: `2592000`. |
+| `uploadTypes` | [Upload file types](#upload-settings). |
+| `useAutoItem` | Allows you to disable the usage of the so called _auto item_ _(not recommended)_. |
+| `versionPeriod` | Duration in seconds for how long previous versions of edited entries should be kept. Default: `7776000`. |
+
+
 ## E-Mail sending configuration
 
 To set up the sending of e-mails via an SMTP server, you need the following information from your host:
@@ -430,7 +499,7 @@ smtp://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>
 ```
 
 Replace the `<PLACEHOLDER>` with the information of the SMTP server used, or remove them accordingly. See also the 
-information in the official [Symfony documentation](https://symfony.com/doc/4.4/mailer.html#transport-setup).
+information in the official [Symfony documentation][SymfonyMailer].
 
 {{% notice warning %}}
 If your username or password contains special characters, they need to be "url encoded". There are several online
@@ -509,3 +578,10 @@ the Contao installation directory:
 php vendor/bin/contao-console cache:clear --env=prod --no-warmup
 ```
 {{% /notice %}}
+
+
+[SymfonyMailer]: https://symfony.com/doc/4.4/mailer.html#transport-setup
+[InsertTags]: /article-management/insert-tags/
+[RequestTokens]: https://docs.contao.org/dev/framework/request-tokens/
+[LegacyRouting]: /layout/site-structure/configure-pages/#legacy-routing-mode
+[PhpSessionSettings]: http://docs.php.net/manual/en/session.configuration.php


### PR DESCRIPTION
This documents the usage of the `contao.localconfig` configuration.

* It is useful to know the respective `contao.localconfig.*` key in order to be able lock a setting to a specific value via the bundle configuration.
* Some settings have neither a bundle configuration nor a setting in a different place in the Contao back end but are still actively used by Contao and not deprecated and thus they need to be documented.

_Note:_ I disregarded any `Config::get` key that might still be additionally in use in Contao **4.4**.