### PR TITLE
Document new website settings

### DIFF
--- a/docs/manual/layout/site-structure/configure-pages.de.md
+++ b/docs/manual/layout/site-structure/configure-pages.de.md
@@ -184,6 +184,34 @@ kann dieses Verhalten beeinflusst und die automatische Weiterleitung zu bestimmt
 werden.
 
 
+### Website-Einstellungen
+
+{{< version "4.9" >}}
+
+**Favicon:** Hier kannst du das Favicon für die `/favicon.ico` URL der Domain festlegen. Dies ist besonders im Multidomain-Betrieb
+hilfreich, damit jede Domain ihr eigenes Standard-Favicon hat. Andernfalls könnte man nur eine einzelne, _physische_ `favicon.ico` Datei im 
+Document Root hinterlegen. Dadurch kann im Browser das korrekte Favicon pro Domain angezeigt werden, wenn Inhalte dargestellt werden, die
+keine HTML-Ausgabe beinhalten (wie zum Beispiel Bilder, PDFs, etc.).
+
+{{% notice "warning" %}}
+Dies wird nicht funktionieren, wenn sich bereits eine physiche `favicon.ico` Datei im Document Root befindet, da der Web Server diese Datei
+dann direkt ausspielt. Stelle daher sicher, dass diese Datei gelöscht wurde, bevor du diese Funktion nutzt.
+{{% /notice %}}
+
+{{% notice "info" %}}
+Diese Funktion gibt keine zusätzlichen HTML Meta Tags auf der Seite aus.
+{{% /notice %}}
+
+**Individuelle robots.txt-Anweisungen:** Hier kannst du eigene Direktiven für die `/robots.txt` URL der Domain eingeben. Dies ist besonders
+im Multidomain-Betrieb hilfreich, damit jede Domain ihre eigenen Direktiven haben kann. Andernfalls könnte man nur eine einzelne, 
+_physische_ `robots.txt` Datei im Document Root hinterlegen.
+
+{{% notice "warning" %}}
+Dies wird nicht funktionieren, wenn sich bereits eine physiche `robots.txt` Datei im Document Root befindet, da der Web Server diese Datei
+dann direkt ausspielt. Stelle daher sicher, dass diese Datei gelöscht wurde, bevor du diese Funktion nutzt.
+{{% /notice %}}
+
+
 ### Globale Einstellungen
 
 **E-Mail-Adresse des Webseiten-Administrators:** Hier kannst du die in den Backend-Einstellungen festgelegte 

--- a/docs/manual/layout/site-structure/configure-pages.de.md
+++ b/docs/manual/layout/site-structure/configure-pages.de.md
@@ -194,7 +194,7 @@ Document Root hinterlegen. Dadurch kann im Browser das korrekte Favicon pro Doma
 keine HTML-Ausgabe beinhalten (wie zum Beispiel Bilder, PDFs, etc.).
 
 {{% notice "warning" %}}
-Dies wird nicht funktionieren, wenn sich bereits eine physiche `favicon.ico` Datei im Document Root befindet, da der Web Server diese Datei
+Dies wird nicht funktionieren, wenn sich bereits eine physische `favicon.ico` Datei im Document Root befindet, da der Web Server diese Datei
 dann direkt ausspielt. Stelle daher sicher, dass diese Datei gelöscht wurde, bevor du diese Funktion nutzt.
 {{% /notice %}}
 
@@ -207,7 +207,7 @@ im Multidomain-Betrieb hilfreich, damit jede Domain ihre eigenen Direktiven habe
 _physische_ `robots.txt` Datei im Document Root hinterlegen.
 
 {{% notice "warning" %}}
-Dies wird nicht funktionieren, wenn sich bereits eine physiche `robots.txt` Datei im Document Root befindet, da der Web Server diese Datei
+Dies wird nicht funktionieren, wenn sich bereits eine physische `robots.txt` Datei im Document Root befindet, da der Web Server diese Datei
 dann direkt ausspielt. Stelle daher sicher, dass diese Datei gelöscht wurde, bevor du diese Funktion nutzt.
 {{% /notice %}}
 

--- a/docs/manual/layout/site-structure/configure-pages.en.md
+++ b/docs/manual/layout/site-structure/configure-pages.en.md
@@ -149,6 +149,34 @@ redirect to the website root of the browser's language (or the fallback language
 without any other parameters. You can exclude certin (or all) website roots from this automatic redirect through this setting.
 
 
+### Website settings
+
+{{< version "4.9" >}}
+
+**Favicon:** This allows you to select a favicon for the `/favicon.ico` URL of your domain. This is especially useful for multidomain setups
+so that you can easily serve different favicons for different domains from within the same Contao instance, since you can only have one
+_physical_ `favicon.ico` file in your document root otherwise. This will enable you to show the correct favicon per domain, if any non-HTML 
+resources are displayed in the browser directly (like images or PDFs, etc.).
+
+{{% notice "warning" %}}
+Keep in mind that this will not work if you already have a physical `favicon.ico` file in your document root, as the web server will then
+serve said file directly. Make sure to delete that file before trying to use this feature.
+{{% /notice %}}
+
+{{% notice "info" %}}
+Keep in mind that this feature will not add any additional meta tags to the HTML output.
+{{% /notice %}}
+
+**Custom robots.txt content:** This allows you to define the content of the `/robots.txt` URL of your domain. This is especially useful for 
+multidomain setups, since you can only have one _physical_ `robots.txt` file in your document root otherwise. This will enable you to define 
+different directives per domain.
+
+{{% notice "warning" %}}
+Keep in mind that this will not work if you already have a physical `robots.txt` file in your document root, as the web server will then
+serve said file directly. Make sure to delete that file before trying to use this feature.
+{{% /notice %}}
+
+
 ### Global settings
 
 **E-mail address of the website administrator:** Here you can overwrite the e-mail address of the system administrator defined in the backend settings for a specific website. This address is used to send notifications about blocked accounts or newly registered users, for example. If you have multiple websites within the site structure, it may be useful to set a separate administrator for each website, who will only receive notifications from his website. You can also use the following notation to add a name to your email address:

--- a/docs/manual/layout/site-structure/configure-pages.en.md
+++ b/docs/manual/layout/site-structure/configure-pages.en.md
@@ -153,7 +153,7 @@ without any other parameters. You can exclude certin (or all) website roots from
 
 {{< version "4.9" >}}
 
-**Favicon:** This allows you to select a favicon for the `/favicon.ico` URL of your domain. This is especially useful for multidomain setups
+**Favicon:** This allows you to select a favicon for the `/favicon.ico` URL of your domain. This is especially useful for multi-domain setups
 so that you can easily serve different favicons for different domains from within the same Contao instance, since you can only have one
 _physical_ `favicon.ico` file in your document root otherwise. This will enable you to show the correct favicon per domain, if any non-HTML 
 resources are displayed in the browser directly (like images or PDFs, etc.).
@@ -168,7 +168,7 @@ Keep in mind that this feature will not add any additional meta tags to the HTML
 {{% /notice %}}
 
 **Custom robots.txt content:** This allows you to define the content of the `/robots.txt` URL of your domain. This is especially useful for 
-multidomain setups, since you can only have one _physical_ `robots.txt` file in your document root otherwise. This will enable you to define 
+multi-domain setups, since you can only have one _physical_ `robots.txt` file in your document root otherwise. This will enable you to define 
 different directives per domain.
 
 {{% notice "warning" %}}


### PR DESCRIPTION
This documents the `favicon.ico` and `robots.txt` settings introduced in Contao 4.9.