### PR TITLE
Prepare renaming the master branch to main

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -3,7 +3,7 @@ name: Build and deploy to https://docs.contao.org
 on:
     push:
         branches:
-            - master
+            - main
     workflow_dispatch: ~
 
 jobs:

--- a/docs/dev/getting-started/extension.md
+++ b/docs/dev/getting-started/extension.md
@@ -145,12 +145,12 @@ the Contao 4 installation:
 ```
 
 In the `require` part we can then request the installation of our extension, using
-the defined package name and `dev-master` as the version.
+the defined package name and `dev-main` as the version.
 
 ```json
 {
     "require": {
-        "somevendor/contao-example-bundle": "dev-master"
+        "somevendor/contao-example-bundle": "dev-main"
     }
 }
 ```
@@ -322,7 +322,7 @@ $ git init
 $ git add --all
 $ git commit -m "initial commit"
 $ git remote add origin git@github.com:somevendor/contao-example-bundle.git
-$ git push origin master
+$ git push origin main
 ```
 
 Then the package can be published on the public Packagist by submitting the URL
@@ -335,7 +335,7 @@ a look at the [dedicated article][9].
 
 Once the package has been published to the public Packagist, the extension's repository
 can actually be removed from the root `composer.json` of the Contao installation.
-When requiring `dev-master` (or any `dev-` branch) of the extension, composer will
+When requiring `dev-main` (or any `dev-` branch) of the extension, composer will
 actually check out the code from the Git repository instead. This enables you to
 push any changes you make back to the origin branch using your SSH key.
 

--- a/docs/dev/internals/issue-workflow.md
+++ b/docs/dev/internals/issue-workflow.md
@@ -42,7 +42,7 @@ After reading a new PR, please label it either as <span class="label-bug">bug</s
 <span class="label-feature">feature</span>.
 
 If the PR is targeted against an active version branch (e.g. `4.4`), please assign it to the corresponding milestone.
-Do not assign PRs targeted against the `master` branch to a milestone.
+Do not assign PRs targeted against the `4.x` branch to a milestone.
 
 Please assign new PRs to their creator.
 

--- a/page/config/dev/params.yml
+++ b/page/config/dev/params.yml
@@ -1,2 +1,2 @@
-editURL: 'https://github.com/contao/docs/edit/master/docs/dev/'
+editURL: 'https://github.com/contao/docs/edit/main/docs/dev/'
 documentation_label: 'Developer Documentation'

--- a/page/config/manual/params.yml
+++ b/page/config/manual/params.yml
@@ -1,2 +1,2 @@
-editURL: 'https://github.com/contao/docs/edit/master/docs/manual/'
+editURL: 'https://github.com/contao/docs/edit/main/docs/manual/'
 documentation_label: Manual


### PR DESCRIPTION
See https://github.com/contao/contao/issues/2642

Fortunately, we do not have to rename links to github.com as they will be redirected to the new default branch automatically (affects contao/contao and symfony/symfony). 🎉 
