### PR TITLE
Extend "Ein Feld im Backend ausblenden"

### DIFF
--- a/docs/manual/guides/dca-adjustments.de.md
+++ b/docs/manual/guides/dca-adjustments.de.md
@@ -71,6 +71,7 @@ PaletteManipulator::create()
 
 unset($GLOBALS['TL_DCA']['tl_member']['fields']['company']);
 ```
+
 Beachte: dadurch wird beim nächsten 
 [Aktualisieren der Datenbank](/de/installation/contao-installtool/#tabellen-aktualisieren) die Spalte `company` 
 zum Löschen vorgeschlagen!

--- a/docs/manual/guides/dca-adjustments.de.md
+++ b/docs/manual/guides/dca-adjustments.de.md
@@ -54,9 +54,9 @@ PaletteManipulator::create()
     ->applyToPalette('default', 'tl_member')
 ;
 
-unset($GLOBALS['TL_DCA']['tl_member']['fields']['dateOfBirth']['eval']['feEditable']);
-unset($GLOBALS['TL_DCA']['tl_member']['fields']['dateOfBirth']['eval']['feViewable']);
-unset($GLOBALS['TL_DCA']['tl_member']['fields']['dateOfBirth']['eval']['feGroup']);
+unset($GLOBALS['TL_DCA']['tl_member']['fields']['company']['eval']['feEditable']);
+unset($GLOBALS['TL_DCA']['tl_member']['fields']['company']['eval']['feViewable']);
+unset($GLOBALS['TL_DCA']['tl_member']['fields']['company']['eval']['feGroup']);
 ```
 
 Du kannst das Feld aber auch vollständig entfernen:   
@@ -69,11 +69,11 @@ PaletteManipulator::create()
     ->applyToPalette('default', 'tl_member')
 ;
 
-unset($GLOBALS['TL_DCA']['tl_member']['fields']['dateOfBirth']);
+unset($GLOBALS['TL_DCA']['tl_member']['fields']['company']);
 ```
 Beachte: dadurch wird beim nächsten 
-[Aktualisieren der Datenbank](/de/installation/contao-installtool/#tabellen-aktualisieren) die Spalte `dateOfBirth` 
-gelöscht!
+[Aktualisieren der Datenbank](/de/installation/contao-installtool/#tabellen-aktualisieren) die Spalte `company` 
+zum Löschen vorgeschlagen!
 {{% /expand %}}
 
 

--- a/docs/manual/guides/dca-adjustments.de.md
+++ b/docs/manual/guides/dca-adjustments.de.md
@@ -42,10 +42,38 @@ $GLOBALS['TL_DCA']['tl_news']['fields']['headline']['eval']['preserveTags'] = tr
 
 
 {{% expand "Ein Feld im Backend ausblenden" %}}
+Um das Feld auszublenden, wird die Palette geändert und das Feld aus den Einstellungen der Konfiguration des 
+[Moduls Personendaten](/de/layout/modulverwaltung/benutzermodule/#personendaten) entfernt:
+
 ```php
 // contao/dca/tl_member.php
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+
+PaletteManipulator::create()
+    ->removeField('company')
+    ->applyToPalette('default', 'tl_member')
+;
+
+unset($GLOBALS['TL_DCA']['tl_member']['fields']['dateOfBirth']['eval']['feEditable']);
+unset($GLOBALS['TL_DCA']['tl_member']['fields']['dateOfBirth']['eval']['feViewable']);
+unset($GLOBALS['TL_DCA']['tl_member']['fields']['dateOfBirth']['eval']['feGroup']);
+```
+
+Du kannst das Feld aber auch vollständig entfernen:   
+```php
+// contao/dca/tl_member.php
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+
+PaletteManipulator::create()
+    ->removeField('company')
+    ->applyToPalette('default', 'tl_member')
+;
+
 unset($GLOBALS['TL_DCA']['tl_member']['fields']['dateOfBirth']);
 ```
+Beachte: dadurch wird beim nächsten 
+[Aktualisieren der Datenbank](/de/installation/contao-installtool/#tabellen-aktualisieren) die Spalte `dateOfBirth` 
+gelöscht!
 {{% /expand %}}
 
 

--- a/docs/manual/guides/dca-adjustments.de.md
+++ b/docs/manual/guides/dca-adjustments.de.md
@@ -43,7 +43,7 @@ $GLOBALS['TL_DCA']['tl_news']['fields']['headline']['eval']['preserveTags'] = tr
 
 {{% expand "Ein Feld im Backend ausblenden" %}}
 ```php
-// for example: contao/dca/tl_member.php
+// contao/dca/tl_member.php
 unset($GLOBALS['TL_DCA']['tl_member']['fields']['dateOfBirth']);
 ```
 {{% /expand %}}

--- a/docs/manual/guides/dca-adjustments.en.md
+++ b/docs/manual/guides/dca-adjustments.en.md
@@ -43,7 +43,7 @@ $GLOBALS['TL_DCA']['tl_news']['fields']['headline']['eval']['preserveTags'] = tr
 
 {{% expand "Hide a field in the backend" %}}
 ```php
-// for example: contao/dca/tl_member.php
+// contao/dca/tl_member.php
 unset($GLOBALS['TL_DCA']['tl_member']['fields']['dateOfBirth']);
 ```
 {{% /expand %}}

--- a/docs/manual/guides/dca-adjustments.en.md
+++ b/docs/manual/guides/dca-adjustments.en.md
@@ -42,12 +42,39 @@ $GLOBALS['TL_DCA']['tl_news']['fields']['headline']['eval']['preserveTags'] = tr
 
 
 {{% expand "Hide a field in the backend" %}}
+To hide the field, you change the palette and remove the field from the configuration settings of the
+[module Personal data](/en/layout/module-management/user-modules/#personal-data):
+
 ```php
 // contao/dca/tl_member.php
-unset($GLOBALS['TL_DCA']['tl_member']['fields']['dateOfBirth']);
-```
-{{% /expand %}}
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
 
+PaletteManipulator::create()
+    ->removeField('company')
+    ->applyToPalette('default', 'tl_member')
+;
+
+unset($GLOBALS['TL_DCA']['tl_member']['fields']['company']['eval']['feEditable']);
+unset($GLOBALS['TL_DCA']['tl_member']['fields']['company']['eval']['feViewable']);
+unset($GLOBALS['TL_DCA']['tl_member']['fields']['company']['eval']['feGroup']);
+```
+
+You can also remove the field entirely:
+```php
+// contao/dca/tl_member.php
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+
+PaletteManipulator::create()
+    ->removeField('company')
+    ->applyToPalette('default', 'tl_member')
+;
+
+unset($GLOBALS['TL_DCA']['tl_member']['fields']['company']);
+```
+
+Note: with this change, the column `company` will be suggested for deletion when you run
+[Update tables](/en/installation/contao-installtool/#update-tables) in the Contao Install Tool!
+{{% /expand %}}
 
 {{% expand "Show IDs in page tree" %}}
 ```php


### PR DESCRIPTION
As commented in Slack the current example would remove the field while the title suggests it would only be hidden.

I tried to be a bit more specific to show both options (hiding and removing).

If we agree on the new description, I will extend the PR to also contain the english texts.