### PR TITLE
Remove MyISAM from fallback table configuration

### DIFF
--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -146,7 +146,6 @@ doctrine:
                 default_table_options:
                     charset: utf8
                     collate: utf8_unicode_ci
-                    engine: MyISAM
 ```
 
 Es wird außerdem empfohlen, MySQL im "Strict Mode" zu betreiben, um korrupte oder abgeschnittene

--- a/docs/manual/installation/system-requirements.en.md
+++ b/docs/manual/installation/system-requirements.en.md
@@ -140,7 +140,6 @@ doctrine:
                 default_table_options:
                     charset: utf8
                     collate: utf8_unicode_ci
-                    engine: MyISAM
 ```
 
 It is further recommended to run MySQL in "strict mode" to prevent corrupt or truncated


### PR DESCRIPTION
Currently the docs suggest to switch back to `utf8` _and_ to `MyISAM` when there are problems with the row size. However, also switching to `MyISAM` might cause additional problems - and `MyISAM` will not be available in all hosting environments anymore. Thus the docs should not suggest this anymore.