### PR TITLE
Update xampp.de.md

### DIFF
--- a/docs/manual/guides/local-installation/xampp.de.md
+++ b/docs/manual/guides/local-installation/xampp.de.md
@@ -67,6 +67,7 @@ Ergänze dazu die Datei D:\xampp\apache\conf\httpd.conf am Ende durch folgenden 
     ThreadStackSize 8388608
 </IfModule> 
 ```
+Danach muss XAMPP (Apache) neu gestartet werden.
 
 **Herzlichen Glückwunsch!** 
 Du hast alle Vorbereitungen für eine lokale Installation von Contao abgeschlossen.
@@ -164,7 +165,7 @@ Nutzung unseres neuen Verzeichnisses erst konfigurieren.
 `#LoadModule vhost_alias_module modules/mod_vhost_alias.so`. Entferne hier den Hashtag `#` und speichere deine Änderung. 
 Füge in der Datei `\apache\conf\extra\httpd-vhosts.conf` folgende Angaben hinzu:
 
-{{% notice info %}}
+```php
 <VirtualHost *:80>
   ServerAdmin webmaster@demo.local
   DocumentRoot "D:\vhost\demo\web"

--- a/docs/manual/guides/local-installation/xampp.de.md
+++ b/docs/manual/guides/local-installation/xampp.de.md
@@ -59,6 +59,7 @@ oder »file_uploads« überprüfen und anpassen.
 {{% /notice %}}
 
 ## Die Appache-Konfiguration
+
 Bei XAMPP bzw. Apache unter Windows ist der Default-Wert der sogenannten ThreadStackSize nur 1MB, während der Wert auf Linux-Plattformen standardmäßig bei 8MB liegt. Um Abstürze des lokalen Servers zu vermeiden, wird empfohlen diesen Wert zu erhöhen.
 Ergänze dazu die Datei D:\xampp\apache\conf\httpd.conf am Ende durch folgenden Code um die ThreadThreadStackSize auf 8MB zu erhöhen 
 

--- a/docs/manual/guides/local-installation/xampp.de.md
+++ b/docs/manual/guides/local-installation/xampp.de.md
@@ -63,7 +63,7 @@ oder »file_uploads« überprüfen und anpassen.
 Bei XAMPP bzw. Apache unter Windows ist der Default-Wert der sogenannten ThreadStackSize nur 1MB, während der Wert auf Linux-Plattformen standardmäßig bei 8MB liegt. Um Abstürze des lokalen Servers zu vermeiden, wird empfohlen diesen Wert zu erhöhen.
 Ergänze dazu die Datei D:\xampp\apache\conf\httpd.conf am Ende durch folgenden Code um die ThreadThreadStackSize auf 8MB zu erhöhen 
 
-```php
+```
 <IfModule mpm_winnt_module>
     ThreadStackSize 8388608
 </IfModule> 

--- a/docs/manual/guides/local-installation/xampp.de.md
+++ b/docs/manual/guides/local-installation/xampp.de.md
@@ -61,7 +61,7 @@ oder »file_uploads« überprüfen und anpassen.
 ## Die Apache-Konfiguration
 
 Bei XAMPP bzw. Apache unter Windows ist der Default-Wert der sogenannten ThreadStackSize nur 1 MB, während der Wert auf Linux-Plattformen standardmäßig bei 8 MB liegt. Um Abstürze des lokalen Servers zu vermeiden, wird empfohlen, diesen Wert zu erhöhen.
-Ergänze dazu die Datei D:\xampp\apache\conf\httpd.conf am Ende durch folgenden Code um die ThreadThreadStackSize auf 8MB zu erhöhen 
+Ergänze dazu die Datei `D:\xampp\apache\conf\httpd.conf` am Ende durch folgenden Code, um die ThreadThreadStackSize auf 8 MB zu erhöhen 
 
 ```
 <IfModule mpm_winnt_module>

--- a/docs/manual/guides/local-installation/xampp.de.md
+++ b/docs/manual/guides/local-installation/xampp.de.md
@@ -60,8 +60,8 @@ oder »file_uploads« überprüfen und anpassen.
 
 ## Die Apache-Konfiguration
 
