### PR TITLE
Clarify installing dev versions and update composer.json

### DIFF
--- a/docs/manual/guides/install-test-versions.de.md
+++ b/docs/manual/guides/install-test-versions.de.md
@@ -137,11 +137,6 @@ zum Testen installiert werden. Auf diese Weise können die neuesten Änderungen 
 getestet werden, ohne auf die Veröffentlichung einer neuen Version warten zu müssen. 
 Natürlich kann diese auch instabilen Programmcode enthalten.
 
-In this case instead of requiring a specific _version_ of Contao, a specific _branch_
-of Contao's public Git repository will be required. The current minor version in development
-will always have a branch name corresponding to the current major version, e.g. `5.x` as
-of this year. This branch needs to be required as `5.x-dev` in Composer.
-
 Statt einer spezifischen _Version_ wird nun ein spezifischer _Branch_ aus dem öffentlichen
 Git-Repository von Contao verlangt. Die aktuell entwickelte »Minor« Version von Contao hat immer 
 einen »Entwicklungszweig (Branch)« dessen Namen der aktuellen »Major« Version entspricht, z. B.

--- a/docs/manual/guides/install-test-versions.de.md
+++ b/docs/manual/guides/install-test-versions.de.md
@@ -132,7 +132,7 @@ Nur die Version des `contao/manager-bundle` muss angepasst werden.
 
 ## Entwicklerversionen installieren
 
-Während der Entwicklungsphase einer Contao Version kann auch die Entwicklerversion 
+Während der [Entwicklungsphase][ReleasePlan] einer Contao Version kann auch die Entwicklerversion 
 zum Testen installiert werden. Auf diese Weise können die neuesten Änderungen sofort 
 getestet werden, ohne auf die Veröffentlichung einer neuen Version warten zu müssen. 
 Natürlich  kann dies auch instabilen Programmcode enthalten.
@@ -226,7 +226,10 @@ Zuerst führt man wie gewohnt die Grundkonfiguration des Contao Managers durch. 
 Anschließend wechselt man zum Menüpunkt »Pakete« und editiert bei »Contao Open Source
 CMS« die Versionsangabe wie oben beschrieben. Abschließend klickt man auf »Änderungen anwenden« und wartet die Aktualisierung der Pakete ab.
 
-[releasePlan]: https://contao.org/de/release-plan.html
 
 ## Weblinks ##
