### PR TITLE
Update mashine translated text

### DIFF
--- a/docs/manual/layout/module-management/miscellaneous.de.md
+++ b/docs/manual/layout/module-management/miscellaneous.de.md
@@ -45,7 +45,7 @@ Das Frontend-Modul generiert folgenden HTML-Code:
 ## Zufallsbild
 
 Das Frontend-Modul »Zufallsbild« fügt der Webseite ein zufälliges Bild aus einer bestimmten Auswahl an Bildern hinzu. 
-Du kannst sowohl einzelne Bilder als auch ganze Ordner als Quelle auswählen. Vorhandene Meta-Dateien werden ausgewertet.
+Du kannst sowohl einzelne Bilder als auch ganze Ordner als Quelle auswählen. Vorhandene Metadaten werden ausgewertet.
 
 **Quelldateien:** Hier kannst du mehrere Dateien bzw. Ordner auswählen. Die in einem Ordner enthaltenen Bilder werden 
 automatisch bei der Auswahl berücksichtigt.
@@ -75,7 +75,7 @@ automatisch bei der Auswahl berücksichtigt.
 **Großansicht/Neues Fenster:** Ist diese Option gewählt, wird das Bild beim Anklicken in seiner Originalgröße 
 geöffnet. Diese Option steht bei verlinkten Bildern nicht zur Verfügung.
 
-**Bildunterschrift anzeigen:** Wenn du diese Option auswählst, wird entweder die entsprechende Bildunterschrift aus der 
+**Bildunterschrift anzeigen:** Wenn du diese Option auswählst, wird entweder die entsprechende Bildunterschrift aus den 
 Metadaten angezeigt oder eine automatische Bildunterschrift aus dem Namen der Datei generiert.
 
 **Individuelles Template:** Hier kannst du das Standard-Template `mod_randomImage` überschreiben.
@@ -115,8 +115,7 @@ Das Modul hat kein umschließendes HTML-Markup.
 Mit dem Frontend-Modul »RSS-Reader« kannst du einen beliebigen RSS-Feed abonnieren und in deine Webseite einfügen. 
 Damit kannst du z. B. den Nachrichtenfeed von contao.org einbinden.
 
-Öffne die Modulverwaltung im Backend, und wähle das Modul »RSS-Leser« aus. Nachfolgend werden dir die einzelnen Eingabefelder 
-näher erklärt.
+Öffne die Modulverwaltung im Backend, und wähle das Modul »RSS-Leser« aus.
 
 **Feed-URLs:** Hier kannst du eine oder mehrere RSS-Feed-URLs eingeben.
 

--- a/docs/manual/layout/module-management/miscellaneous.en.md
+++ b/docs/manual/layout/module-management/miscellaneous.en.md
@@ -6,10 +6,6 @@ aliases:
 weight: 50
 ---
 
-{{% notice warning %}}
-This article is machine translated.
-{{% /notice %}}
-
 In this section you will be introduced to the other core modules in the "Miscellaneous" section. The list of frontend modules can also be extended by (third-party) extensions.
 
 ## Article list
@@ -22,7 +18,7 @@ With the frontend module "article list" you can output a list of all articles of
 
 **Set a reference page:** Here you can assign an individual source or target page to the module.
 
-**Individual template:** Here you can overwrite the standard `mod_articlelist`template.
+**Individual template:** Here you can overwrite the standard `mod_articlelist` template.
 
 **HTML OutputThe**  
  frontend module generates the following HTML code:
@@ -43,7 +39,7 @@ With the frontend module "article list" you can output a list of all articles of
 
 ## Random image
 
-The frontend module "Random Image" adds a random image from a certain selection of images to the website. You can select single images or whole folders as source. Existing meta files are evaluated.
+The frontend module "Random Image" adds a random image from a certain selection of images to the website. You can select single images or complete folders as source. Existing metadata are evaluated.
 
 **Source files:** Here you can select multiple files or folders. The images contained in a folder are automatically included in the selection.
 
