### PR TITLE
Depreate characterSet localconfig

### DIFF
--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -444,7 +444,7 @@ Beschreibung.
 | `adminEmail` | [E-Mail-Adresse des Systemadministrators](#globale-einstellungen). |
 | `allowedDownload` | [Erlaubte Download-Dateitypen](#dateien-und-bilder). |
 | `allowedTags` | [Erlaubte HTML-Tags](#sicherheitseinstellungen). |
-| `characterSet` | Der von Contao benutzte Zeichensatz. Standard: `utf-8` |
+| `characterSet` | Der von Contao benutzte Zeichensatz. _(veraltet)_ Nutze den Parameter `kernel.charset` stattdessen. Standard: `UTF-8`. |
 | `dateFormat` | [Datumsformat](#datum-und-zeit). |
 | `datimFormat` | [Datums- und Zeitformat](#datum-und-zeit). |
 | `defaultChmod` | [Standard-Zugriffsrechte](#standard-zugriffsrechte). |

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -429,7 +429,7 @@ The following is a comprehensive list of localconfig configurations still in use
 | `adminEmail` | [E-mail address of the system administrator](#global-configuration). |
 | `allowedDownload` | [Download file types](#files-and-images). |
 | `allowedTags` | [Allowed HTML tags](#security-settings). |
-| `characterSet` | Character set used by Contao. Default: `utf-8` |
+| `characterSet` | Character set used by Contao. _(deprecated)_ Use the parameter `kernel.charset` instead. Default: `UTF-8` |
 | `dateFormat` | [Date format](#date-and-time). |
 | `datimFormat` | [Date and time format](#date-and-time). |
 | `defaultChmod` | [Default access rights](#default-access-rights). |


### PR DESCRIPTION
First part of #769.
This can be merged before the release of 4.12 IMO, because `kernel.charset` already works in Contao 4.9.