+
 Videoanleitung: [Contao 4 – Testversion | Entwicklerversion | Release Candidate installieren](https://youtu.be/0nUROGy_jLU)
+
+
+[releasePlan]: https://to.contao.org/release-plan

--- a/docs/manual/guides/install-test-versions.de.md
+++ b/docs/manual/guides/install-test-versions.de.md
@@ -135,7 +135,7 @@ Nur die Version des `contao/manager-bundle` muss angepasst werden.
 Während der [Entwicklungsphase][ReleasePlan] einer Contao Version kann auch die Entwicklerversion 
 zum Testen installiert werden. Auf diese Weise können die neuesten Änderungen sofort 
 getestet werden, ohne auf die Veröffentlichung einer neuen Version warten zu müssen. 
-Natürlich  kann dies auch instabilen Programmcode enthalten.
+Natürlich kann diese auch instabilen Programmcode enthalten.
 
 In this case instead of requiring a specific _version_ of Contao, a specific _branch_
 of Contao's public Git repository will be required. The current minor version in development

--- a/docs/manual/guides/install-test-versions.de.md
+++ b/docs/manual/guides/install-test-versions.de.md
@@ -143,7 +143,7 @@ will always have a branch name corresponding to the current major version, e.g. 
 of this year. This branch needs to be required as `5.x-dev` in Composer.
 
 Statt einer spezifischen _Version_ wird nun ein spezifischer _Branch_ aus dem öffentlichen
-Git Repository von Contao verlangt. Die aktuell entwickelte »Minor« Version von Contao hat immer 
+Git-Repository von Contao verlangt. Die aktuell entwickelte »Minor« Version von Contao hat immer 
 einen »Entwicklungszweig (Branch)« dessen Namen der aktuellen »Major« Version entspricht, z. B.
 `5.x` seit Anfang 2022. Dieser Branch muss als `5.x-dev` in Composer verlangt werden.
 

--- a/docs/manual/guides/install-test-versions.de.md
+++ b/docs/manual/guides/install-test-versions.de.md
@@ -78,10 +78,10 @@ zu lassen, _inklusive_ den neuesten Release Candidates (wenn vorhanden):
 ```json
 {
     "name": "contao/managed-edition",
+    "description": "Contao Managed Edition",
+    "license": "LGPL-3.0-or-later",
     "type": "project",
-    "description": "Contao Open Source CMS",
     "require": {
-        "php": "^7.1",
         "contao/calendar-bundle": "^4.9",
         "contao/comments-bundle": "^4.9",
         "contao/conflicts": "@dev",
@@ -98,11 +98,16 @@ zu lassen, _inklusive_ den neuesten Release Candidates (wenn vorhanden):
     "conflict": {
         "contao-components/installer": "<1.3"
     },
-    "extra": {
-        "contao-component-dir": "assets",
-        "symfony": {
-            "require": "^4.4"
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "contao-community-alliance/composer-plugin": true,
+            "contao-components/installer": true,
+            "contao/manager-plugin": true
         }
+    },
+    "extra": {
+        "contao-component-dir": "assets"
     },
     "scripts": {
         "post-install-cmd": [
@@ -127,52 +132,62 @@ Nur die Version des `contao/manager-bundle` muss angepasst werden.
 
 ## Entwicklerversionen installieren
 
-Während der Release Candidate und davor auch während der Entwicklungsphase einer
-Contao Version kann auch die Entwicklerversion zum Testen installiert werden. Auf
-diese Weise können die neuesten Änderungen sofort getestet werden, ohne auf einen
-neuen Release Candidate warten zu müssen. Natürlich kann dies auch instabilen Programmcode
-enthalten.
+Während der Entwicklungsphase einer Contao Version kann auch die Entwicklerversion 
+zum Testen installiert werden. Auf diese Weise können die neuesten Änderungen sofort 
+getestet werden, ohne auf die Veröffentlichung einer neuen Version warten zu müssen. 
+Natürlich  kann dies auch instabilen Programmcode enthalten.
+
+In this case instead of requiring a specific _version_ of Contao, a specific _branch_
+of Contao's public Git repository will be required. The current minor version in development
+will always have a branch name corresponding to the current major version, e.g. `5.x` as
+of this year. This branch needs to be required as `5.x-dev` in Composer.
 
 Statt einer spezifischen _Version_ wird nun ein spezifischer _Branch_ aus dem öffentlichen
-Git Repository von Contao verlangt. Jede »Minor« Version von Contao hat ihren eigenen
-»Entwicklungszweig (Branch)«, z. B. `4.9.x-dev` für Contao `4.9`.
+Git Repository von Contao verlangt. Die aktuell entwickelte »Minor« Version von Contao hat immer 
+einen »Entwicklungszweig (Branch)« dessen Namen der aktuellen »Major« Version entspricht, z. B.
+`5.x` seit Anfang 2022. Dieser Branch muss als `5.x-dev` in Composer verlangt werden.
 
-Eine komplettes Beispiel einer `composer.json`, wo der Entwicklungszweig von Contao 
-`4.9` installiert wird, sieht so aus:
+Eine komplettes Beispiel einer `composer.json`, wo der Entwicklungszweig von Contao's nächster
+Version wird, sieht so aus:
 
 ```json
 {
     "name": "contao/managed-edition",
+    "description": "Contao Managed Edition",
+    "license": "LGPL-3.0-or-later",
     "type": "project",
-    "description": "Contao Open Source CMS",
     "require": {
-        "php": "^7.1",
-        "contao/calendar-bundle": "4.9.x-dev",
-        "contao/comments-bundle": "4.9.x-dev",
+        "contao/calendar-bundle": "5.x-dev",
+        "contao/comments-bundle": "5.x-dev",
         "contao/conflicts": "@dev",
-        "contao/core-bundle": "4.9.x-dev",
-        "contao/faq-bundle": "4.9.x-dev",
-        "contao/installation-bundle": "4.9.x-dev",
-        "contao/listing-bundle": "4.9.x-dev",
-        "contao/manager-bundle": "4.9.x-dev",
-        "contao/news-bundle": "4.9.x-dev",
-        "contao/newsletter-bundle": "4.9.x-dev"
+        "contao/core-bundle": "5.x-dev",
+        "contao/faq-bundle": "5.x-dev",
+        "contao/installation-bundle": "5.x-dev",
+        "contao/listing-bundle": "5.x-dev",
+        "contao/manager-bundle": "5.x-dev",
+        "contao/news-bundle": "5.x-dev",
+        "contao/newsletter-bundle": "5.x-dev"
     },
     "conflict": {
         "contao-components/installer": "<1.3"
     },
-    "extra": {
-        "contao-component-dir": "assets",
-        "symfony": {
-            "require": "^4.2"
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "contao-community-alliance/composer-plugin": true,
+            "contao-components/installer": true,
+            "contao/manager-plugin": true
         }
+    },
+    "extra": {
+        "contao-component-dir": "assets"
     },
     "scripts": {
         "post-install-cmd": [
-            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
+            "@php vendor/bin/contao-setup"
         ],
         "post-update-cmd": [
-            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
+            "@php vendor/bin/contao-setup"
         ]
     }
 }
@@ -187,6 +202,11 @@ Update-Operation drastisch erhöhen).
 
 Jedes mal, wenn eine Paketaktualisierung durchgeführt wird, wird der neueste Programmcode
 aus diesem Branch des öffentlichen Git Repositorys von Contao geholt.