@@ -69,12 +65,11 @@ The frontend module "Random Image" adds a random image from a certain selection 
 
 **Large View/New Window:** If this option is selected, the image will open in its original size when clicked. This option is not available for linked images.
 
-**Show caption:** If you select this option, either the corresponding caption from the metadata is displayed or an automatic caption is generated from the file name.
+**Show caption:** If you select this option, the corresponding caption from the metadata is displayed if available. Otherwise an automatic caption is generated from the file name.
 
-**Individual template:** Here you can overwrite the standard `mod_randomImage`template.
+**Individual template:** Here you can overwrite the standard `mod_randomImage` template.
 
-**HTML OutputThe**  
- front-end module generates the following HTML code:
+**HTML Output** The front-end module generates the following HTML code:
 
 ```html
 <!-- indexer::stop -->
@@ -90,31 +85,31 @@ The frontend module "Random Image" adds a random image from a certain selection 
 <!-- indexer::continue -->
 ```
 
-## Own HTML code
+## Custom HTML code
 
-The frontend module "Own HTML code" adds any HTML code to the web page.
+The frontend module "Custom HTML code" adds arbitrary HTML code to the web page.
 
-**HTML code:** Here you can enter the HTML code. Note that only those HTML tags can be used that you have enabled in the backend settings under "Allowed HTML tags".
+**HTML code:** Here you can enter the HTML code. Please note that only those HTML tags can be used that you have enabled in the backend settings under "Allowed HTML tags".
 
 The module has no enclosing HTML markup.
 
-**Individual template:** Here you can overwrite the standard `mod_html`template.
+**Individual template:** Here you can overwrite the standard `mod_html` template.
 
 ## RSS reader
 
 With the frontend module "RSS Reader" you can subscribe to any RSS feed and insert it into your website, e.g. to integrate the news feed of contao.org.
 
-Open the module administration in the backend and select the module "RSS reader". In the following, the individual input fields will be explained to you.
+Open the module administration in the backend and select the module "RSS reader". 
 
 **Feed URLs:** Here you can enter one or more RSS feed URLs.
 
 **Total number of posts:** Here you define how many posts are displayed.
 
-**Elements per page:** If you enter a value greater than 0 here, Contao will automatically spread the posts over multiple pages - assuming you have the right number of elements.
+**Elements per page:** If you enter a value greater than 0, Contao will automatically spread the posts over multiple pages - given there are enough elements.
 
 **Skip elements:** Here you can specify that a certain number of posts are skipped from the most recent post of the RSSS feed.
 
-**Cache expiration time:** Here you can specify how long an RSS feed is stored in the local cache before a new request is made.
+**Cache expiration time:** Here you can specify how long a RSS feed is stored in the local cache before a new request is made.
 
 **Feed-Template:** Here you select the feed template.
 
@@ -123,8 +118,7 @@ Open the module administration in the backend and select the module "RSS reader"
 | `rss_default` | Both the header of the RSS feed and the contributions are displayed. |
 | `rss_items_only` | Only the articles of the RSS feed are displayed. |
 
-**HTML OutputThe**  
- front-end module generated using the `rss_default`following HTML code:
+**HTML Output** Using the `rss_default` template, the front-end module generates the following HTML code:
 
 ```html
 <!-- indexer::stop -->
@@ -152,7 +146,7 @@ Open the module administration in the backend and select the module "RSS reader"
 <!-- indexer::continue -->
 ```
 
-The frontend module generates with `rss_items_only`the following HTML code:
+Using the `rss_items_only` template, the frontend module generates the following HTML code:  
 
 ```html
 <!-- indexer::stop -->


### PR DESCRIPTION
Changed in german doc also:
* meta files are obsolete. Should be metadata
* remove the sentence "In the following, the individual input fields will be explained to you." as we don't have this in the other sections