### PR TITLE
Update callbacks - missing serp preview eval.url, eval.title_tag

### DIFF
--- a/docs/dev/reference/dca/callbacks.md
+++ b/docs/dev/reference/dca/callbacks.md
@@ -558,6 +558,28 @@ a button for an import "wizard".
 {{% /expand %}}
 
 
+### `fields.<FIELD>.eval.url`
+
+Allows you to add an url to the serp preview field.
+
+{{% expand "Parameters" %}}
+* `\Contao\Model` Model object (class from the table)
+
+**return:** `string` URL for the serp preview
+{{% /expand %}}
+
+
+### `fields.<FIELD>.eval.title_tag`
+
+Allows you to modify the title tag of the serp preview field.
+
+{{% expand "Parameters" %}}
+* `\Contao\Model` Model object (class from the table)
+
+**return:** `string` title tag for the serp preview
+{{% /expand %}}
+
+
 ## Edit Callbacks
 
 The following is a list of callbacks relating to edit actions of a Data Container.

--- a/docs/dev/reference/dca/callbacks.md
+++ b/docs/dev/reference/dca/callbacks.md
@@ -628,6 +628,7 @@ namespace App\EventListener\DataContainer;
 
 use App\Model\ExampleCategoryModel;
 use App\Model\ExampleModel;
+use Contao\Controller;
 use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\LayoutModel;
 use Contao\PageModel;
@@ -657,7 +658,7 @@ class ExampleSerpPreviewTitleTagCallbackListener
 
         /** @var LayoutModel $layout */
         $layout = $page->getRelated('layout');
-        
+
         if (null === $layout) {
             return '';
         }
@@ -665,7 +666,7 @@ class ExampleSerpPreviewTitleTagCallbackListener
         global $objPage;
         $objPage = $page;
 
-        return self::replaceInsertTags(str_replace('{{page::pageTitle}}', '%s', $layout->titleTag ?: '{{page::pageTitle}} - {{page::rootPageTitle}}'));
+        return Controller::replaceInsertTags(str_replace('{{page::pageTitle}}', '%s', $layout->titleTag ?: '{{page::pageTitle}} - {{page::rootPageTitle}}'));
     }
 }
 ```

--- a/docs/dev/reference/dca/callbacks.md
+++ b/docs/dev/reference/dca/callbacks.md
@@ -623,7 +623,7 @@ Allows you to modify the title tag of the serp preview field.
 {{% expand "Example" %}}
 
 ```php
-// src/EventListener/DataContainer/ExampleSerpPreviewTagTitleCallbackListener.php
+// src/EventListener/DataContainer/ExampleSerpPreviewTitleTagCallbackListener.php
 namespace App\EventListener\DataContainer;
 
 use App\Model\ExampleCategoryModel;
@@ -635,7 +635,7 @@ use Contao\PageModel;
 /**
  * @Callback(table="tl_example", target="fields.serpPreview.eval.title_tag")
  */
-class ExampleSerpPreviewTagTitleCallbackListener
+class ExampleSerpPreviewTitleTagCallbackListener
 {
     public function __invoke(ExampleModel $model): string
     {


### PR DESCRIPTION
Currently the field callbacks of the serp preview are not in the docs.
But we have to wait for a fix of the core, because we cannot tag them in a service for now!