### PR TITLE
Add SendNewsletterEvent

### DIFF
--- a/docs/dev/reference/events.md
+++ b/docs/dev/reference/events.md
@@ -391,6 +391,65 @@ class FilterPageTypeListener
 {{% /expand %}}
 
 
+## `SendNewsletterEvent`
+
+{{% version "4.13" %}}
+
+This event is triggered for each newsletter mail and allows  you to customize
+the newsletter text and HTML content, prevent the submission or perform other
+related actions to the newsletter (e.g. logging).
+
+The event is triggered when sending a newsletter preview as well as when sending
+a newsletter to real recipients.
+
+<table>
+<tr><th>Name</th><td><code>\Contao\NewsletterBundle\Event\SendNewsletterEvent::class</code></td></tr>
+<tr><th>Constant</th><td>N/A</td></tr>
+<tr><th>Event</th><td><code>\Contao\NewsletterBundle\Event\SendNewsletterEvent</code></td></tr>
+</table>
+<br>
+
+{{% expand "Example" %}}
+```php
+// src/EventListener/SendNewsletterListener.php
+namespace App\EventListener;
+
+use Contao\NewsletterBundle\Event\SendNewsletterEvent;
+use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
+
+/**
+ * @ServiceTag("kernel.event_listener")
+ */
+class SendNewsletterListener
+{
+    public function __invoke(SendNewsletterEvent $event): void
+    {
+        // Skip sending under certain conditions
+        if (!preg_match('/@contao\.org/i', $event->getRecipientAddress())) {
+            $event->setSkipSending(true);
+        }
+
+        if ($event->isHtmlAllowed()) {
+            // Get the parsed HTML content of the newsletter
+            $html = $event->getHtml();
+
+            // Use the original, unparsed HTML content of the newsletter
+            $html = $event->getNewsletterValue('content') ;
+
+            // Get any data from the newsletter
+            $id = $event->getNewsletterValue('id');
+
+            // Get any data from the recipient
+            $greeting = $event->getRecipientValue('greeting');
+
+            // Overwrite the HTML with custom content
+            $event->setHtml($html);
+        }
+    }
+}
+```
+{{% /expand %}}
+
 [SymfonyEventDispatcher]: https://symfony.com/doc/current/event_dispatcher.html
 [ContaoHooks]: /framework/hooks
 [BackEndRoutes]: /guides/back-end-routes

--- a/docs/dev/reference/hooks/sendNewsletter.md
+++ b/docs/dev/reference/hooks/sendNewsletter.md
@@ -10,6 +10,10 @@ aliases:
 
 This hook is executed directly after Contao has sent a newsletter to its recipients.
 
+{{% notice info %}}
+Using the `sendNewsletter` hook has been deprecated and will no longer work in Contao 5.0.
+Use the [SendNewsletterEvent](/reference/events#sendnewsletterevent) instead.
+{{% /notice %}}
 
 ## Parameters
 


### PR DESCRIPTION
Adds documentation and examples for the `SendNewsletterEvent` from https://github.com/contao/contao/pull/3489.

Additionally, a deprecation notice is added to the `sendNewsletter` hook.