### PR TITLE
Explain TRADITIONAL SQL mode

### DIFF
--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -180,6 +180,15 @@ doctrine:
                     1002: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"
 ```
 
+{{% notice "note" %}}
+Der [`TRADITIONAL` SQL Modus](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_traditional) ist ein Kombinations-Modus
+welcher unter Anderem aus den Modi `STRICT_TRANS_TABLES` und `STRICT_ALL_TABLES` besteht. Der »[Strict SQL Modus](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sql-mode-strict)« 
+ist aktiv wenn einer dieser Modi aktiviert ist. Der »Strict Modus« ist in aktuellen MySQL und MariaDB Versionen über die Einstellung 
+`STRICT_TRANS_TABLES` der Standard, jedoch nutzen viele Shared Hosting Umgebungen eigene Einstellungen. Der Vorteil des Strict Modus ist,
+dass fehlerhafte Datenbankoperationen auch tatsächlich einen Fehler verursachen, anstatt ohne Meldung vom Datenbankserver ignoriert zu
+werden. Dies führt zu einer verbesserten Datenintegrität und Sicherheit.
+{{% /notice %}}
+
 
 ## Webserver
 

--- a/docs/manual/installation/system-requirements.en.md
+++ b/docs/manual/installation/system-requirements.en.md
@@ -174,6 +174,15 @@ doctrine:
                     1002: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"
 ```
 
+{{% notice "note" %}}
+The [`TRADITIONAL` SQL mode](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_traditional) is a combination mode consisting of
+several SQL modes like `STRICT_TRANS_TABLES` and `STRICT_ALL_TABLES` among others. The "[Strict SQL Mode](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sql-mode-strict)" 
+is active when either `STRICT_TRANS_TABLES` or `STRICT_ALL_TABLES` is enabled. Strict mode (specifically `STRICT_TRANS_TABLES`) is enabled 
+by default in current versions of MySQL as well as MariaDB. However, many shared hosting environments use different settings. The advantage 
+of strict mode is that erroneous database operations will actually cause an error instead of being silently ignored by the database server, 
+leading to better data integrity and security.
+{{% /notice %}}
+
 
 ## Web server
 


### PR DESCRIPTION
This explains the `TRADITIONAL` SQL mode setting, which the Contao Install Tool currently suggests should be used (in case the strict mode is not enabled by default), in more detail. See also https://github.com/contao/contao/pull/3554