+
+Jede vergangene und noch unterstützte »Minor« Version von Contao hat ebenfalls ihren eigenen
+Entwicklungs-Branch, z. B. `4.13.x-dev` für Contao `4.13`. Falls du also den aktuellen
+Entwicklungsstand testen möchtest ohne auf die Veröffentlichung einer neuen Version zu warten
+kann stattdessen dieser Branch in der oben erwähnten `composer.json` verlangt werden.
 
 
 ## Contao Manager

--- a/docs/manual/guides/install-test-versions.en.md
+++ b/docs/manual/guides/install-test-versions.en.md
@@ -124,9 +124,9 @@ Only the requested version of the `contao/manager-bundle` needs to be adjusted.
 
 ## Installing Developer Versions
 
-During the [development of a Contao version][releasePlan] you can also install the development 
-version for testing purposes. This way you can test the latest changes without having
-to wait for a new release. Though this might of course also contain some unstable code.
+You can also install the [development version][releasePlan] for testing purposes instead of 
+just the already defined release candidates. This way you can test the latest changes without 
+having to wait for a new release. Though this might of course also contain some unstable code.
 
 In this case instead of requiring a specific _version_ of Contao, a specific _branch_
 of Contao's public Git repository will be required. The current minor version in development

--- a/docs/manual/guides/install-test-versions.en.md
+++ b/docs/manual/guides/install-test-versions.en.md
@@ -71,10 +71,10 @@ its latest release candidates (if there are any):
 ```json
 {
     "name": "contao/managed-edition",
+    "description": "Contao Managed Edition",
+    "license": "LGPL-3.0-or-later",
     "type": "project",
-    "description": "Contao Open Source CMS",
     "require": {
-        "php": "^7.1",
         "contao/calendar-bundle": "^4.9",
         "contao/comments-bundle": "^4.9",
         "contao/conflicts": "@dev",
@@ -91,11 +91,16 @@ its latest release candidates (if there are any):
     "conflict": {
         "contao-components/installer": "<1.3"
     },
-    "extra": {
-        "contao-component-dir": "assets",
-        "symfony": {
-            "require": "^4.4"
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "contao-community-alliance/composer-plugin": true,
+            "contao-components/installer": true,
+            "contao/manager-plugin": true
         }
+    },
+    "extra": {
+        "contao-component-dir": "assets"
     },
     "scripts": {
         "post-install-cmd": [
@@ -119,52 +124,56 @@ Only the requested version of the `contao/manager-bundle` needs to be adjusted.
 
 ## Installing Developer Versions
 
-During the release candidate and development phase of a Contao version, you can
-also install the development version for testing purposes instead of just the already
-defined release candidates. This way you can test the latest changes without having
-to wait for a new release candidate. Though this might of course also contain some
-unstable code.
+You can also install the development version for testing purposes instead of just the 
+already defined release candidates. This way you can test the latest changes without having
+to wait for a new release. Though this might of course also contain some unstable code.
 
-In this case, instead of requiring a specific _version_ of Contao, a specific _branch_
-of Contao's public Git repository will be required. Each minor version of Contao
-has its own development branch, e.g. `4.9.x-dev` for Contao `4.9` for instance.
+In this case instead of requiring a specific _version_ of Contao, a specific _branch_
+of Contao's public Git repository will be required. The current minor version in development
+will always have a branch name corresponding to the current major version, e.g. `5.x` as
+of 2022. This branch needs to be required as `5.x-dev` in Composer.
 
 Here is a full `composer.json` example, requiring the development branch of Contao's
-`4.9` version:
+next version:
 
 ```json
 {
     "name": "contao/managed-edition",
+    "description": "Contao Managed Edition",
+    "license": "LGPL-3.0-or-later",
     "type": "project",
-    "description": "Contao Open Source CMS",
     "require": {
-        "php": "^7.1",
-        "contao/calendar-bundle": "4.9.x-dev",
-        "contao/comments-bundle": "4.9.x-dev",
+        "contao/calendar-bundle": "5.x-dev",
+        "contao/comments-bundle": "5.x-dev",
         "contao/conflicts": "@dev",
-        "contao/core-bundle": "4.9.x-dev",
-        "contao/faq-bundle": "4.9.x-dev",
-        "contao/installation-bundle": "4.9.x-dev",
-        "contao/listing-bundle": "4.9.x-dev",
-        "contao/manager-bundle": "4.9.*",
-        "contao/news-bundle": "4.9.x-dev",
-        "contao/newsletter-bundle": "4.9.x-dev"
+        "contao/core-bundle": "5.x-dev",
+        "contao/faq-bundle": "5.x-dev",
+        "contao/installation-bundle": "5.x-dev",
+        "contao/listing-bundle": "5.x-dev",
+        "contao/manager-bundle": "5.x-dev",
+        "contao/news-bundle": "5.x-dev",
+        "contao/newsletter-bundle": "5.x-dev"
     },
     "conflict": {
         "contao-components/installer": "<1.3"
     },
-    "extra": {
-        "contao-component-dir": "assets",
-        "symfony": {
-            "require": "^4.4"
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "contao-community-alliance/composer-plugin": true,
+            "contao-components/installer": true,
+            "contao/manager-plugin": true
         }
+    },
+    "extra": {
+        "contao-component-dir": "assets"
     },
     "scripts": {
         "post-install-cmd": [
-            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
+            "@php vendor/bin/contao-setup"
         ],
         "post-update-cmd": [
-            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
+            "@php vendor/bin/contao-setup"
         ]
     }
 }
