### PR TITLE
Remove inclusion note for breadcrumb module

### DIFF
--- a/docs/manual/layout/module-management/navigation-modules.de.md
+++ b/docs/manual/layout/module-management/navigation-modules.de.md
@@ -169,10 +169,6 @@ Das Frontend-Modul generiert folgenden HTML-Code:
 </div>
 <!-- indexer::continue -->
 ```
-**Einbindung**
-Der Navigationspfad sollte nicht in die Kopfzeile (Header) eingefügt werden, da die Eigenschaft »breadcrumb« von
-dem Schema (z. B. schema.org) nicht als Objekt des Typs WPHeader erkannt wird. Die korrekte Einbindung kann z. B.
-mit dem [»Testtool für strukturierte Daten«](https://search.google.com/structured-data/testing-tool) geprüft werden.
 
 
 ## Quicknavigation

--- a/docs/manual/layout/module-management/navigation-modules.en.md
+++ b/docs/manual/layout/module-management/navigation-modules.en.md
@@ -140,11 +140,6 @@ The front-end module "Individual Navigation" adds a navigation menu to the Web p
 <!-- indexer::continue -->
 ```
 
-**Inclusion**
-The navigation path should not be inserted in the header, because the property "breadcrumb" is not recognized by
-the schema (e.g. schema.org) does not recognize it as an object of type WPHeader. The correct inclusion can be checked e.g.
-with the ["Structured Data Test Tool"](https://search.google.com/structured-data/testing-tool).
-
 
 ## Quick navigation
 


### PR DESCRIPTION
As discussed in https://github.com/contao/docs/pull/770 these changes were wrong. It is perfectly fine to include the breadcrumb navigation module into the `header` column in Contao (at least with the default `fe_page` template).