### PR TITLE
Simplify + optimize code example / 'handling/saving form data' section

### DIFF
--- a/docs/manual/guides/form-save.de.md
+++ b/docs/manual/guides/form-save.de.md
@@ -89,8 +89,8 @@ use Doctrine\DBAL\Connection;
 class PrepareFormDataListener
 {
     // Change these variables for your form, calendar and author
-    private const FORM_ID = 6;
-    private const CALENDAR_ID = 2;
+    private const FORM_ID = 3;
+    private const CALENDAR_ID = 5;
     private const AUTHOR_ID = 1;
 
     private $slug;

--- a/docs/manual/guides/form-save.de.md
+++ b/docs/manual/guides/form-save.de.md
@@ -89,8 +89,8 @@ use Doctrine\DBAL\Connection;
 class PrepareFormDataListener
 {
     // Change these variables for your form, calendar and author
-    private const FORM_ID = 3;
-    private const CALENDAR_ID = 5;
+    private const FORM_ID = 6;
+    private const CALENDAR_ID = 2;
     private const AUTHOR_ID = 1;
 
     private $slug;
@@ -120,12 +120,12 @@ class PrepareFormDataListener
         $submittedData['alias'] = $this->getSlug($submittedData['title']);
 
         // Convert and set date fields
-        $submittedData['startDate'] = strtotime(trim($submittedData['startDate']));
+        $submittedData['startDate'] = strtotime(trim($submittedData['startDate'])) ?: null;
         $submittedData['startTime'] = $submittedData['startDate'];
 
         // Optional fields
         if (!empty(trim($submittedData['endDate']))) {
-            $submittedData['endDate'] = strtotime($submittedData['endDate']);
+            $submittedData['endDate'] = strtotime(trim($submittedData['endDate'])) ?: null;
             $submittedData['endTime'] = $submittedData['endDate'];
         } else {
             $submittedData['endDate'] = null;
@@ -147,6 +147,7 @@ class PrepareFormDataListener
         return $this->slug->generate($text, $options, $duplicateCheck);
     }
 }
+
 ```
 
 Die für unser Kalender benötigten Felder werden in dieser Datei gesetzt. Die folgenden Werte mußt du entsprechend

--- a/docs/manual/guides/form-save.de.md
+++ b/docs/manual/guides/form-save.de.md
@@ -128,28 +128,23 @@ class PrepareFormDataListener
             $submittedData['endDate'] = strtotime($submittedData['endDate']);
             $submittedData['endTime'] = $submittedData['endDate'];
         } else {
-            $submittedData['endTime'] = null;
             $submittedData['endDate'] = null;
+            $submittedData['endTime'] = null;
         }
     }
 
-    public function getSlug(string $text, string $locale = 'de', string $validChars = '0-9a-z'): string
+    private function getSlug(string $text, string $locale = 'de', string $validChars = '0-9a-z'): string
     {
         $options = [
             'locale' => $locale,
             'validChars' => $validChars,
         ];
-
+        
         $duplicateCheck = function (string $slug): bool {
-            return $this->slugExists($slug);
+            return $this->db->fetchOne('SELECT COUNT(*) FROM tl_calendar_events WHERE alias = ?', [$slug]) > 0;
         };
 
         return $this->slug->generate($text, $options, $duplicateCheck);
-    }
-
-    private function slugExists(string $slug): bool
-    {
-        return !empty($this->db->fetchAllAssociative('SELECT * FROM tl_calendar_events WHERE alias = ?', [$slug]));
     }
 }
 ```


### PR DESCRIPTION
followup to #781

I applied some best practices to the code example:
* `COUNT` should be preferred over fetching records (cheaper)
* `fetchOne` should be preferred over `fetchAssociative` if values are not needed (cheaper)
* methods should be `private` by default
* the `duplicateCheck` method is redundant - either the `slugExists` should be referenced as callback method or (what I did) the method can be inlined