### PR TITLE
Prepare Twig template documentation

### DIFF
--- a/docs/manual/layout/templates/_index.de.md
+++ b/docs/manual/layout/templates/_index.de.md
@@ -9,9 +9,9 @@ aliases:
 weight: 40
 ---
 
+
 Ein Template wird zur Ausgabe eines Moduls, Inhaltselements, Formulars oder einer anderen Komponente 
-verwendet und beinhaltet HTML- und PHP-Code. Im 
-[Navigationsbereich](../../administrationsbereich/aufruf-und-aufbau-des-backends/#der-navigationsbereich) »Layout« 
+verwendet. Im [Navigationsbereich](../../administrationsbereich/aufruf-und-aufbau-des-backends/#der-navigationsbereich) »Layout« 
 unter »Templates« können die Dateien erstellt, in Ordnern abgelegt und bearbeitet werden. Diese Anpassungen sind updatesicher.
 
 {{% children %}}
@@ -21,11 +21,3 @@ Template Änderungen sind nicht notwendig, wenn du nur eine zusätzliche CSS-ID 
 Contao-Komponenten kannst du diese im Bereich »Experten-Einstellungen« eintragen. Die entsprechenden Bezeichnungen 
 werden von den Templates übernommen und im Quelltext ausgegeben.
 {{% /notice %}}
-
-{{% notice note %}}
-Im [Debug-Modus](../../system/debug-modus/) werden die Template-Namen im HTML-Quellcode als Kommentare ausgegeben. 
-Man kann hierüber nachvollziehen welches Template zum Einsatz kommt.
-{{% /notice %}}
-
-{{% taxonomylist context="tags" filter="Template" title="Anleitungen" description=true %}}
-

--- a/docs/manual/layout/templates/php/_index.de.md
+++ b/docs/manual/layout/templates/php/_index.de.md
@@ -1,0 +1,30 @@
+---
+title: "PHP-Templates"
+description: "Übersicht PHP-Templates."
+url: "layout/templates/php"
+aliases:
+    - /de/templates/php/
+weight: 10
+---
+
+
+Ein Template wird zur Ausgabe eines Moduls, Inhaltselements, Formulars oder einer anderen Komponente 
+verwendet und beinhaltet HTML- und PHP-Code. Im 
+[Navigationsbereich](../../administrationsbereich/aufruf-und-aufbau-des-backends/#der-navigationsbereich) »Layout« 
+unter »Templates« können die Dateien erstellt, in Ordnern abgelegt und bearbeitet werden. Diese Anpassungen sind updatesicher.
+
+{{% children %}}
+
+{{% notice info %}}
+Template Änderungen sind nicht notwendig, wenn du nur eine zusätzliche CSS-ID oder CSS-Klasse benötigst. Bei den meisten 
+Contao-Komponenten kannst du diese im Bereich »Experten-Einstellungen« eintragen. Die entsprechenden Bezeichnungen 
+werden von den Templates übernommen und im Quelltext ausgegeben.
+{{% /notice %}}
+
+{{% notice note %}}
+Im [Debug-Modus](../../system/debug-modus/) werden die Template-Namen im HTML-Quellcode als Kommentare ausgegeben. 
+Man kann hierüber nachvollziehen welches Template zum Einsatz kommt.
+{{% /notice %}}
+
+{{% taxonomylist context="tags" filter="Template" title="Anleitungen" description=true %}}
+

--- a/docs/manual/layout/templates/php/_index.en.md
+++ b/docs/manual/layout/templates/php/_index.en.md
@@ -1,9 +1,9 @@
 ---
-title: "Templates"
-description: "The Templates navigation area."
+title: "PHP templates"
+description: "Overview PHP templates."
 aliases:
-    - /en/layout/templates/
-weight: 40
+    - /en/templates/php/
+weight: 10
 ---
 
 
@@ -14,3 +14,9 @@ A template is used to output a module, content element, form or other component 
 {{% notice info %}}
 Template changes are not necessary if you only need an additional CSS ID or CSS class. For most Contao components, you can enter them in the "Expert settings" section. The corresponding names are taken from the templates and displayed in the source code.
 {{% /notice %}}
+
+{{% notice note %}}
+In [debug mode](/en/system/debug-mode/), the template names in the HTML source code are displayed as comments, so you can see which template is being used.
+{{% /notice %}}
+
+{{% taxonomylist context="tags" filter="Template" title="Guides" description=true %}}

--- a/docs/manual/layout/templates/php/manage-template.de.md
+++ b/docs/manual/layout/templates/php/manage-template.de.md
@@ -1,10 +1,10 @@
 ---
 title: "Templates verwalten"
 description: "Die Verwaltung der Template-Dateien."
-url: "layout/templates/verwaltung"
+url: "layout/templates/php/verwaltung"
 aliases:
-    - /de/layout/templates/verwaltung/
-weight: 10
+    - /de/layout/templates/php/verwaltung/
+weight: 20
 ---
 
 ## Ordnerstruktur

--- a/docs/manual/layout/templates/php/manage-template.en.md
+++ b/docs/manual/layout/templates/php/manage-template.en.md
@@ -2,8 +2,8 @@
 title: 'Manage templates'
 description: 'The management of the template files.'
 aliases:
-    - /en/layout/templates/manage-template/
-weight: 10
+    - /en/layout/templates/php/manage-template/
+weight: 20
 ---
 
 ## Directory structure

--- a/docs/manual/layout/templates/php/template-assets.de.md
+++ b/docs/manual/layout/templates/php/template-assets.de.md
@@ -1,10 +1,10 @@
 ---
 title: "CSS- und JavaScript-Assets"
 description: "CSS- und JavaScript-Assets in Templates einsetzen."
-url: "layout/templates/assets"
+url: "layout/templates/php/assets"
 aliases:
-    - /de/layout/templates/assets/
-weight: 20
+    - /de/layout/templates/php/assets/
+weight: 30
 ---
 
 Oft werden zu einem individuellen Template zusätzliche Inhalte (»Assets«)m wie CSS- oder JavaScript-Dateien benötigt.

--- a/docs/manual/layout/templates/php/template-assets.en.md
+++ b/docs/manual/layout/templates/php/template-assets.en.md
@@ -2,8 +2,8 @@
 title: 'CSS and JavaScript assets'
 description: 'Use CSS and JavaScript assets in templates.'
 aliases:
-    - /en/layout/templates/template-assets/
-weight: 20
+    - /en/layout/templates/php/template-assets/
+weight: 30
 ---
 
 Oftentimes, templates require additional assets, such as CSS or JavaScript files. You *can* integrate them via your

--- a/docs/manual/layout/templates/php/template-data.de.md
+++ b/docs/manual/layout/templates/php/template-data.de.md
@@ -1,10 +1,10 @@
 ---
 title: "Template-Daten anzeigen"
 description: "Alle Template-Daten anzeigen."
-url: "layout/templates/data"
+url: "layout/templates/php/data"
 aliases:
-    - /de/layout/templates/data/
-weight: 50
+    - /de/layout/templates/php/data/
+weight: 60
 ---
 
 Die verfügbaren Template-Daten variieren je nach Quelle der Vorlage. In der Regel ist der vollständige 

--- a/docs/manual/layout/templates/php/template-data.en.md
+++ b/docs/manual/layout/templates/php/template-data.en.md
@@ -2,8 +2,8 @@
 title: 'Display template data'
 description: 'Display all template data.'
 aliases:
-    - /en/layout/templates/template-data/
-weight: 50
+    - /en/layout/templates/php/template-data/
+weight: 60
 ---
 
 The available template context varies depending on the template source. Usually, the complete data can be accessed via

--- a/docs/manual/layout/templates/php/template-inheritance.de.md
+++ b/docs/manual/layout/templates/php/template-inheritance.de.md
@@ -1,10 +1,10 @@
 ---
 title: "Template vererben"
 description: "Die Template Vererbung."
-url: "layout/templates/vererbung"
+url: "layout/templates/php/vererbung"
 aliases:
-    - /de/layout/templates/vererbung/
-weight: 30
+    - /de/layout/templates/php/vererbung/
+weight: 40
 ---
 
 Contao erlaubt das Vererben von Templates. Dabei wird ein Template nicht komplett überschrieben, sondern nur gezielt

--- a/docs/manual/layout/templates/php/template-inheritance.en.md
+++ b/docs/manual/layout/templates/php/template-inheritance.en.md
@@ -2,8 +2,8 @@
 title: 'Inherit templates'
 description: 'The template inheritance.'
 aliases:
-    - /en/layout/templates/template-inheritance/
-weight: 30
+    - /en/layout/templates/php/template-inheritance/
+weight: 40
 ---
 
 Contao template inheritance allows overwriting only certain sections of a template (blocks).

--- a/docs/manual/layout/templates/php/template-insertion.de.md
+++ b/docs/manual/layout/templates/php/template-insertion.de.md
@@ -1,10 +1,10 @@
 ---
 title: "Template mischen"
 description: "Ein Template mischen."
-url: "layout/templates/insertion"
+url: "layout/templates/php/insertion"
 aliases:
-    - /de/layout/templates/insertion/
-weight: 40
+    - /de/layout/templates/php/insertion/
+weight: 50
 ---
 
 Mit Hilfe der `insert()`-Funktion kann ein Template in ein anderes Template eingefügt werden. Die Funktion akzeptiert 

--- a/docs/manual/layout/templates/php/template-insertion.en.md
+++ b/docs/manual/layout/templates/php/template-insertion.en.md
@@ -2,8 +2,8 @@
 title: 'Mix templates'
 description: 'Mix a template.'
 aliases:
-    - /en/layout/templates/template-insertion/
-weight: 40
+    - /en/layout/templates/php/template-insertion/
+weight: 50
 ---
 
 The `insert()` function allows inserting a template into another one. You can pass variables as an optional second

--- a/docs/manual/layout/templates/twig/_index.de.md
+++ b/docs/manual/layout/templates/twig/_index.de.md
@@ -15,7 +15,7 @@ PHP-Templates enthalten Twig-Templates keine Geschäftslogik, was die gemeinsame
 Diese Tatsache hilft, eine saubere Trennung zwischen der Präsentations- und der Daten-/Logikschicht aufrechtzuerhalten.
 
 Twig bietet außerdem viele leistungsstarke Methoden zur Strukturierung von Vorlagen, wie z. B. das Einbinden, Vererben, Wiederverwenden 
-von Blöcken oder Makros, erleichtert den Zugriff auf Objekte mit »Property Access«, verfügt über Leerzeichenkontrolle, 
+von Blöcken oder Makros, den erleichterten Zugriff auf Objekte mit »Property Access«, verfügt über Leerzeichenkontrolle, 
 String-Interpolationsfunktionen und vieles mehr.
 
 {{% notice warning %}}

--- a/docs/manual/layout/templates/twig/_index.de.md
+++ b/docs/manual/layout/templates/twig/_index.de.md
@@ -1,0 +1,63 @@
+---
+title: "Twig-Templates"
+description: "Übersicht Twig-Templates."
+url: "layout/templates/twig"
+aliases:
+    - /de/layout/templates/twig/
+weight: 10
+---
+
+
+{{< version "4.12" >}}
+
+Twig ist Symfony's Standardmethode zum Schreiben von Templates. Es ist schnell, sicher und leicht erweiterbar. Im Gegensatz zu 
+PHP-Templates enthalten Twig-Templates keine Geschäftslogik, was die gemeinsame Nutzung durch Designer und Programmierer erleichtert. 
+Diese Tatsache hilft, eine saubere Trennung zwischen der Präsentations- und der Daten-/Logikschicht aufrechtzuerhalten.
+
+Twig bietet außerdem viele leistungsstarke Methoden zur Strukturierung von Vorlagen, wie z. B. das Einbinden, Vererben, Wiederverwenden 
+von Blöcken oder Makros, erleichtert den Zugriff auf Objekte mit »Property Access«, verfügt über Leerzeichenkontrolle, 
+String-Interpolationsfunktionen und vieles mehr.
+
+{{% notice warning %}}
+Die Unterstützung von Twig ist derzeit *experimentell* und daher nicht durch das Contao BC-Versprechen abgedeckt. Klassen, die mit 
+`@experimental` gekennzeichnet sind, sollten vorerst als intern betrachtet werden. Obwohl es nicht wahrscheinlich ist, könnte es auch 
+einige Änderungen geben, also sei darauf vorbereitet.
+{{% /notice %}}
+
+{{% notice info %}}
+Die Dokumentation der Twig Nutzung in Contao wird ständig erweitert. Bis dahin findest du in 
+[diesem Beitrag](https://docs.contao.org/dev/framework/templates/twig/) weitere, detaillierte Informationen zum Thema.
+{{% /notice %}}
+
+
+## Erste Schritte
+
+Du kannst Twig-Templates überall dort verwenden, wo du auch eine PHP-Vorlage verwenden würdest, nur mit einer anderen Dateierweiterung 
+(`.html.twig` statt `.html5`). Es ist sogar möglich, PHP-Templates aus den Twig-Templates heraus zu erweitern.
+
+Lege dir eine `fe_page.html.twig` in deinem Template-Verzeichnis an. In diesem Beispiel wird eine Überschrift über dem Hauptabschnitt 
+hinzugefügt und alles andere bleibt gleich:
+
+```twig
+{# /templates/fe_page.html.twig #}
+
+{% extends '@Contao/fe_page' %}
+
+{% block main %}
+  <h1>Hello from Twig!</h1>
+  {{ parent() }}
+{% endblock %}
+```
+
+1. Benenne dein Twig-Template wie das Contao-Pendant (mit Ausnahme der Dateierweiterung) und lege dieses in einem normalen 
+Contao Template Verzeichnis ab. Es kann derzeit **entweder** eine Twig- **oder** eine PHP-Variante des gleichen Templates am gleichen Ort geben.
+
+2. Um eine bestehende Vorlage zu erweitern (anstatt diese komplett zu ersetzen), verwende das Schlüsselwort `extends` und den 
+speziellen `@Contao` [Namensraum](https://docs.contao.org/dev/framework/templates/twig/#namespace-magic).
+
+3. Verwende den gleichen Blocknamen wie in der ursprünglichen Vorlage.
+
+{{% notice note %}}
+Du kannst Twig-Templates nicht aus PHP-Templates heraus erweitern, nur umgekehrt. Eine Auswahl vorhandener Twig-Templates,
+z. B. über ein Inhaltselement, ist derzeit noch nicht möglich.
+{{% /notice %}}

--- a/docs/manual/layout/templates/twig/_index.de.md
+++ b/docs/manual/layout/templates/twig/_index.de.md
@@ -10,6 +10,12 @@ weight: 10
 
 {{< version "4.12" >}}
 
+{{% notice warning %}}
+Die Unterstützung von Twig ist derzeit *experimentell* und daher nicht durch das Contao BC-Versprechen abgedeckt. Klassen, die mit 
+`@experimental` gekennzeichnet sind, sollten vorerst als intern betrachtet werden. Obwohl es nicht wahrscheinlich ist, könnte es auch 
+einige Änderungen geben, also sei darauf vorbereitet.
+{{% /notice %}}
+
 Twig ist Symfony's Standardmethode zum Schreiben von Templates. Es ist schnell, sicher und leicht erweiterbar. Im Gegensatz zu 
 PHP-Templates enthalten Twig-Templates keine Geschäftslogik, was die gemeinsame Nutzung durch Designer und Programmierer erleichtert. 
 Diese Tatsache hilft, eine saubere Trennung zwischen der Präsentations- und der Daten-/Logikschicht aufrechtzuerhalten.
@@ -17,12 +23,6 @@ Diese Tatsache hilft, eine saubere Trennung zwischen der Präsentations- und der
 Twig bietet außerdem viele leistungsstarke Methoden zur Strukturierung von Vorlagen, wie z. B. das Einbinden, Vererben, Wiederverwenden 
 von Blöcken oder Makros, den erleichterten Zugriff auf Objekte mit »Property Access«, verfügt über Leerzeichenkontrolle, 
 String-Interpolationsfunktionen und vieles mehr.
-
-{{% notice warning %}}
-Die Unterstützung von Twig ist derzeit *experimentell* und daher nicht durch das Contao BC-Versprechen abgedeckt. Klassen, die mit 
-`@experimental` gekennzeichnet sind, sollten vorerst als intern betrachtet werden. Obwohl es nicht wahrscheinlich ist, könnte es auch 
-einige Änderungen geben, also sei darauf vorbereitet.
-{{% /notice %}}
 
 {{% notice info %}}
 Eine Auswahl vorhandener Twig-Templates, z. B. über ein Inhaltselement, ist derzeit noch nicht möglich. Die Dokumentation der Twig Nutzung in Contao wird ständig erweitert. Bis dahin findest du in [diesem Beitrag](https://docs.contao.org/dev/framework/templates/twig/) weitere, detaillierte Informationen zum Thema.

--- a/docs/manual/layout/templates/twig/_index.de.md
+++ b/docs/manual/layout/templates/twig/_index.de.md
@@ -25,8 +25,7 @@ einige Änderungen geben, also sei darauf vorbereitet.
 {{% /notice %}}
 
 {{% notice info %}}
-Die Dokumentation der Twig Nutzung in Contao wird ständig erweitert. Bis dahin findest du in 
-[diesem Beitrag](https://docs.contao.org/dev/framework/templates/twig/) weitere, detaillierte Informationen zum Thema.
+Eine Auswahl vorhandener Twig-Templates, z. B. über ein Inhaltselement, ist derzeit noch nicht möglich. Die Dokumentation der Twig Nutzung in Contao wird ständig erweitert. Bis dahin findest du in [diesem Beitrag](https://docs.contao.org/dev/framework/templates/twig/) weitere, detaillierte Informationen zum Thema.
 {{% /notice %}}
 
 
@@ -58,6 +57,5 @@ speziellen `@Contao` [Namensraum](https://docs.contao.org/dev/framework/template
 3. Verwende den gleichen Blocknamen wie in der ursprünglichen Vorlage.
 
 {{% notice note %}}
-Du kannst Twig-Templates nicht aus PHP-Templates heraus erweitern, nur umgekehrt. Eine Auswahl vorhandener Twig-Templates,
-z. B. über ein Inhaltselement, ist derzeit noch nicht möglich.
+Du kannst Twig-Templates nicht aus PHP-Templates heraus erweitern, nur umgekehrt.
 {{% /notice %}}

--- a/docs/manual/layout/templates/twig/_index.en.md
+++ b/docs/manual/layout/templates/twig/_index.en.md
@@ -22,8 +22,7 @@ considered internal for now. Although not likely, there could also be some behav
 {{% /notice %}}
 
 {{% notice info %}}
-The documentation of Twig usage in Contao is constantly being extended. Until then you can find more detailed information 
-[here](https://docs.contao.org/dev/framework/templates/twig/).
+A selection of existing Twig templates, e.g. via a content element, is currently not yet possible. The documentation of Twig usage in Contao is constantly being extended. Until then you can find more detailed information [here](https://docs.contao.org/dev/framework/templates/twig/).
 {{% /notice %}}
 
 
@@ -55,6 +54,5 @@ There can **either** be a Twig **or** a PHP variant of the same template in the 
 3. Use the same block names as in the original template.
 
 {{% notice note %}}
-You cannot extend Twig templates from within PHP templates only the other way round. A selection of existing Twig templates,
-e.g. via a content element, is currently not yet possible.
+You cannot extend Twig templates from within PHP templates only the other way round.
 {{% /notice %}}

--- a/docs/manual/layout/templates/twig/_index.en.md
+++ b/docs/manual/layout/templates/twig/_index.en.md
@@ -1,0 +1,60 @@
+---
+title: "Twig templates"
+description: "Overview Twig templates."
+aliases:
+    - /en/layout/templates/twig/
+weight: 10
+---
+
+
+{{< version "4.12" >}}
+
+Twig is Symfony’s default way to write templates. It’s fast, safe and easily extensible. Contrary to PHP templates, Twig templates won’t 
+contain business logic which allows to share them more easily between designers and programmers. This fact also helps you maintain 
+a clean separation between your presentation and data/logic layer.
+
+Twig also features a lot of powerful methods to structure your templates like including, embedding, inheriting, reusing blocks or macros, 
+eases accessing objects with “property access”, has whitespace control, string interpolation features and a ton more… Give it a try!
+
+{{% notice warning %}}
+Twig support is currently *experimental* and therefore not covered by Contao's BC promise. Classes marked with `@experimental` should be 
+considered internal for now. Although not likely, there could also be some behavioral changes, so be prepared. 
+{{% /notice %}}
+
+{{% notice info %}}
+The documentation of Twig usage in Contao is constantly being extended. Until then you can find more detailed information 
+[here](https://docs.contao.org/dev/framework/templates/twig/).
+{{% /notice %}}
+
+
+## Getting started
+
+You can use Twig templates at any place you would use a Contao PHP template, just with a different file extension 
+(`.html.twig` instead of `.html5`). It’s even possible to extend Contao PHP templates from within your Twig templates.
+
+Go ahead and place a `fe_page.html.twig` in your template directory - this example will add a friendly headline above the main section 
+and keep everything else the same:
+
+```twig
+{# /templates/fe_page.html.twig #}
+
+{% extends '@Contao/fe_page' %}
+
+{% block main %}
+  <h1>Hello from Twig!</h1>
+  {{ parent() }}
+{% endblock %}
+```
+
+1. Name your Twig templates like your Contao counterpart (except for the file extension) and put them in a regular Contao template directory. 
+There can **either** be a Twig **or** a PHP variant of the same template in the same location.
+
+2. To extend an existing template (instead of completely replacing it) use the `extends` keyword and the special `@Contao` 
+[namespace](https://docs.contao.org/dev/framework/templates/twig/#namespace-magic).
+
+3. Use the same block names as in the original template.
+
+{{% notice note %}}
+You cannot extend Twig templates from within PHP templates only the other way round. A selection of existing Twig templates,
+e.g. via a content element, is currently not yet possible.
+{{% /notice %}}

--- a/docs/manual/layout/templates/twig/_index.en.md
+++ b/docs/manual/layout/templates/twig/_index.en.md
@@ -9,17 +9,17 @@ weight: 10
 
 {{< version "4.12" >}}
 
+{{% notice warning %}}
+Twig support is currently *experimental* and therefore not covered by Contao's BC promise. Classes marked with `@experimental` should be 
+considered internal for now. Although not likely, there could also be some behavioral changes, so be prepared. 
+{{% /notice %}}
+
 Twig is Symfony’s default way to write templates. It’s fast, safe and easily extensible. Contrary to PHP templates, Twig templates won’t 
 contain business logic which allows to share them more easily between designers and programmers. This fact also helps you maintain 
 a clean separation between your presentation and data/logic layer.
 
 Twig also features a lot of powerful methods to structure your templates like including, embedding, inheriting, reusing blocks or macros, 
 eases accessing objects with “property access”, has whitespace control, string interpolation features and a ton more… Give it a try!
-
-{{% notice warning %}}
-Twig support is currently *experimental* and therefore not covered by Contao's BC promise. Classes marked with `@experimental` should be 
-considered internal for now. Although not likely, there could also be some behavioral changes, so be prepared. 
-{{% /notice %}}
 
 {{% notice info %}}
 A selection of existing Twig templates, e.g. via a content element, is currently not yet possible. The documentation of Twig usage in Contao is constantly being extended. Until then you can find more detailed information [here](https://docs.contao.org/dev/framework/templates/twig/).


### PR DESCRIPTION
This is a new implementation in preparation for the new Twig integration. As discussed in #914, "PHP templates" and "Twig templates" are now split into separate sections.

The new Twig Templates section currently contains general details (regardless of the current technical status) with a reference to this [dev post](https://docs.contao.org/dev/framework/templates/twig/). 

Therefore, this could be published in advance/interim.

Then, in a new separate pull request, we can gradually expand the actual twig documentation based on this.
(This then with regard to the status of e.g. [#3538](https://github.com/contao/contao/pull/3538), [#3834 ](https://github.com/contao/contao/issues/3834) and [#3274 ](https://github.com/contao/contao/issues/3274)).