### PR TITLE
Fixed OptIn service example code

### DIFF
--- a/docs/dev/reference/services.md
+++ b/docs/dev/reference/services.md
@@ -127,7 +127,7 @@ class Example
 
     public function createOptIn(string $email, ExampleModel $model, string $optInUrl): void
     {
-        $token = $this->optIn->create('example-', $email, ['tl_example' => $model->id]);
+        $token = $this->optIn->create('example-', $email, ['tl_example' => [$model->id]]);
         $token->send('Opt-In', 'Click this link to opt-in: '.$optInUrl.'?token='.$token->getIdentifier());
     }
 

--- a/docs/dev/reference/services.md
+++ b/docs/dev/reference/services.md
@@ -105,6 +105,8 @@ class ExampleFormElementController extends AbstractContentElementController
 
 ## OptIn
 
+{{< version "4.7" >}}
+
 Contao offers an opt-in service (`contao.opt-in`) so that any opt-in process can be tracked centrally. The opt-in references will be saved 
 for the legally required duration and are then automatically discarded (if applicable).
 


### PR DESCRIPTION
This PR fix the example code for the opt in service. The related ids must be given as array, see https://github.com/contao/contao/blob/24b1731cb798ba9e6dc81135f2b1771d0d9fccd9/core-bundle/src/Resources/contao/models/OptInModel.php#L224