@@ -179,6 +188,11 @@ a composer update).
 
 Each time the packages are updated, the most recent code for this branch will be 
 pulled from Contao's public Git repository.
+
+Each past (and still supported) minor version of Contao also has its own development 
+branch, e.g. `4.13.x-dev` for Contao `4.13`. So if you want to test the current state 
+of development of the next bugfix version, you can require this branch in the above 
+`composer.json` instead.
 
 
 ## Contao Manager

--- a/docs/manual/guides/install-test-versions.en.md
+++ b/docs/manual/guides/install-test-versions.en.md
@@ -124,8 +124,8 @@ Only the requested version of the `contao/manager-bundle` needs to be adjusted.
 
 ## Installing Developer Versions
 
-You can also install the development version for testing purposes instead of just the 
-already defined release candidates. This way you can test the latest changes without having
+During the [development of a Contao version][releasePlan] you can also install the development 
+version for testing purposes. This way you can test the latest changes without having
 to wait for a new release. Though this might of course also contain some unstable code.
 
 In this case instead of requiring a specific _version_ of Contao, a specific _branch_


### PR DESCRIPTION
This clarifies how to install RC (e.g. 4.13-RC) and old (e.g. 4.9.x) and new dev versions (e.g. 5.x) and also updates the `composer.json` examples to the current state of the default `composer.json` of the Contao Managed Edition.