-Bei XAMPP bzw. Apache unter Windows ist der Default-Wert der sogenannten ThreadStackSize nur 1 MB, während der Wert auf Linux-Plattformen standardmäßig bei 8 MB liegt. Um Abstürze des lokalen Servers zu vermeiden, wird empfohlen, diesen Wert zu erhöhen.
-Ergänze dazu die Datei `D:\xampp\apache\conf\httpd.conf` am Ende durch folgenden Code, um die ThreadThreadStackSize auf 8 MB zu erhöhen 
+Bei XAMPP bzw. Apache unter Windows ist der Default-Wert der sogenannten `ThreadStackSize` nur 1 MB, während der Wert auf Linux-Plattformen standardmäßig bei 8 MB liegt. Um Abstürze des lokalen Servers zu vermeiden, wird empfohlen, diesen Wert zu erhöhen.
+Ergänze dazu die Datei `D:\xampp\apache\conf\httpd.conf` am Ende durch folgenden Code, um die `ThreadStackSize` auf 8 MB zu erhöhen 
 
 ```
 <IfModule mpm_winnt_module>

--- a/docs/manual/guides/local-installation/xampp.de.md
+++ b/docs/manual/guides/local-installation/xampp.de.md
@@ -60,7 +60,7 @@ oder »file_uploads« überprüfen und anpassen.
 
 ## Die Appache-Konfiguration
 
-Bei XAMPP bzw. Apache unter Windows ist der Default-Wert der sogenannten ThreadStackSize nur 1MB, während der Wert auf Linux-Plattformen standardmäßig bei 8MB liegt. Um Abstürze des lokalen Servers zu vermeiden, wird empfohlen diesen Wert zu erhöhen.
+Bei XAMPP bzw. Apache unter Windows ist der Default-Wert der sogenannten ThreadStackSize nur 1 MB, während der Wert auf Linux-Plattformen standardmäßig bei 8 MB liegt. Um Abstürze des lokalen Servers zu vermeiden, wird empfohlen, diesen Wert zu erhöhen.
 Ergänze dazu die Datei D:\xampp\apache\conf\httpd.conf am Ende durch folgenden Code um die ThreadThreadStackSize auf 8MB zu erhöhen 
 
 ```

--- a/docs/manual/guides/local-installation/xampp.de.md
+++ b/docs/manual/guides/local-installation/xampp.de.md
@@ -68,6 +68,7 @@ Ergänze dazu die Datei `D:\xampp\apache\conf\httpd.conf` am Ende durch folgende
     ThreadStackSize 8388608
 </IfModule> 
 ```
+
 Danach muss XAMPP (Apache) neu gestartet werden.
 
 **Herzlichen Glückwunsch!** 

--- a/docs/manual/guides/local-installation/xampp.de.md
+++ b/docs/manual/guides/local-installation/xampp.de.md
@@ -58,6 +58,16 @@ Darüber hinaus könntest du optional auch die Einträge »allow_url_fopen«, »
 oder »file_uploads« überprüfen und anpassen.
 {{% /notice %}}
 
+## Die Appache-Konfiguration
+Bei XAMPP bzw. Apache unter Windows ist der Default-Wert der sogenannten ThreadStackSize nur 1MB, während der Wert auf Linux-Plattformen standardmäßig bei 8MB liegt. Um Abstürze des lokalen Servers zu vermeiden, wird empfohlen diesen Wert zu erhöhen.
+Ergänze dazu die Datei D:\xampp\apache\conf\httpd.conf am Ende durch folgenden Code um die ThreadThreadStackSize auf 8MB zu erhöhen 
+
+```php
+<IfModule mpm_winnt_module>
+    ThreadStackSize 8388608
+</IfModule> 
+```
+
 **Herzlichen Glückwunsch!** 
 Du hast alle Vorbereitungen für eine lokale Installation von Contao abgeschlossen.
 
@@ -154,7 +164,7 @@ Nutzung unseres neuen Verzeichnisses erst konfigurieren.
 `#LoadModule vhost_alias_module modules/mod_vhost_alias.so`. Entferne hier den Hashtag `#` und speichere deine Änderung. 
 Füge in der Datei `\apache\conf\extra\httpd-vhosts.conf` folgende Angaben hinzu:
 
-```php
+{{% notice info %}}
 <VirtualHost *:80>
   ServerAdmin webmaster@demo.local
   DocumentRoot "D:\vhost\demo\web"

--- a/docs/manual/guides/local-installation/xampp.de.md
+++ b/docs/manual/guides/local-installation/xampp.de.md
@@ -58,7 +58,7 @@ Darüber hinaus könntest du optional auch die Einträge »allow_url_fopen«, »
 oder »file_uploads« überprüfen und anpassen.
 {{% /notice %}}
 
-## Die Appache-Konfiguration
+## Die Apache-Konfiguration
 
 Bei XAMPP bzw. Apache unter Windows ist der Default-Wert der sogenannten ThreadStackSize nur 1 MB, während der Wert auf Linux-Plattformen standardmäßig bei 8 MB liegt. Um Abstürze des lokalen Servers zu vermeiden, wird empfohlen, diesen Wert zu erhöhen.
 Ergänze dazu die Datei D:\xampp\apache\conf\httpd.conf am Ende durch folgenden Code um die ThreadThreadStackSize auf 8MB zu erhöhen 


### PR DESCRIPTION
Anpassungen der httpd.conf wegen Problemen mit Contao 4.12 (Installtool) unter PHP8. Die Probleme müssen sich aber nicht nur auf das Szenario beschränken