### PR TITLE
A new approach for #880 that had to be reverted

### DIFF
--- a/page/static/css/theme-contao.css
+++ b/page/static/css/theme-contao.css
@@ -521,6 +521,7 @@ option {
     padding: 0 25px 0 30px;
     margin: 0;
     font-weight: 300;
+    -webkit-appearance: none;
 }
 
 .algolia-searchbox input[type="search"]::-webkit-input-placeholder {

--- a/page/static/css/theme-contao.css
+++ b/page/static/css/theme-contao.css
@@ -521,6 +521,7 @@ option {
     padding: 0 25px 0 30px;
     margin: 0;
     font-weight: 300;
+    appearance: none;
     -webkit-appearance: none;
 }
 


### PR DESCRIPTION
Here is a new approach to solve the "text not visible in search field". I tested it with safari (iOS and MacOS) as well as Chrome and Firefox on MacOS.

