### PR TITLE
Consistently name file extension yml

### DIFF
--- a/docs/dev/framework/image-processing/image-sizes.md
+++ b/docs/dev/framework/image-processing/image-sizes.md
@@ -22,12 +22,12 @@ different settings again.
 ## Size Configuration
 
 As already mentioned you can pre-configure image sizes in the container configuration of your application 
-(`config/config.yaml`) via `contao.image.sizes` without the need to store them in the database. Here you can define 
+(`config/config.yml`) via `contao.image.sizes` without the need to store them in the database. Here you can define 
 multiple image sizes and their properties. The following is a basic example that creates two image size configurations 
 called `example` and `foobar` which will resize the images to a width of 512 or 1024 pixels respectively when selected:
 
 ```yaml
-# config/config.yaml
+# config/config.yml
 contao:
     image:
         sizes:
@@ -42,7 +42,7 @@ pixel and zoom fully into its _important part_ (if defined). Furthermore the ima
 densities and the `<img>` will have a CSS class called `example`: 
 
 ```yaml
-# config/config.yaml
+# config/config.yml
 contao:
     image:
         sizes:
@@ -231,7 +231,7 @@ contao:
 
 ### Translating Size Configurations
 
-Every configured image size will show up in the back end under the key given in the `config/config.yaml`. However, in
+Every configured image size will show up in the back end under the key given in the `config/config.yml`. However, in
 order to improve usability for your back end users you might want to have a better label for these size configurations.
 This is possible via Symfony translations by using the `image_sizes` translation domain. The translation label will be
 the name of the size according to your configuration. The following example would change the label for the `example` and

--- a/docs/manual/installation/contao-manager.de.md
+++ b/docs/manual/installation/contao-manager.de.md
@@ -205,7 +205,7 @@ In diesem Fall kannst du die [config.yml](/de/system/einstellungen/#config-yml) 
 Contao Manager (»Systemwartung« > »Prod.-Cache erneuern«) oder über die Konsole einmalig den Anwendungs-Cache leeren.
 
 ```yml
-# config/config.yaml
+# config/config.yml
 contao_manager:
     manager_path: dein-name.phar.php
 ```

--- a/docs/manual/performance/http-caching.en.md
+++ b/docs/manual/performance/http-caching.en.md
@@ -274,8 +274,8 @@ lists of irrelevant cookies, it has good default settings, but you can optimize 
 environment variables and tune it for performance.
 
 {{% notice idea %}}
-Are you wondering why Contao is configured by editing the `config.yaml` and the Contao Cache Proxy using environment variables?
-The `config.yaml` for Contao itself is application configuration. The included Contao Cache Proxy, however, needs to know its
+Are you wondering why Contao is configured by editing the `config.yml` and the Contao Cache Proxy using environment variables?
+The `config.yml` for Contao itself is application configuration. The included Contao Cache Proxy, however, needs to know its
 settings **before Contao** is even booted. Booting is exactly what we want to prevent.
 Thus, environment variables are the best choice for configuring our proxy.
 {{% /notice %}}

--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -79,7 +79,7 @@ Ein paar zusätzliche Parameter können über die `config/config.yml` konfigurie
 Die folgende Konfiguration definiert einige Beispielwerte:
 
 ```yml
-# config/config.yaml
+# config/config.yml
 contao:
     backend:
         attributes:
@@ -446,7 +446,7 @@ Das folgende Beispiel zeigt, wie man die E-Mail-Adresse des Systemadministrators
 Wiederherstellungsperiode auf 60 Tage verlängern könnte:
 
 ```yaml
-# config/config.yaml
+# config/config.yml
 contao:
     localconfig:
         adminEmail: '%env(ADMIN_EMAIL)%'

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -76,7 +76,7 @@ Some additional parameters can be configured via the `config/config.yml`.
 The following config defines some example values: 
 
 ```yml
-# config/config.yaml
+# config/config.yml
 contao:
     backend:
         attributes:
@@ -449,7 +449,7 @@ The following example defines the administrator's e-mail address via an environm
 to 60 days:
 
 ```yaml
-# config/config.yaml
+# config/config.yml
 contao:
     localconfig:
         adminEmail: '%env(ADMIN_EMAIL)%'


### PR DESCRIPTION
In most places of the docs the configuration file is called `config/config.yml` as opposed to `config/config.yaml`. For consistency reasons I would find it clearer to use the `.yml` file name extension throughout. This PR tries to fix this.

Opinions please.