### PR TITLE
Improve template data section (hackaton, task 30)

### DIFF
--- a/docs/manual/layout/templates/template-data.de.md
+++ b/docs/manual/layout/templates/template-data.de.md
@@ -8,25 +8,19 @@ weight: 50
 ---
 
 Die verfügbaren Template-Daten variieren je nach Quelle der Vorlage. In der Regel ist der vollständige 
-Datensatz im Template verfügbar. Die einzelnen Datensätze entsprechen den jeweiligen Datenbankeinträgen und 
-sind im Template über die Angabe von `$this->…` erreichbar. 
+Datensatz im Template über die Angabe von `$this->…` erreichbar.
 
-Du kannst dir alle verfügbaren Template-Daten eines Templates anzeigen lassen. Entweder über 
+Du kannst dir alle verfügbaren Daten eines Templates anzeigen lassen: 
 
 ```php
 <?php $this->dumpTemplateVars() ?>
 ```
 
-oder über 
-
-```php
-<?php dump($this) ?>
-```
-
-Beide Anweisungen verwenden die [Symfony VarDumper-Komponente](https://symfony.com/doc/current/components/var_dumper.html) 
-zur Anzeige der Template-Daten.
+Die Anweisung verwendet die [Symfony VarDumper-Komponente](https://symfony.com/doc/current/components/var_dumper.html) 
+zur Anzeige der Template-Daten – im Debug-Modus wird die Ausgabe dabei an die Symfony Debug Toolbar umgeleitet.  
 
 {{% notice info %}}
-Falls du die [Template-Vererbung]({{< ref "template-inheritance.de.md" >}}) nutzt, wird der Auszug der Template-Daten nur im 
-[Debug-Modus]({{< ref "debug-mode.de.md" >}}) angezeigt oder wenn sich die Anweisung zwischen `$this->block(…)` und `$this->endblock()` befindet.
+Falls du [Template-Vererbung]({{< ref "template-inheritance.de.md" >}}) nutzt, wird der Auszug der Template-Daten nur im 
+[Debug-Modus]({{< ref "debug-mode.de.md" >}}) angezeigt oder wenn sich die Anweisung zwischen `$this->block(…)` und
+`$this->endblock()` befindet.
 {{% /notice %}}

--- a/docs/manual/layout/templates/template-data.en.md
+++ b/docs/manual/layout/templates/template-data.en.md
@@ -6,26 +6,19 @@ aliases:
 weight: 50
 ---
 
-{{% notice warning %}}
-This article is machine translated.
-{{% /notice %}}
+The available template context varies depending on the template source. Usually, the complete data can be accessed via
+`$this->…`.
 
-The available template data varies depending on the template source. Usually the complete data set is available in the template. The individual data records correspond to the respective database entries and can be `$this->…`accessed in the template by specifying
-
-You can display all available template data of a template. You can either use
+You can dump all available template data to see what's there:
 
 ```php
 <?php $this->dumpTemplateVars() ?>
 ```
 
-or via
-
-```php
-<?php dump($this) ?>
-```
-
-Both statements use the [Symfony VarDumper component to](https://symfony.com/doc/current/components/var_dumper.html) display the template data.
+This statement uses the [Symfony VarDumper component](https://symfony.com/doc/current/components/var_dumper.html) to 
+display the data. In debug mode, the output will therefore be redirected to the Symfony Debug Toolbar.
 
 {{% notice info %}}
-If you use [template inheritance]({{< ref "template-inheritance.en.md" >}}), the template data is only displayed in debug mode or if the statement is between `$this->block(…)`and `$this->endblock()`
+If you use [template inheritance]({{< ref "template-inheritance.en.md" >}}), the template data is only displayed in
+debug mode or if the statement is enclosed between `$this->block(…)` and `$this->endblock()` statements.
 {{% /notice %}}


### PR DESCRIPTION
(also includes some changes to the german version)

Removed the reference to `dump($this)` as it's IMHO less helpful to give both options and added a word about the output landing in the debug toolbar instead.