### PR TITLE
Add the "release procedure" article and explain @experimental tags

### DIFF
--- a/docs/dev/internals/bc-promise.md
+++ b/docs/dev/internals/bc-promise.md
@@ -19,13 +19,17 @@ Therefore, our BC promise deviates from the Symfony BC promise in some regards:
   of services Contao provides. If you want to change the behaviour of a service, do not replace it with your own
   instance of the class but instead decorate the original service (see the tip about "Composition over Inheritance").
 
+* Our BC promise does not cover classes and methods marked as `@experimental`. Being able to add experimental code
+  is a great opportunity for us to release new features early without having to worry about the backwards compatibility
+  of the yet unstable API.
+
 * Our BC promise does not cover templates. Templates are subject to change very often and you have to compare
   them with every update of Contao. Generally, we try to only ever apply template changes in major and minor
   versions but if a bugfix requires us to change a template, then we might do that as well.
   
 * Our BC promise does not cover translation keys. Translations may be added and removed in every minor version as
   they change quite often. If you want to reuse the labels provided by the core, double check them after
-  every update. You may also provide your own labels so you are not affected by any changes in the core.
+  every update. You may also provide your own labels, so you are not affected by any changes in the core.
   
 * Because Contao is a Symfony bundle like every other bundle, our BC promise does not cover anything that is about 
   integrating Contao into the Symfony application. This includes:
@@ -55,7 +59,7 @@ Also see how you can [decorate a service in Symfony](https://symfony.com/doc/cur
 
 {{% /notice %}}
 
-If you should encounter a problematic break, please open an issue in our [monorepository on GitHub][Monorepo_Issues]
+If you should encounter a problematic break, please open an issue in our [monorepository on GitHub][Monorepo_Issues],
 so we can analyze and discuss if there is a possible solution.
 
 [SF_BC_Promise]: https://symfony.com/doc/current/contributing/code/bc.html

--- a/docs/dev/internals/issue-workflow.md
+++ b/docs/dev/internals/issue-workflow.md
@@ -32,7 +32,7 @@ After reading a new issue, please label it either as <span class="label-bug">bug
 <span class="label-feature">feature</span>.
 
 If it is a bug, please also assign the ticket to the milestone of the version in which the bug needs to be fixed (e.g.
-`4.4`). Do not assign feature requests to a milestone. 
+`4.9`). Do not assign feature requests to a milestone. 
 
 New issues do not get an assignee by default.
 
@@ -41,7 +41,7 @@ New issues do not get an assignee by default.
 After reading a new PR, please label it either as <span class="label-bug">bug</span> or as
 <span class="label-feature">feature</span>.
 
-If the PR is targeted against an active version branch (e.g. `4.4`), please assign it to the corresponding milestone.
+If the PR is targeted against an active version branch (e.g. `4.9`), please assign it to the corresponding milestone.
 Do not assign PRs targeted against the `4.x` branch to a milestone.
 
 Please assign new PRs to their creator.

--- a/docs/dev/internals/release-procedure.md
+++ b/docs/dev/internals/release-procedure.md
@@ -1,0 +1,35 @@
+---
+title: "Release procedure"
+description: "Details about the release procedure"
+---
+
+The [Contao release plan][Release_Plan] defines when new Contao versions are released. This article explains when and
+how a PR has to be submitted to be included in a new version.
+
+## Stages
+
+Before a new version is considered stable, it goes through three stages:
+
+* **Dev**: About six months. The version is under active development. You can add new feature PRs at anytime.
+* **Review**: About two weeks. Complete feature PRs will be reviewed and merged. Incomplete feature PRs will be moved
+  to the next milestone.
+* **RC**: Release candidate. About four weeks. Only bug fixes. New feature PRs will be moved to the next milestone.
+
+Please note that there is no explicit beta phase. Experience has shown that hardly anyone installs and tests a beta
+version, so a beta phase had no added value for us.
+
+## When is a PR considered "complete"?
+
+In order for your feature PR to be reviewed and merged, it must meet the following requirements:
+
+1. The PR must no longer be a draft;
+2. all functions must be implemented;
+3. all unit tests must be in place;
+4. the CI checks must not fail.
+
+## Deadlines
+
+The winter release is published around February 15 of each year, so your feature PR has to be completed by December 31.
+The summer release is published around August 15 of each year, so your feature PR has to be completed by June 31.
+
+[Release_Plan]: https://contao.org/en/release-plan.html


### PR DESCRIPTION
So we can link to the docs in cases like [this](https://github.com/contao/contao/pull/3498#issuecomment-1002173825).