### PR TITLE
Improve move contao section (hackaton, task 8)

### DIFF
--- a/docs/manual/installation/move-contao.en.md
+++ b/docs/manual/installation/move-contao.en.md
@@ -23,7 +23,7 @@ To reduce the risk of conflicts, make sure your source and target server both ru
 You can either create a MySQL dump with the graphical database administration tool [phpMyAdmin](https://www.phpmyadmin.net/)
 or use the `mysqldump` program from the command line.
 
-{{< tabs >}}
+{{< tabs groupId="mysql-transfer" >}}
 {{% tab name="phpMyAdmin" %}}
 Log into "phpMyAdmin", select the database you want to export, select the "Export" tab in the upper menu and click "Ok".
 
@@ -47,7 +47,7 @@ A `my_dump.sql.gz` file containing the dumps will be saved in the current direct
 
 
 ### Import the database (target)
-{{< tabs >}}
+{{< tabs groupId="mysql-transfer" >}}
 {{% tab name="phpMyAdmin" %}}
 Open "phpMyAdmin" on the target server and create a new database for your Contao application. Depending on the server
 configuration, this might only be possible via the provider's administration interface (e.g. Confixx, Plesk or cPanel). 

--- a/docs/manual/installation/move-contao.en.md
+++ b/docs/manual/installation/move-contao.en.md
@@ -90,13 +90,13 @@ scp -r files/ templates/ composer.json composer.lock your_server:/www/project/
 
 ## Installing Contao
 
-1. Make sure you have correctly set up your [hosting configuration](/en//installation/install-contao/#hosting-configuration).
+1. Make sure you have correctly set up your [hosting configuration](/en/installation/install-contao/#hosting-configuration).
 2. Then we let Composer do its work – as we also transferred the `composer.lock` file containing all package version
    details from the original server, Composer will replicate the identical state as before.
    
    To do so, either use the [Contao Manager](/en/installation/install-contao#installation-via-the-contao-manager) or the 
-   [command line](/en//installation/install-contao#installation-via-the-command-line) like you would with a regular
+   [command line](/en/installation/install-contao#installation-via-the-command-line) like you would with a regular
    installation.
-3. Run the [install tool](/en//installation/contao-installtool) to configure the new database connection. 
+3. Run the [install tool](/en/installation/contao-installtool) to configure the new database connection. 
 
 That's it! You're now ready to use your Contao installation on a new location.

--- a/docs/manual/installation/move-contao.en.md
+++ b/docs/manual/installation/move-contao.en.md
@@ -1,125 +1,102 @@
 ---
-title: 'Contao move'
-description: 'Moving a local installation to a live server is almost the same as a new installation.'
+title: 'Move Contao'
+description: 'Moving a Contao installation is almost the same as a new installation.'
 aliases:
     - /en/installation/move-contao/
 weight: 50
 ---
 
+Moving a Contao installation from one location to another (e.g. from a local installation to a live server) is almost
+the same as [installing](/en/installation/install-contao) but also includes transferring the existing database and
+application related files.
+
+1. [Transferring the database](#transferring-the-database)
+2. [Transferring the files](#transferring-the-files)
+3. [Installing Contao](#installing-contao)
+
 {{% notice warning %}}
-This article is machine translated.
+To reduce the risk of conflicts, make sure your source and target server both run the **[same PHP version](/en/installation/system-requirements/#minimum-php-requirements)**.
 {{% /notice %}}
 
-Moving a local installation to a live server is almost the same as a new installation.
+## Transferring the database
+### Export the database (source)
+You can either create a MySQL dump with the graphical database administration tool [phpMyAdmin](https://www.phpmyadmin.net/)
+or use the `mysqldump` program from the command line.
 
-{{% notice warning %}}
-To avoid inconvenience during the move, your local server should have the **[same PHP version](/en/installation/system-requirements/#minimum-php-requirements)** as running on the live server.
-{{% /notice %}}
+{{< tabs >}}
+{{% tab name="phpMyAdmin" %}}
+Log into "phpMyAdmin", select the database you want to export, select the "Export" tab in the upper menu and click "Ok".
 
-## Move Contao with the Contao Manager
-
-### Export database on the local server
-
-The easiest way to create a MySQL dump is to use the database administration "[phpMyAdmin](https://www.phpmyadmin.net/)". Log in to "phpMyAdmin", select the database you want to export and click the "Export" button in the upper menu.
+You will receive a `sql` file that you can import in the next step.
 
 ![Exporting the database](/de/installation/images/de/datenbank-exportieren.png?classes=shadow)
+{{% /tab %}}
+{{% tab name="Command line" %}}
+Make sure `mysqldump` and `gzip` is installed, then run the following command (replacing "my_user" and "my_db_name" with
+your database user and database name):
 
-### Import database on the live server
+```bash
+mysqldump --host=localhost --user=my_user --password --hex-blob --opt my_db_name | gzip -c > my_dump.sql.gz
+```
 
-Open "phpMyAdmin" on the target server and create a new database for Contao. Depending on the server configuration, this might only be possible via the administration interface (e.g. Confixx, Plesk or cPanel). Select the new empty database and click on the "Import" button in the upper menu. Then upload the SQL dump of the local database and start the import.
+Enter your database password if asked for.
+
+A `my_dump.sql.gz` file containing the dumps will be saved in the current directory that you can use in the next step.
+{{% /tab %}}
+{{< /tabs >}}
+
+
+### Import the database (target)
+{{< tabs >}}
+{{% tab name="phpMyAdmin" %}}
+Open "phpMyAdmin" on the target server and create a new database for your Contao application. Depending on the server
+configuration, this might only be possible via the provider's administration interface (e.g. Confixx, Plesk or cPanel). 
+
+Select the new (empty) database and click on the "Import" button in the upper menu. Then upload the previously created
+SQL dump and start the import.
 
 ![Importing the database](/de/installation/images/de/datenbank-importieren.png?classes=shadow)
+{{% /tab %}}
+{{% tab name="Command line" %}}
+Copy the previously created dump file to the target machine and navigate to it.
 
-### Installing Contao Manager on the live server
+Make sure `mysql` and `gunzip` is installed, then run the following command (replacing "my_user" and "my_db_name" with
+your database user and database name as well as "my_dump.sql.gz" with the appropriate file name of the copied dump.):
 
-Before you can move Contao to your server, you need to [install and configure the Contao Manager](/en/installation/contao-manager/#install-contao-manager).
+```bash
+gunzip < my_dump.sql.gz | mysql --host=localhost --user=my_user --password my_db_name
+```
+{{% /tab %}}
+{{< /tabs >}}
 
-### Transfer files to the live server { #transfer files to the server }
-
-Open your FTP program and connect to your server. Copy the following files and folders from the localContao directory to the server.
+## Transferring the files
+The following files and folders need to be transferred from the source to the target machine.
 
 - `files`
 - `templates`
 - `composer.json`
 - `composer.lock`
 
-If you still have old extensions within `system/modules/` or if you have created a `config.yml` in the directory `config/` or **before Contao 4.8** `app/config/` or if you created Contao adjustments under `contao/` or **before Contao 4.8** `app/Resources/contao/` then they have to be transferred to your server as well.
+If you still have old extensions within `system/modules/` or if you have created a `config.yml` in the directory
+`config/` (or **before Contao 4.8** `app/config/`) or if you created Contao adjustments under `contao/` (or **before 
+Contao 4.8** `app/Resources/contao/`), then they have to be transferred as well.
 
-### Install Contao on the live server
-
-Log in to the Contao Manager. Call your domain with the extension `/contao-manager.phar.php` and enter your access data.
-
-The Contao Manager automatically detects the extensions you have stored in the root directory `composer.json` and `composer.lock` when you click on the "Install" button, the manager `composer install` runs in the background and installs Contao and the extensions you used in the local installation.
-
-![Install Composer dependencies](/de/installation/images/de/composer-abhaengigkeiten-installieren.png?classes=shadow)
-
-The installation can now take several minutes. Details of the installation process can be displayed by clicking on the icon![Show/Hide Console Output](/de/icons/konsolenausgabe.png?classes=icon).
-
-![Relocation completed](/de/installation/images/de/umzug-abgeschlossen.png?classes=shadow)
-
-Open the [Contao install tool](/en/installation/contao-installtool/) and enter the access data for the new database.
-
-## Moving Contao from the command line { #contao-over-the-command line-move}
-
-### Export database on the local server
-
-The easiest way to create a MySQL dump on the command line is to use the following command followed by the password
-
+You can use an FTP client for this task or, if you prefer the command line, use `scp`:
 ```bash
-mysqldump -h localhost -u Benutzer -p --opt Datenbankname | gzip -c > mysqldump.sql.gz
+cd /path/to/project
+
+scp -r files/ templates/ composer.json composer.lock your_server:/www/project/
 ```
 
-The file will be saved in the directory you are in when you send the command.
+## Installing Contao
 
-### Transfer files to the server
+1. Make sure you have correctly set up your [hosting configuration](/en//installation/install-contao/#hosting-configuration).
+2. Then we let Composer do its work – as we also transferred the `composer.lock` file containing all package version
+   details from the original server, Composer will replicate the identical state as before.
+   
+   To do so, either use the [Contao Manager](/en/installation/install-contao#installation-via-the-contao-manager) or the 
+   [command line](/en//installation/install-contao#installation-via-the-command-line) like you would with a regular
+   installation.
+3. Run the [install tool](/en//installation/contao-installtool) to configure the new database connection. 
 
-Now you can transfer the data `secure copy` to your server.
-
-```bash
-scp -r /pfad/lokal/files/ /pfad/lokal/templates/ /pfad/lokal/composer.json /pfad/lokal/composer.lock 
-/pfad/lokal/mysqldump.sql.gz benutzername@example.com:server/www/example/
-```
-
-### Hosting Configuration
-
-In Contao, all publicly accessible files are located in the subfolder `/web` of the installation. Set the document root of the installation to this subfolder via the admin panel of the hosting provider and set up a database on this occasion.
-
-Example: `example.com`points to the directory `/www/example/web`
-
-{{% notice note %}}
-Pro Contao installation therefore requires a separate (sub)domain.
-{{% /notice %}}
-
-### Import database on the live server
-
-You have logged on to your server with your user name and domain.
-
-```bash
-ssh benutzername@example.com
-```
-
-To do this, change to the directory on the console where you want to install Contao.
-
-```bash
-cd www/example/
-```
-
-If [Composer has not yet been installed](/en/installation/install-contao/#install-composer), we will install it later.
-
-In the next step you can import the MySQL dump with the following command followed by the password.
-
-```bash
-gunzip < mysqldump.sql.gz | mysql -h localhost -u Benutzer -p Datenbankname
-```
-
-### Installing Contao on the live server
-
-After we have successfully completed all preparations, we install Contao with `composer install`. Unlike the `update`, 
-the `install` does not resolve any dependencies, they are located in the included `composer.lock`. Therefore, this process 
-will not go wrong because the system requirements are too high.
-
-```bash
-php composer.phar install
-```
-
-Then open the [Contao install tool](/en/installation/contao-installtool/) and enter the access data for the new database.
+That's it! You're now ready to use your Contao installation on a new location.

--- a/docs/manual/installation/move-contao.en.md
+++ b/docs/manual/installation/move-contao.en.md
@@ -7,7 +7,7 @@ weight: 50
 ---
 
 Moving a Contao installation from one location to another (e.g. from a local installation to a live server) is almost
-the same as [installing](/en/installation/install-contao) but also includes transferring the existing database and
+the same as [installing](../install-contao) but also includes transferring the existing database and
 application related files.
 
 1. [Transferring the database](#transferring-the-database)
@@ -15,7 +15,7 @@ application related files.
 3. [Installing Contao](#installing-contao)
 
 {{% notice warning %}}
-To reduce the risk of conflicts, make sure your source and target server both run the **[same PHP version](/en/installation/system-requirements/#minimum-php-requirements)**.
+To reduce the risk of conflicts, make sure your source and target server both run the **[same PHP version](../system-requirements/#minimum-php-requirements)**.
 {{% /notice %}}
 
 ## Transferring the database
@@ -90,13 +90,13 @@ scp -r files/ templates/ composer.json composer.lock your_server:/www/project/
 
 ## Installing Contao
 
-1. Make sure you have correctly set up your [hosting configuration](/en/installation/install-contao/#hosting-configuration).
+1. Make sure you have correctly set up your [hosting configuration](../install-contao/#hosting-configuration).
 2. Then we let Composer do its work – as we also transferred the `composer.lock` file containing all package version
    details from the original server, Composer will replicate the identical state as before.
    
-   To do so, either use the [Contao Manager](/en/installation/install-contao#installation-via-the-contao-manager) or the 
-   [command line](/en/installation/install-contao#installation-via-the-command-line) like you would with a regular
+   To do so, either use the [Contao Manager](../install-contao#installation-via-the-contao-manager) or the 
+   [command line](../install-contao#installation-via-the-command-line) like you would with a regular
    installation.
-3. Run the [install tool](/en/installation/contao-installtool) to configure the new database connection. 
+3. Run the [install tool](../contao-installtool) to configure the new database connection. 
 
 That's it! You're now ready to use your Contao installation on a new location.


### PR DESCRIPTION
This improves the "Move Contao" section.

* I wasn't really happy with the original document so I restructured it, made use of the tab feature and removed redundant content (see installation).
* I also adjusted the args of the dump/import commands because they were IMO easy to get wrong (no space in `-uUsername` for instance) or potentially generating bad files (missing `--hex-blob`).

These two things should get reviewed first IMO, because we likely want to port them to the German version as well.

Images will be adjusted by @stefansl in a followup PR.