### PR TITLE
Add comment for debug button in back-end

### DIFF
--- a/docs/manual/system/debug-mode.de.md
+++ b/docs/manual/system/debug-mode.de.md
@@ -125,6 +125,9 @@ werden. Dazu befindet sich ein Button gleich neben dem Vorschau Button. Dieser B
 setzt dann ein spezielles Cookie, welches den Debug-Modus nur für den aktuellen
 Benutzer aktiviert.
 
+{{% notice info %}}
+Der Button wird nur angezeigt, wenn du keine App Umgebung in deiner `.env` Datei definiert hast. 
+{{% /notice %}}
 
 #### Contao Manager
 

--- a/docs/manual/system/debug-mode.en.md
+++ b/docs/manual/system/debug-mode.en.md
@@ -119,6 +119,8 @@ The debug mode can also be enabled by administrators within the back end of Cont
 Next to the preview button there will be a _Debug Mode_ button. When clicked, this
 will set a special cookie that enables the debug mode only for the current user.
 
+{{% notice info %}}
+The button will only be displayed, if no app environment is defined in your `.env` file.
 
 #### Contao Manager
 

--- a/docs/manual/system/debug-mode.en.md
+++ b/docs/manual/system/debug-mode.en.md
@@ -120,7 +120,8 @@ Next to the preview button there will be a _Debug Mode_ button. When clicked, th
 will set a special cookie that enables the debug mode only for the current user.
 
 {{% notice info %}}
-The button will only be displayed, if no app environment is defined in your `.env` file.
+The button will only be displayed, if you have not defined the app environment in your `.env` file.
+{{% /notice %}}
 
 #### Contao Manager
 


### PR DESCRIPTION
Clarifies, that you cannot switch to debug mode in back-end, if you have an app envrionment defined in your .env file