### PR TITLE
Clarify cache rebuilding

### DIFF
--- a/docs/manual/layout/site-structure/multilingual-websites.de.md
+++ b/docs/manual/layout/site-structure/multilingual-websites.de.md
@@ -44,6 +44,7 @@ erneuern«) oder alternativ über die Kommandozeile erneuert werden.
 
 ```bash
 vendor/bin/contao-console cache:clear --env=prod --no-warmup
+vendor/bin/contao-console cache:warmup --env=prod
 ```
 {{% /notice %}}
 

--- a/docs/manual/layout/site-structure/multilingual-websites.en.md
+++ b/docs/manual/layout/site-structure/multilingual-websites.en.md
@@ -32,6 +32,7 @@ For the changes to take effect, the application cache must be refreshed via the 
 
 ```bash
 vendor/bin/contao-console cache:clear --env=prod --no-warmup
+vendor/bin/contao-console cache:warmup --env=prod
 ```
 {{% /notice %}}
 

--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -528,6 +528,7 @@ Installationsverzeichnis befinden.
 
 ```bash
 php vendor/bin/contao-console cache:clear --env=prod --no-warmup
+php vendor/bin/contao-console cache:warmup --env=prod
 ```
 {{% /notice %}}
 
@@ -644,6 +645,7 @@ Installationsverzeichnis befinden.
 
 ```bash
 php vendor/bin/contao-console cache:clear --env=prod --no-warmup
+php vendor/bin/contao-console cache:warmup --env=prod
 ```
 {{% /notice %}}
 

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -511,6 +511,7 @@ In order to enable these changes, the application cache must be rebuilt using th
 
 ```bash
 php vendor/bin/contao-console cache:clear --env=prod --no-warmup
+php vendor/bin/contao-console cache:warmup --env=prod
 ```
 {{% /notice %}}
 
@@ -623,6 +624,7 @@ the Contao installation directory:
 
 ```bash
 php vendor/bin/contao-console cache:clear --env=prod --no-warmup
+php vendor/bin/contao-console cache:warmup --env=prod
 ```
 {{% /notice %}}
 


### PR DESCRIPTION
When clearing the cache with `--no-warmup` (which you should use), you should always also then warmup the cache afterwards - at least for the production environment. Otherwise the internal cache of Contao will be missing and thus the website will be slower.