### PR TITLE
Link to Devilbox documentation for Docker and Docker Compose installation

### DIFF
--- a/docs/manual/guides/local-installation/devilbox.de.md
+++ b/docs/manual/guides/local-installation/devilbox.de.md
@@ -13,6 +13,13 @@ tags:
 Das [Devilbox Project](http://devilbox.org/) ist ein fertiges LAMP Stack für [Docker](https://www.docker.com/). 
 Wenn du die Docker-Toolbox einsetzt, sind [diese Angaben](https://devilbox.readthedocs.io/en/latest/howto/docker-toolbox/docker-toolbox-and-the-devilbox.html#howto-docker-toolbox-and-the-devilbox "Docker Toolbox and the Devilbox") der Dokumentation lesenswert.
 
+{{% notice note %}}
+Um die Devilbox nutzen zu können muss _Docker_ und _Docker Compose_ auf deinem System installiert sein. Falls das noch
+nicht der Fall ist, kannst du dir die 
+[Devilbox Prerequisites Dokumentation](https://devilbox.readthedocs.io/en/latest/getting-started/prerequisites.html) für 
+mehr Informationen zur Installation dieser Programme durchlesen.
+{{% /notice %}}
+
 
 ## Devilbox installieren und konfigurieren
 

--- a/docs/manual/guides/local-installation/devilbox.en.md
+++ b/docs/manual/guides/local-installation/devilbox.en.md
@@ -12,6 +12,12 @@ tags:
 The [Devilbox Project](http://devilbox.org/) is a complete LAMP stack for [Docker](https://www.docker.com/).
 If you use the Docker-Toolbox, [this part](https://devilbox.readthedocs.io/en/latest/howto/docker-toolbox/docker-toolbox-and-the-devilbox.html#howto-docker-toolbox-and-the-devilbox) of the documentation are worth reading.
 
+{{% notice note %}}
+In order to run the Devilbox you need to have _Docker_ and _Docker Compose_ installed on your system. Read through the
+[Devilbox Prerequisites documentation](https://devilbox.readthedocs.io/en/latest/getting-started/prerequisites.html) for 
+more information on that, if you are not running these applications yet on your system.
+{{% /notice %}}
+
 
 ## Install and configure the Devilbox
 


### PR DESCRIPTION
This is an alternative PR for https://github.com/contao/docs/pull/663. Instead of also explaining how to install _Docker_ and _Docker Compose_, which is just a basic requirement for running the Devilbox, we should simply link to the documentation on Devilbox on how to do that, should anyone require any help on how to install those software applications.