### PR TITLE
Fix missing nullable type in onload callback

### DIFF
--- a/docs/dev/reference/dca/callbacks.md
+++ b/docs/dev/reference/dca/callbacks.md
@@ -83,7 +83,7 @@ class MakeTextNotMandatoryCallback
         $this->requestStack = $requestStack;
     }
 
-    public function __invoke(DataContainer $dc = null): void
+    public function __invoke(?DataContainer $dc = null): void
     {
         if (null === $dc || !$dc->id || 'edit' !== $this->requestStack->getCurrentRequest()->query->get('act')) {
             return;


### PR DESCRIPTION
This PR fix a missing nullable type in the onload callback example.