### PR TITLE
Add non-HTTPS CSRF cookie to example allow list

### DIFF
--- a/docs/dev/reference/config.md
+++ b/docs/dev/reference/config.md
@@ -242,7 +242,7 @@ So in most cases, the following configuration will score the maximum cache hits 
 cookies of extensions you installed:
 
 ```
-COOKIE_ALLOW_LIST=PHPSESSID,csrf_https-contao_csrf_token,trusted_device,REMEMBERME
+COOKIE_ALLOW_LIST=PHPSESSID,csrf_https-contao_csrf_token,csrf_contao_csrf_token,trusted_device,REMEMBERME
 ```
     
 {{% notice note %}}

--- a/docs/manual/performance/http-caching.de.md
+++ b/docs/manual/performance/http-caching.de.md
@@ -317,7 +317,7 @@ aus DSGVO-Sicht völlig unbedenklich sind, da technisch notwendig:
 Die höchste Anzahl Cache-Treffer und somit optimale Performance lässt sich folglich mit folgender Umgebungsvariable erzielen:
 
 ```
-COOKIE_ALLOW_LIST=PHPSESSID,csrf_https-contao_csrf_token,trusted_device,REMEMBERME
+COOKIE_ALLOW_LIST=PHPSESSID,csrf_https-contao_csrf_token,csrf_contao_csrf_token,trusted_device,REMEMBERME
 ```
     
 {{% notice note %}}

--- a/docs/manual/performance/http-caching.en.md
+++ b/docs/manual/performance/http-caching.en.md
@@ -312,7 +312,7 @@ So in most cases, the following configuration will score the maximum cache hits 
 cookies of extensions you installed:
 
 ```
-COOKIE_ALLOW_LIST=PHPSESSID,csrf_https-contao_csrf_token,trusted_device,REMEMBERME
+COOKIE_ALLOW_LIST=PHPSESSID,csrf_https-contao_csrf_token,csrf_contao_csrf_token,trusted_device,REMEMBERME
 ```
     
 {{% notice note %}}


### PR DESCRIPTION
Local development via unsecure HTTP is still quite common I think. 
And if the `csrf_contao_csrf_token` is missing in the allow list, debugging the CSRF issue is quite bad (I learned the hard way 😅).