### PR TITLE
Update move-contao.de.md Dateien übertragen system/config

### DIFF
--- a/docs/manual/installation/move-contao.de.md
+++ b/docs/manual/installation/move-contao.de.md
@@ -85,9 +85,10 @@ Die folgenden Dateien und Ordner müssen vom Quell- zum Zielserver übertragen w
 - `composer.json`
 - `composer.lock`
 
-Falls du noch alte Erweiterungen unter `system/modules` abgelegt hast, eine `config.yml` im Verzeichnis `config/`
-(bzw. **vor Contao 4.8** `app/config/`) oder Contao Anpassungen unter `contao/` (bzw. **vor Contao 4.8** 
-`app/Resources/contao/`) angelegt hast, müssen diese auch auf deinen Server übertragen werden.
+Falls du noch alte Erweiterungen unter `system/modules` abgelegt hast, alte Konfigurationen unter `system/config`,
+eine `config.yml` im Verzeichnis `config/` (bzw. **vor Contao 4.8** `app/config/`) oder Contao Anpassungen unter
+`contao/` (bzw. **vor Contao 4.8**  `app/Resources/contao/`) angelegt hast, müssen diese auch auf deinen Server
+übertragen werden.
 
 Du kannst dazu entweder einen FTP-Client verwenden oder – falls du die Konsole bevorzugst – das Programm `scp`:
 


### PR DESCRIPTION
Erwähnung von ``system/config`` im Abschnitt ``Dateien übertragen``.