### PR TITLE
Fix headline levels on update page

### DIFF
--- a/docs/manual/installation/update-contao.de.md
+++ b/docs/manual/installation/update-contao.de.md
@@ -12,33 +12,33 @@ Komponenten aktualisiert, Fehler behoben, neue Funktionen hinzugefügt oder die
 empfohlen, immer eine aktuelle Version zu verwenden.
 
 
-### Der Contao-Update-Zyklus
+## Der Contao-Update-Zyklus
 
 Contao folgt für die Versionsbezeichnungen dem Konzept von [Semantic Versioning](https://semver.org).
 Das klingt etwas gar technisch weshalb wir uns schnell gemeinsam mit der verwendeten Terminologie vertraut machen:
 
 
-#### Major-Release
+### Major-Release
 
 Bei einem Major-Release handelt es sich um eine komplett neue Version der Software, bei der viele grundlegende Dinge 
 geändert wurden und mit der bereits bestehende Seiten unter Umständen nicht mehr funktionieren. Die aktuelle 
 Major-Version von Contao ist beim Schreiben dieser Zeilen die **Version 4**.
 
 
-#### Minor-Release
+### Minor-Release
 
 Bei einem Minor-Release handelt es sich um eine Art Meilenstein auf dem Weg der Entwicklung, bei dem neue Funktionen 
 hinzugefügt wurden. Kleinere Anpassungen bestehender Seiten können daher notwendig sein. Die aktuelle Minor-Version von 
 Contao ist beim Schreiben dieser Zeilen die **Version 4.8**.
 
 
-#### Bugfix-Release
+### Bugfix-Release
 
 Bei einem Bugfix-Release handelt es sich um ein Wartungsrelease, dessen primärer Zweck die Behebung von Fehlern ist. 
 Die aktuelle Bugfix-Version von Contao ist beim Schreiben dieser Zeilen die **Version 4.8.4**.
 
 
-#### Long-Term-Support-Versionen
+### Long-Term-Support-Versionen
 
 Mit Version 2.11 wurde der [Release-Zyklus von Contao](https://contao.org/de/release-plan.html) angepasst und 
 [Long-Term-Support](https://de.wikipedia.org/wiki/Support_(Dienstleistung)#Long_Term_Support)-Versionen (LTS) 
@@ -47,7 +47,7 @@ Contao-Versionen veröffentlicht wurden. Eine Übersicht aller Contao Versionen 
 [Wikipedia](https://de.wikipedia.org/wiki/Contao#Versionen).
 
 
-### Aktualisierung mit dem Contao Manager
+## Aktualisierung mit dem Contao Manager
 
 {{% notice note %}}
 Vor der Aktualisierung von Contao wird empfohlen, ein Backup der `composer.json`,  `composer.lock` sowie der Datenbank 
@@ -70,7 +70,7 @@ werden.
 ![Aktualisierung für Minor-Release abgeschloßen](/de/installation/images/de/aktualisierung-fuer-minor-release-abgeschlossen.png?classes=shadow)
 
 
-#### Datenbanktabellen aktualisieren
+### Datenbanktabellen aktualisieren
 
 Öffne das [Contao-Installtool](../contao-installtool/), und überprüfe, ob nach der Aktualisierung irgendwelche 
 Änderungen an deiner Datenbank notwendig sind. Führe gegebenenfalls die vorgeschlagenen Änderungen durch, und schließe 
@@ -79,7 +79,7 @@ dann das Installtool.
 Deine Contao-Installation ist jetzt auf dem neuesten Stand.
 
 
-### Aktualisierung über die Kommandozeile {#aktualisierung-ueber-die-kommandozeile}
+## Aktualisierung über die Kommandozeile {#aktualisierung-ueber-die-kommandozeile}
 
 {{% notice note %}}
  Um Contao über die Kommandozeile aktualisieren zu können, muss Composer 
@@ -134,7 +134,7 @@ $ composer update
 ```
 
 
-#### Datenbanktabellen aktualisieren
+### Datenbanktabellen aktualisieren
 
 Öffne das [Contao-Installtool](../contao-installtool/), und überprüfe, ob nach der Aktualisierung irgendwelche 
 Änderungen an deiner Datenbank notwendig sind. Führe gegebenenfalls die vorgeschlagenen Änderungen durch, und schließe 
@@ -150,7 +150,7 @@ verwenden.
 Deine Contao-Installation ist jetzt auf dem neuesten Stand.
 
 
-### Lokale Aktualisierung ohne die Composer Resolver Cloud
+## Lokale Aktualisierung ohne die Composer Resolver Cloud
 
 Die Vorgehensweisen, die oben in [Aktualisierung über die Kommandozeile](#aktualisierung-ueber-die-kommandozeile) 
 und [Aktualisierung mit dem Contao Manager](#aktualisierung-mit-dem-contao-manager) beschrieben wurden, kannst du
@@ -160,7 +160,7 @@ Konfiguration selbst nach Bedarf anpassen.
 
 
 
-#### Voraussetzungen bei Verwendung der Kommandozeile
+### Voraussetzungen bei Verwendung der Kommandozeile
 
 Was benötigst du auf deinem Computer?
 
@@ -175,7 +175,7 @@ Was benötigst du _nicht_?
 - Eine lokale Contao-Installation
 
 
-#### Die Aktualisierung durchführen
+### Die Aktualisierung durchführen
 
 Kopiere die `composer.json` und `composer.lock` von deinem Hosting in dein Arbeitsverzeichnis.
 Im Wesentlichen machst du dann das Gleiche, wie oben unter
@@ -211,7 +211,7 @@ ausführen«.
 Zum Abschluss musst du noch die Datenbanktabellen aktualisieren. 
 
 
-#### Datenbanktabellen aktualisieren
+### Datenbanktabellen aktualisieren
 
 Öffne das [Contao-Installtool](../contao-installtool/) und überprüfe, ob nach der Aktualisierung Änderungen an deiner 
 Datenbank notwendig sind. Führe gegebenenfalls die vorgeschlagenen Änderungen durch und schließe dann das Installtool.
@@ -226,7 +226,7 @@ verwenden.
 Deine Contao-Installation ist jetzt auf dem neuesten Stand.
 
 
-#### Verschiedene PHP-Versionen
+### Verschiedene PHP-Versionen
 
 Wenn die lokal verwendete PHP-Version eine andere ist, als bei deinem Hosting, musst du in der `composer.json`
 angeben, welche PHP-Version verwendet werden soll:
@@ -244,7 +244,7 @@ angeben, welche PHP-Version verwendet werden soll:
     ...
 ```
 
-#### Lokale Updates mit dem Contao Manager
+### Lokale Updates mit dem Contao Manager
 
 Du benötigst eine lokale Contao-Installation. In dieser installierst du den Contao Manager und führst das Update wie
 im Abschnitt [Aktualisierung mit dem Contao Manager](#aktualisierung-mit-dem-contao-manager) beschrieben durch. 

--- a/docs/manual/installation/update-contao.en.md
+++ b/docs/manual/installation/update-contao.en.md
@@ -12,39 +12,39 @@ bugs are fixed, new features are added or performance is improved. It is therefo
 version.
 
 
-### The Contao update cycle
+## The Contao update cycle
 
 Contao follows the concept of [Semantic Versioning](https://semver.org) for the version numbers, which sounds a bit 
 technical so we will quickly get familiar with the terminology used:
 
 
-#### Major release
+### Major release
 
 A major release is a completely new version of the software where many basic things have been changed and existing pages 
 may not work anymore. The current major release of Contao is **version 4** when writing these lines.
 
 
-#### Minor release
+### Minor release
 
 A minor release is a kind of milestone on the development path where new features have been added. Minor changes to 
 existing pages might therefore be necessary. When writing these lines, the current minor version of Contao 
 is **version 4.10**.
 
 
-#### Bugfix release
+### Bugfix release
 
 A bugfix release is a maintenance release whose primary purpose is to fix bugs; the current bugfix version of Contao 
 when writing these lines is **version 4.10.4**.
 
 
-#### Long-Term Support Versions
+### Long-Term Support Versions
 
 With version 2.11, the [release cycle of Contao](https://contao.org/de/release-plan.html) has been adjusted and 
 Long-Term Support (LTS) versions have been introduced that are supported and updated for 24 months, even if newer Contao 
 versions have been released in the meantime. An overview of all Contao versions is available on [Wikipedia](https://en.wikipedia.org/wiki/Contao#Versions).
 
 
-### Updating with the Contao Manager
+## Updating with the Contao Manager
 
 {{% notice note %}}
  Before updating Contao, it is recommended to create a backup of the `composer.json`, `composer.lock` files and the 
@@ -67,14 +67,14 @@ icon![Show/Hide Console Output](/de/icons/konsolenausgabe.png?classes=icon).
 ![Update for minor release completed](/de/installation/images/de/aktualisierung-fuer-minor-release-abgeschlossen.png?classes=shadow)
 
 
-#### Update database tables
+### Update database tables
 
 Open the [Contao install tool](../contao-installtool/) and check if any changes to your database are necessary after 
 the update. If necessary, make the suggested changes and then close the install tool.
 
 Your Contao installation is now up to date.
 
-### Updating via the command line {#update-via-the-command-line}
+## Updating via the command line {#update-via-the-command-line}
 
 {{% notice note %}}
  To update Contao via the command line you need to have Composer [installed](../install-contao/#install-composer). 
@@ -127,7 +127,7 @@ Now trigger the update on the command line.
 $ composer update
 ```
 
-#### Update database tables
+### Update database tables
 
 Open the [Contao install tool](../contao-installtool/) and check if any changes to your database are necessary after 
 the update. If necessary, make the suggested changes and then close the install tool.
@@ -141,7 +141,7 @@ $ vendor/bin/contao-console contao:migrate
 Your Contao installation is now up to date.
 
 
-### Update locally without the Composer Resolver Cloud
+## Update locally without the Composer Resolver Cloud
 
 The procedures described above in [Updating via the command line](#update-via-the-command-line) 
 and [Update with the Contao Manager](#updating-with-the-contao-manager), can also be used locally. 
@@ -150,7 +150,7 @@ unfulfilled system requirements such as insufficient memory, because you can set
 configuration as required yourself.
 
 
-#### Requirements for using the command line
+### Requirements for using the command line
 
 What do you need on your computer?
 
@@ -165,7 +165,7 @@ What do you _not_ need?
 - A local Contao installation
 
 
-#### Perform the update
+### Perform the update
 
 Copy the `composer.json` and `composer.lock` from your hosting to your working directory.
 You then do essentially the same as described above in
@@ -201,7 +201,7 @@ execute".
 Finally you have to update the database tables. 
 
 
-#### Update database tables
+### Update database tables
 
 Open the [Contao-Installtool](../contao-installtool/) and check if changes to your database are necessary. If necessary, 
 make the suggested changes and then close the install tool.
@@ -216,7 +216,7 @@ use.
 Your Contao installation is now up to date.
 
 
-#### Different PHP versions
+### Different PHP versions
 
 If the PHP version used locally is different from the one on your hosting, you need to specify which PHP version should 
 be used in your `composer.json` file:
@@ -235,7 +235,7 @@ be used in your `composer.json` file:
 ```
 
 
-#### Local updates with the Contao Manager
+### Local updates with the Contao Manager
 
 You need a local Contao installation. In this installation, you install the Contao Manager and run the update like
 described in the section [Updating with the Contao Manager](#updating-with-the-contao-manager). 


### PR DESCRIPTION
The headline levels were not correct on the update page (`h1`, `h3`, `h4`, … instead of `h1`, `h2`, `h3`).