### PR TITLE
Fix file hint

### DIFF
--- a/docs/dev/framework/content-elements.md
+++ b/docs/dev/framework/content-elements.md
@@ -230,7 +230,7 @@ class ExampleController extends AbstractContentElementController
 ```
 
 ```php
-// contao/dca/tl_module.php
+// contao/dca/tl_content.php
 use App\Controller\ContentElement\ExampleController;
 
 $GLOBALS['TL_DCA']['tl_content']['palettes'][ExampleController::TYPE] = 


### PR DESCRIPTION
The file hint within the code example was pointing to contao/dca/tl_module.php. In the example a tl_content palette is added, which should be placed in contao/dca/tl_content.php