### PR TITLE
Fix urlSuffix notation in page-controllers.md

### DIFF
--- a/docs/dev/framework/page-controllers.md
+++ b/docs/dev/framework/page-controllers.md
@@ -99,7 +99,7 @@ There are however a few differences and additional options.
  * @Page(
  *   type="example",
  *   path="/foo/bar",
- *   urlSuffix="html",
+ *   urlSuffix=".html",
  *   contentComposition=true
  * )
  */

--- a/docs/dev/framework/page-controllers.md
+++ b/docs/dev/framework/page-controllers.md
@@ -115,7 +115,7 @@ services:
                 name: contao.page
                 type: example
                 path: /foo/bar
-                urlSuffix: html
+                urlSuffix: .html
                 contentComposition: true
 ```
 {{% /tab %}}


### PR DESCRIPTION
Using urlSuffix="html" results in the path /foo/barhtml, which might not be desirable.