### PR TITLE
Add doNotRedirectEmpty and fix some other things

### DIFF
--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -96,18 +96,18 @@ contao:
 
 {{% notice note %}}
 Ab Version **4.10** wird die folgende Einstellung im Startpunkt der Webseite vorgenommen:
+{{% /notice %}}
 
 **Ordner-URLs verwenden:** Hier kannst du Ordnerstrukturen in Seitenaliasen aktivieren. Damit werden die in der
 Seitenhierarchie vorhandenen Aliase in den Alias mit übernommen z. B. die Seite »Download« im Seitenpfad 
 »Docs > Install« zu `docs/install/download.html` anstatt nur `download.html`.
-{{% /notice %}}
 
 {{% notice note %}}
 Ab Version **4.10** ist diese Einstellung entfallen:
+{{% /notice %}}
 
 **Leere URLs nicht umleiten:** Bei einer leeren URL die Webseite anzeigen anstatt auf den Startpunkt der Sprache 
 weiterzuleiten _(nicht empfohlen)_.
-{{% /notice %}}
 
 ### Sicherheitseinstellungen
 
@@ -471,6 +471,7 @@ Beschreibung.
 | `disableInsertTags` | Erlaubt es das Ersetzen von [Insert-Tags][InsertTags] global zu deaktivieren. |
 | `disableRefererCheck` | Erlaubt es die [Request Token Überprüfung][RequestTokens] komplett zu deaktivieren _(veraltet)_. |
 | `doNotCollapse` | [Elemente nicht verkürzen](#backend-einstellungen). |
+| `doNotRedirectEmpty` | [Leere URLs nicht umleiten](#frontend-einstellungen). |
 | `folderUrl` | [Ordner-URLs verwenden](#frontend-einstellungen). |
 | `gdMaxImgHeight` | [Maximale GD-Bildhöhe](#dateien-und-bilder). |
 | `gdMaxImgWidth` | [Maximale GD-Bildbreite](#dateien-und-bilder). |

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -91,21 +91,21 @@ contao:
 
 ### Front end configuration
 
+{{% notice note %}}
+Starting with version **4.10** this setting can be changed in the settings of the website root instead:
+{{% /notice %}}
+
 **Enable folder URLs:** Here you can activate folder structures in page aliases. This will add the aliases that exist in 
 the page hierarchy to the alias, e.g. the page "Download" in the page path "Docs &gt; Install" will use the alias 
 `docs/install/download.html` instead of just `download.html`.
 
+{{% notice note %}}
+This setting does not exist anymore in Contao **4.10** and higher:
+{{% /notice %}}
+
 **Do not redirect empty URLs:** Allows you to disable the redirect of the "empty URL" to the start page of the browser's 
 language respective website root when using the [legacy routing mode][LegacyRouting] without `contao.prepend_locale: true` 
 *(not recommended)*.
-
-**Deactivate the command scheduler:** Here you can disable the Periodic Command Scheduler and run the route 
-`_contao/cron` using a real cron job (which you have to set up yourself). Starting with Contao **4.9** you can also
-use the following command:
-
-```
-php vendor/bin/contao-console contao:cron
-```
 
 
 ### Security settings
@@ -169,6 +169,17 @@ contao:
         index_protected: false
 ```
 {{% /notice %}}
+
+
+### Cron job settings
+
+**Deactivate the command scheduler:** Here you can disable the Periodic Command Scheduler and run the route 
+`_contao/cron` using a real cron job (which you have to set up yourself). Starting with Contao **4.9** you can also
+use the following command:
+
+```
+php vendor/bin/contao-console contao:cron
+```
 
 
 ### Default access rights
@@ -445,6 +456,7 @@ The following is a comprehensive list of localconfig configurations still in use
 | `disableInsertTags` | Allows you to disable the replacement of [insert tags][InsertTags] globally. |
 | `disableRefererCheck` | Allows you to disable the [request token check][RequestTokens] entirely _(deprecated)_. |
 | `doNotCollapse` | [Do not collapse elements](#back-end-configuration). |
+| `doNotRedirectEmpty` | [Do not redirect empty URLs](#front-end-configuration). |
 | `folderUrl` | [Enable folder URLs](#front-end-configuration). |
 | `gdMaxImgHeight` | [Maximum GD image height](#files-and-images). |
 | `gdMaxImgWidth` | [Maximum GD image width](#files-and-images). |


### PR DESCRIPTION
This PR provides the following:

* Added the missing `doNotRedirectEmpty` `localconfig` setting.
* Fixed the notices for the front end configuration in the German version.
* Added the missing notices for the front end configuration in the English version.
* Moved the cron job settings in the English version (which was already done in the German version).