### PR TITLE
Twig Manual

### DIFF
--- a/docs/manual/layout/templates/twig/_index.de.md
+++ b/docs/manual/layout/templates/twig/_index.de.md
@@ -4,7 +4,7 @@ description: "Übersicht Twig-Templates."
 url: "layout/templates/twig"
 aliases:
     - /de/layout/templates/twig/
-weight: 10
+weight: 15
 ---
 
 
@@ -18,44 +18,54 @@ einige Änderungen geben, also sei darauf vorbereitet.
 
 Twig ist Symfony's Standardmethode zum Schreiben von Templates. Es ist schnell, sicher und leicht erweiterbar. Im Gegensatz zu 
 PHP-Templates enthalten Twig-Templates keine Geschäftslogik, was die gemeinsame Nutzung durch Designer und Programmierer erleichtert. 
-Diese Tatsache hilft, eine saubere Trennung zwischen der Präsentations- und der Daten-/Logikschicht aufrechtzuerhalten.
 
-Twig bietet außerdem viele leistungsstarke Methoden zur Strukturierung von Vorlagen, wie z. B. das Einbinden, Vererben, Wiederverwenden 
-von Blöcken oder Makros, den erleichterten Zugriff auf Objekte mit »Property Access«, verfügt über Leerzeichenkontrolle, 
-String-Interpolationsfunktionen und vieles mehr.
-
-{{% notice info %}}
-Eine Auswahl vorhandener Twig-Templates, z. B. über ein Inhaltselement, ist derzeit noch nicht möglich. Die Dokumentation der Twig Nutzung in Contao wird ständig erweitert. Bis dahin findest du in [diesem Beitrag](https://docs.contao.org/dev/framework/templates/twig/) weitere, detaillierte Informationen zum Thema.
-{{% /notice %}}
+{{% children %}}
 
 
-## Erste Schritte
+## Erste Schritte mit Twig
 
-Du kannst Twig-Templates überall dort verwenden, wo du auch eine PHP-Vorlage verwenden würdest, nur mit einer anderen Dateierweiterung 
-(`.html.twig` statt `.html5`). Es ist sogar möglich, PHP-Templates aus den Twig-Templates heraus zu erweitern.
+Wenn du bereits mit Twig vertraut bist, kannst du diesen Schritt überspringen.
 
-Lege dir eine `fe_page.html.twig` in deinem Template-Verzeichnis an. In diesem Beispiel wird eine Überschrift über dem Hauptabschnitt 
-hinzugefügt und alles andere bleibt gleich:
+Twig-Templates haben ihre eigene Syntax. Das folgende Beispiel zeigt wie ein PHP-Template in ein analoges Twig-Template übersetzt werden kann:
 
-```twig
-{# /templates/fe_page.html.twig #}
+{{< tabs groupId="twig">}}
+{{% tab name="PHP" %}}
+```html
+<div class="about-me">
+  <h2><?= $this->name ?></h2>
+  <p>I am <?= round($this->age) ?> years old.</p>
 
-{% extends '@Contao/fe_page' %}
-
-{% block main %}
-  <h1>Hello from Twig!</h1>
-  {{ parent() }}
-{% endblock %}
+  <ul class="hobby-list">
+    <?php foreach $this->hobbies as $hobby: ?>
+      <li><?= ucfirst($hobby) ?></li>
+    <?php endforeach; ?>
+  </ul>
+</div>
 ```
+{{% /tab %}}
+{{% tab name="Twig" %}}
+```twig
+<div class="about-me">
+  <h2>{{ name }}</h2>
+  <p>I am {{ age|round }} years old.</p>
 
-1. Benenne dein Twig-Template wie das Contao-Pendant (mit Ausnahme der Dateierweiterung) und lege dieses in einem normalen 
-Contao Template Verzeichnis ab. Es kann derzeit **entweder** eine Twig- **oder** eine PHP-Variante des gleichen Templates am gleichen Ort geben.
+  <ul class="hobby-list">
+    {% for hobby in hobbies %}
+      <li>{{ hobby|capitalize }}</li>
+    {% endfor %}
+  </ul>
+</div>
+```
+{{% /tab %}}
+{{< /tabs >}}
 
-2. Um eine bestehende Vorlage zu erweitern (anstatt diese komplett zu ersetzen), verwende das Schlüsselwort `extends` und den 
-speziellen `@Contao` [Namensraum](https://docs.contao.org/dev/framework/templates/twig/#namespace-magic).
 
-3. Verwende den gleichen Blocknamen wie in der ursprünglichen Vorlage.
+### Die Syntax erlernen
 
-{{% notice note %}}
-Du kannst Twig-Templates nicht aus PHP-Templates heraus erweitern, nur umgekehrt.
-{{% /notice %}}
+Zur Ausgabe von Variablen benutzt du deren Namen in geschweiften Klammern `{{ foo }}`. Schlüsselwörter wie `for` werden innerhalb von `{%` und `%}` 
+gesetzt. Zur weiteren Verarbeitung der Ausgabe verwendest du [Filter](https://twig.symfony.com/doc/3.x/filters/index.html)
+`|foo` und [Funktionen](https://twig.symfony.com/doc/3.x/functions/index.html) `bar()`.
+
+Die Twig Syntax ist [gut dokumentiert](https://twig.symfony.com/doc/3.x/). Ein guter Startpunkt ist der
+Abschnitt [Twig für Template-Designer](https://twig.symfony.com/doc/3.x/templates.html). Du möchtest schnell etwas ausprobieren? 
+Verwende dazu [Twig fiddle](https://twigfiddle.com/).

--- a/docs/manual/layout/templates/twig/_index.en.md
+++ b/docs/manual/layout/templates/twig/_index.en.md
@@ -3,7 +3,7 @@ title: "Twig templates"
 description: "Overview Twig templates."
 aliases:
     - /en/layout/templates/twig/
-weight: 10
+weight: 15
 ---
 
 
@@ -15,44 +15,58 @@ considered internal for now. Although not likely, there could also be some behav
 {{% /notice %}}
 
 Twig is Symfony’s default way to write templates. It’s fast, safe and easily extensible. Contrary to PHP templates, Twig templates won’t 
-contain business logic which allows to share them more easily between designers and programmers. This fact also helps you maintain 
-a clean separation between your presentation and data/logic layer.
+contain business logic which allows to share them more easily between designers and programmers. 
 
-Twig also features a lot of powerful methods to structure your templates like including, embedding, inheriting, reusing blocks or macros, 
-eases accessing objects with “property access”, has whitespace control, string interpolation features and a ton more… Give it a try!
-
-{{% notice info %}}
-A selection of existing Twig templates, e.g. via a content element, is currently not yet possible. The documentation of Twig usage in Contao is constantly being extended. Until then you can find more detailed information [here](https://docs.contao.org/dev/framework/templates/twig/).
-{{% /notice %}}
+{{% children %}}
 
 
-## Getting started
+## Getting started with Twig
 
-You can use Twig templates at any place you would use a Contao PHP template, just with a different file extension 
-(`.html.twig` instead of `.html5`). It’s even possible to extend Contao PHP templates from within your Twig templates.
+If you're already familiar with Twig, you might want to skip this step.
 
-Go ahead and place a `fe_page.html.twig` in your template directory - this example will add a friendly headline above the main section 
-and keep everything else the same:
+Twig templates have their own syntax, but don't be afraid, you'll quickly
+find your way. Switch between the following tabs to see how an example PHP
+template would translate to an analog Twig template:
 
-```twig
-{# /templates/fe_page.html.twig #}
+{{< tabs groupId="twig">}}
+{{% tab name="PHP" %}}
+```html
+<div class="about-me">
+  <h2><?= $this->name ?></h2>
+  <p>I am <?= round($this->age) ?> years old.</p>
 
-{% extends '@Contao/fe_page' %}
-
-{% block main %}
-  <h1>Hello from Twig!</h1>
-  {{ parent() }}
-{% endblock %}
+  <ul class="hobby-list">
+    <?php foreach $this->hobbies as $hobby: ?>
+      <li><?= ucfirst($hobby) ?></li>
+    <?php endforeach; ?>
+  </ul>
+</div>
 ```
+{{% /tab %}}
+{{% tab name="Twig" %}}
+```twig
+<div class="about-me">
+  <h2>{{ name }}</h2>
+  <p>I am {{ age|round }} years old.</p>
 
-1. Name your Twig templates like your Contao counterpart (except for the file extension) and put them in a regular Contao template directory. 
-There can **either** be a Twig **or** a PHP variant of the same template in the same location.
+  <ul class="hobby-list">
+    {% for hobby in hobbies %}
+      <li>{{ hobby|capitalize }}</li>
+    {% endfor %}
+  </ul>
+</div>
+```
+{{% /tab %}}
+{{< /tabs >}}
 
-2. To extend an existing template (instead of completely replacing it) use the `extends` keyword and the special `@Contao` 
-[namespace](https://docs.contao.org/dev/framework/templates/twig/#namespace-magic).
 
-3. Use the same block names as in the original template.
+### Learning the syntax
 
-{{% notice note %}}
-You cannot extend Twig templates from within PHP templates only the other way round.
-{{% /notice %}}
+To output variables wrap their name in curly braces `{{ foo }}`, to use keywords
+like `for` wrap them in `{%` and `%}`, to further process any output, use [filters](https://twig.symfony.com/doc/3.x/filters/index.html)
+`|foo` and [functions](https://twig.symfony.com/doc/3.x/functions/index.html) `bar()`.
+
+Twig is very [well documented](https://twig.symfony.com/doc/3.x/) - a good place to start is the
+[Twig for template designers](https://twig.symfony.com/doc/3.x/templates.html) section that covers syntax
+details as well as helpful IDE plugins for autocompletion and syntax highlighting. For quickly trying something out, you can 
+use [Twig fiddle](https://twigfiddle.com/).

--- a/docs/manual/layout/templates/twig/assets.de.md
+++ b/docs/manual/layout/templates/twig/assets.de.md
@@ -1,0 +1,25 @@
+---
+title: "CSS- und JavaScript-Assets"
+description: "CSS- und JavaScript-Assets in Templates einsetzen."
+url: "layout/templates/twig/assets"
+aliases:
+    - /de/layout/templates/twig/assets/
+weight: 30
+---
+
+
+Oft werden zu einem individuellen Template zusätzliche Inhalte (»Assets«) wie CSS- oder JavaScript-Dateien benötigt.
+Man kann diese Dateien grundsätzlich über das Seitenlayout eines Themes einbinden, allerdings werden sie dann immer
+geladen, egal ob sie auf einer Seite benötigt werden oder nicht. Es kann daher sinnvoll sein, Assets an spezifische
+Templates zu binden.
+
+
+#### Assets einbinden
+
+Am einfachsten ist es, die Dateien in einem öffentlichen Verzeichnis unterhalb von `/files` anzulegen und dann im
+Template zu referenzieren:
+
+```twig
+<link href="files/myfolder/custom.css" rel="stylesheet">
+<script src="files/myfolder/custom.js"></script>
+```

--- a/docs/manual/layout/templates/twig/assets.en.md
+++ b/docs/manual/layout/templates/twig/assets.en.md
@@ -1,0 +1,23 @@
+---
+title: 'CSS and JavaScript assets'
+description: 'Use CSS and JavaScript assets in templates.'
+aliases:
+    - /en/layout/templates/twig/template-assets/
+weight: 30
+---
+
+
+Oftentimes, templates require additional assets, such as CSS or JavaScript files. You *can* integrate them via your
+theme's page layout, but this also means they will always be loaded, no matter if they are needed or not. Luckily,
+you can also tie assets to specific templates.
+
+
+#### Adding assets
+
+The easiest way is to put the needed files into a public directory inside `/files` and then reference them in the
+template:
+
+```twig
+<link href="files/myfolder/custom.css" rel="stylesheet">
+<script src="files/myfolder/custom.js"></script>
+```

--- a/docs/manual/layout/templates/twig/data.de.md
+++ b/docs/manual/layout/templates/twig/data.de.md
@@ -1,0 +1,20 @@
+---
+title: "Template-Daten anzeigen"
+description: "Alle Template-Daten anzeigen."
+url: "layout/templates/twig/data"
+aliases:
+    - /de/layout/templates/twig/data/
+weight: 60
+---
+
+
+Die verfügbaren Template-Daten variieren je nach Quelle der Vorlage. 
+
+Innerhalb von Twig-Templates kannst du dir alle verfügbaren oder gezielt einzelne Template-Daten anzeigen lassen.
+Dies funktioniert allerdings nur bei aktiviertem Debug-Modus.
+
+```twig
+{{ dump() }}
+{{ dump(varA) }}
+{{ dump(varA, varB) }}
+```

--- a/docs/manual/layout/templates/twig/data.de.md
+++ b/docs/manual/layout/templates/twig/data.de.md
@@ -10,11 +10,14 @@ weight: 60
 
 Die verfügbaren Template-Daten variieren je nach Quelle der Vorlage. 
 
-Innerhalb von Twig-Templates kannst du dir alle verfügbaren oder gezielt einzelne Template-Daten anzeigen lassen.
-Dies funktioniert allerdings nur bei aktiviertem Debug-Modus.
+Innerhalb von Twig-Templates kannst du dir alle verfügbaren oder gezielt einzelne Variablen anzeigen lassen.
 
 ```twig
 {{ dump() }}
 {{ dump(varA) }}
 {{ dump(varA, varB) }}
 ```
+
+{{% notice warning %}}
+Dies funktioniert nur bei aktiviertem [Debug-Modus](/de/system/debug-modus/).
+{{% /notice %}}

--- a/docs/manual/layout/templates/twig/data.en.md
+++ b/docs/manual/layout/templates/twig/data.en.md
@@ -10,10 +10,13 @@ weight: 60
 The available template context varies depending on the template source. 
 
 Within Twig templates you can display all available or specific template data.
-This only works while the debug mode is enabled.
 
 ```twig
 {{ dump() }}
 {{ dump(varA) }}
 {{ dump(varA, varB) }}
 ```
+
+{{% notice warning %}}
+This only works while the [debug mode](/en/system/debug-mode/) is enabled.
+{{% /notice %}}

--- a/docs/manual/layout/templates/twig/data.en.md
+++ b/docs/manual/layout/templates/twig/data.en.md
@@ -1,0 +1,19 @@
+---
+title: 'Display template data'
+description: 'Display all template data.'
+aliases:
+    - /en/layout/templates/twig/template-data/
+weight: 60
+---
+
+
+The available template context varies depending on the template source. 
+
+Within Twig templates you can display all available or specific template data.
+This only works while the debug mode is enabled.
+
+```twig
+{{ dump() }}
+{{ dump(varA) }}
+{{ dump(varA, varB) }}
+```

--- a/docs/manual/layout/templates/twig/encoding.de.md
+++ b/docs/manual/layout/templates/twig/encoding.de.md
@@ -1,0 +1,46 @@
+---
+title: "Kodierung / Escaping"
+description: "Informationen zu Kodierung / Escaping."
+url: "layout/templates/twig/encoding"
+aliases:
+    - /de/layout/templates/twig/encoding/
+weight: 70
+---
+
+
+Aus historischen Gründen verwendet Contao die *Eingabe*-Kodierung, aber Twig verwendet die vernünftigere *Ausgabe*-Kodierung. 
+Du kannst mehr über das Thema (und warum die Ausgabekodierung bevorzugt werden sollte) in 
+diesem [OWASP-Artikel](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-0-never-insert-untrusted-data-except-in-allowed-locations) über Verhinderung von Cross Site Scripting (XSS) Angriffen lesen.
+
+
+## Warum dich das interessieren sollte
+
+Das Wesentliche: Als Vorlagendesigner musst du entscheiden, wie Dinge ausgegeben werden sollen, denn *du* kennst den Kontext und weißt, 
+welchen Inhalten du vertrauen kannst oder nicht. Die *exakt gleichen* Daten können in einem Kontext gefährlich und in einem anderen harmlos sein:
+
+Mit Twig können wir genau festlegen, wie eine bestimmte Variable behandelt werden soll. Verwende dazu den Filter `|escape` oder kurz `|e`:
+
+```twig
+<style>
+  .box { background: {{ color|e('css') }} }
+</style>
+
+[…]
+
+<div class="box">{{ color|e('html') }}</div>
+```
+
+{{% notice note %}}
+Standardmäßig kodiert Twig **alle** Variablen. Die gewählte Escaper Strategie hängt von der Dateierweiterung der Vorlage ab: Deine 
+`.html.twig` Vorlagen werden automatisch mit `|e('html')` behandelt, so dass du diesen Teil im obigen Beispiel weglassen könntest.
+{{% /notice %}}
+
+
+## Vertrauenswürdige Rohdaten
+
+Wenn du absichtlich eine Variable ausgeben möchtest, die reines HTML enthält, wie z. B.  `<b>nett</b>`, musst du den Escape-Filter 
+`|raw` der Variablen hinzufügen. Andernfalls wird `&lt;b&gt;nett&lt;/b&gt;` ausgegeben.
+
+{{% notice warning %}}
+Denke daran, dass du `|raw` immer nur vertrauenswürdigen Eingaben hinzufügst. Die Verwendung von `|raw` kann ansonsten zu schwerwiegenden XSS-Schwachstellen führen.
+{{% /notice %}}

--- a/docs/manual/layout/templates/twig/encoding.de.md
+++ b/docs/manual/layout/templates/twig/encoding.de.md
@@ -18,7 +18,8 @@ diesem [OWASP-Artikel](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site
 Das Wesentliche: Als Vorlagendesigner musst du entscheiden, wie Dinge ausgegeben werden sollen, denn *du* kennst den Kontext und weißt, 
 welchen Inhalten du vertrauen kannst oder nicht. Die *exakt gleichen* Daten können in einem Kontext gefährlich und in einem anderen harmlos sein:
 
-Mit Twig können wir genau festlegen, wie eine bestimmte Variable behandelt werden soll. Verwende dazu den Filter `|escape` oder kurz `|e`:
+Mit Twig können wir genau festlegen, wie eine bestimmte Variable behandelt werden soll. Verwende dazu den 
+[Filter](https://twig.symfony.com/doc/3.x/filters/escape.html) `|escape` oder kurz `|e`:
 
 ```twig
 <style>

--- a/docs/manual/layout/templates/twig/encoding.de.md
+++ b/docs/manual/layout/templates/twig/encoding.de.md
@@ -36,11 +36,14 @@ Standardmäßig kodiert Twig **alle** Variablen. Die gewählte Escaper Strategie
 `.html.twig` Vorlagen werden automatisch mit `|e('html')` behandelt, so dass du diesen Teil im obigen Beispiel weglassen könntest.
 {{% /notice %}}
 
+Mit dem [autoescape](https://twig.symfony.com/doc/3.x/tags/autoescape.html) Tag kannst du einen ganzen Abschnitt so markieren, 
+dass er escaped wird oder nicht.
+
 
 ## Vertrauenswürdige Rohdaten
 
-Wenn du absichtlich eine Variable ausgeben möchtest, die reines HTML enthält, wie z. B.  `<b>nett</b>`, musst du den Escape-Filter 
-`|raw` der Variablen hinzufügen. Andernfalls wird `&lt;b&gt;nett&lt;/b&gt;` ausgegeben.
+Wenn du absichtlich eine Variable ausgeben möchtest, die reines HTML enthält, wie z. B.  `<b>nett</b>`, musst du den 
+[Filter](https://twig.symfony.com/doc/3.x/filters/raw.html) `|raw` der Variablen hinzufügen. Andernfalls wird `&lt;b&gt;nett&lt;/b&gt;` ausgegeben.
 
 {{% notice warning %}}
 Denke daran, dass du `|raw` immer nur vertrauenswürdigen Eingaben hinzufügst. Die Verwendung von `|raw` kann ansonsten zu schwerwiegenden XSS-Schwachstellen führen.

--- a/docs/manual/layout/templates/twig/encoding.en.md
+++ b/docs/manual/layout/templates/twig/encoding.en.md
@@ -38,12 +38,16 @@ templates will automatically get the `|e('html')` treatment, so you could omit
 this part in the above example.
 {{% /notice %}}
 
+You can mark a whole section of a template to be escaped or not by using the 
+[autoescape](https://twig.symfony.com/doc/3.x/tags/autoescape.html) tag.
+
 
 ## Trusted raw data
 
 If you intentionally **do** want to output a variable containing raw HTML, like 
-`<b>nice</b>`, you need to add the `|raw` escaper filter to your variable which tells Twig to skip escaping this value.
-Otherwise `&lt;b&gt;nice&lt;/b&gt;` will be output, i.e. a text saying *&lt;b&gt;nice&lt;/b&gt;* and not a bold word <b>nice</b>. 
+`<b>nice</b>`, you need to add the `|raw` [filter](https://twig.symfony.com/doc/3.x/filters/raw.html) to your variable which tells 
+Twig to skip escaping this value. Otherwise `&lt;b&gt;nice&lt;/b&gt;` will be output, i.e. a text saying *&lt;b&gt;nice&lt;/b&gt;* and 
+not a bold word <b>nice</b>. 
 
 {{% notice warning %}}
 Keep in mind, that you only ever add `|raw` to trusted input! Using `|raw` on 

--- a/docs/manual/layout/templates/twig/encoding.en.md
+++ b/docs/manual/layout/templates/twig/encoding.en.md
@@ -1,0 +1,51 @@
+---
+title: "Encoding / Escaping"
+description: "Encoding and Escaping information."
+aliases:
+    - /en/layout/templates/twig/encoding/
+weight: 70
+---
+
+
+For historic reasons Contao uses *input* encoding, but Twig embraces the more
+sane *output* encoding. You can read more about the topic (and why you should
+favor output encoding) in this [OWASP article](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-0-never-insert-untrusted-data-except-in-allowed-locations) about preventing Cross Site Scripting (XSS) attacks.
+
+
+## Why you should care
+
+The gist: You, as a template designer, have to decide how things should be
+output, because *you* know the context and which content you trust or not. The
+*exact same* data can be dangerous in one context and harmless in another:
+
+With Twig we can be specific how a certain variable should be treated. Use the
+`|escape` or - short - `|e` filter for this:
+
+```twig
+<style>
+  .box { background: {{ color|e('css') }} }
+</style>
+
+[…]
+
+<div class="box">{{ color|e('html') }}</div>
+```
+
+{{% notice note %}}
+By default Twig encodes **all** variables. The chosen escaper
+strategy will depend on the template's file extension: your `.html.twig`
+templates will automatically get the `|e('html')` treatment, so you could omit
+this part in the above example.
+{{% /notice %}}
+
+
+## Trusted raw data
+
+If you intentionally **do** want to output a variable containing raw HTML, like 
+`<b>nice</b>`, you need to add the `|raw` escaper filter to your variable which tells Twig to skip escaping this value.
+Otherwise `&lt;b&gt;nice&lt;/b&gt;` will be output, i.e. a text saying *&lt;b&gt;nice&lt;/b&gt;* and not a bold word <b>nice</b>. 
+
+{{% notice warning %}}
+Keep in mind, that you only ever add `|raw` to trusted input! Using `|raw` on 
+anything else may result in severe XSS vulnerabilities!
+{{% /notice %}}

--- a/docs/manual/layout/templates/twig/encoding.en.md
+++ b/docs/manual/layout/templates/twig/encoding.en.md
@@ -18,8 +18,8 @@ The gist: You, as a template designer, have to decide how things should be
 output, because *you* know the context and which content you trust or not. The
 *exact same* data can be dangerous in one context and harmless in another:
 
-With Twig we can be specific how a certain variable should be treated. Use the
-`|escape` or - short - `|e` filter for this:
+With Twig we can be specific how a certain variable should be treated. Use the `|escape` or - short - `|e` 
+[filter](https://twig.symfony.com/doc/3.x/filters/escape.html) for this:
 
 ```twig
 <style>

--- a/docs/manual/layout/templates/twig/extension.de .md
+++ b/docs/manual/layout/templates/twig/extension.de .md
@@ -1,0 +1,34 @@
+---
+title: "Erweiterungen"
+description: "Twig Erweiterungen."
+url: "layout/templates/twig/extensions"
+aliases:
+    - /de/layout/templates/twig/extensions/
+weight: 90
+---
+
+
+In Twig kannst du problemlos Erweiterungen verwenden. Der Contao-Kern beinhaltet beispielsweise das 
+[KnpTimeBundle](https://github.com/KnpLabs/KnpTimeBundle), um Datums- und Zeitangaben zu formatieren ("vor 5 Minuten").
+Da dieses Bundle eine Twig-Erweiterung mit einem `|ago`-Filter bereitstellt, kannst du diese Funktionalität direkt im Templates verwenden:
+
+```twig
+<p>Last edited: {{ modified_at|ago }}</p>
+
+{# <p>Last edited: 5 minutes ago</p> #}
+```
+
+
+### Weitere Erweiterungen verwenden
+
+Tatsächlich gibt es bereits eine Menge Twig-Erweiterungen, darunter einige
+[offizielle](https://github.com/twigphp/Twig/tree/3.x/extra). Diese "twig-extra"-Bundles können einfach
+mit Composer oder über den [Contao Manager](https://extensions.contao.org/?q=twig&pages=1) installiert werden und sind dann einsatzbereit.
+
+```twig
+{# using twig/intl-extra #}
+
+{{ '1000000'|format_currency('EUR') }}
+
+{# €1,000,000.00 #}
+```

--- a/docs/manual/layout/templates/twig/extension.de .md
+++ b/docs/manual/layout/templates/twig/extension.de .md
@@ -22,8 +22,9 @@ Da dieses Bundle eine Twig-Erweiterung mit einem `|ago`-Filter bereitstellt, kan
 ### Weitere Erweiterungen verwenden
 
 Tatsächlich gibt es bereits eine Menge Twig-Erweiterungen, darunter einige
-[offizielle](https://github.com/twigphp/Twig/tree/3.x/extra). Diese "twig-extra"-Bundles können einfach
-mit Composer oder über den [Contao Manager](https://extensions.contao.org/?q=twig&pages=1) installiert werden und sind dann einsatzbereit.
+[offizielle](https://github.com/twigphp/Twig/tree/3.x/extra). Diese »[twig-extra](https://extensions.contao.org/?q=twig&pages=1)« Bundles 
+können einfach mit Composer oder über den Contao Manager (siehe [extensions.contao.org](https://extensions.contao.org/?q=twig&pages=1)) 
+installiert werden und sind dann einsatzbereit.
 
 ```twig
 {# using twig/intl-extra #}

--- a/docs/manual/layout/templates/twig/extension.de .md
+++ b/docs/manual/layout/templates/twig/extension.de .md
@@ -1,6 +1,6 @@
 ---
-title: "Erweiterungen"
-description: "Twig Erweiterungen."
+title: "Twig Erweiterungen"
+description: "Informationen zu offiziellen Twig Erweiterungen."
 url: "layout/templates/twig/extensions"
 aliases:
     - /de/layout/templates/twig/extensions/

--- a/docs/manual/layout/templates/twig/extension.en.md
+++ b/docs/manual/layout/templates/twig/extension.en.md
@@ -23,8 +23,9 @@ directly use this functionality in your templates:
 ### Using twig-extra bundles
 
 In fact, there are already a lot of Twig extensions in the wild, including some
-[official ones](https://github.com/twigphp/Twig/tree/3.x/extra). These "twig-extra" bundles can simply be installed
-with composer or with the [Contao Manager](https://extensions.contao.org/?q=twig&pages=1) and are directly ready to be used.
+[official ones](https://github.com/twigphp/Twig/tree/3.x/extra). These "[twig-extra](https://extensions.contao.org/?q=twig&pages=1)" bundles 
+can simply be installed with composer or with the Contao Manager (see [extensions.contao.org](https://extensions.contao.org/?q=twig&pages=1)) 
+and are directly ready to be used.
 
 ```twig
 {# using twig/intl-extra #}

--- a/docs/manual/layout/templates/twig/extension.en.md
+++ b/docs/manual/layout/templates/twig/extension.en.md
@@ -1,0 +1,35 @@
+---
+title: "Extensions"
+description: "Twig Extensions."
+url: "layout/templates/twig/extensions"
+aliases:
+    - /en/layout/templates/twig/extensions/
+weight: 90
+---
+
+
+In Twig you can easily use extensions. The Contao core for instance
+uses the [KnpTimeBundle](https://github.com/KnpLabs/KnpTimeBundle) to format dates/time in a nice way ("5 minutes ago").
+As this bundle provides a Twig extension with an `|ago` filter, you can
+directly use this functionality in your templates:  
+
+```twig
+<p>Last edited: {{ modified_at|ago }}</p>
+
+{# <p>Last edited: 5 minutes ago</p> #}
+```
+
+
+### Using twig-extra bundles
+
+In fact, there are already a lot of Twig extensions in the wild, including some
+[official ones](https://github.com/twigphp/Twig/tree/3.x/extra). These "twig-extra" bundles can simply be installed
+with composer or with the [Contao Manager](https://extensions.contao.org/?q=twig&pages=1) and are directly ready to be used.
+
+```twig
+{# using twig/intl-extra #}
+
+{{ '1000000'|format_currency('EUR') }}
+
+{# €1,000,000.00 #}
+```

--- a/docs/manual/layout/templates/twig/extension.en.md
+++ b/docs/manual/layout/templates/twig/extension.en.md
@@ -1,6 +1,6 @@
 ---
-title: "Extensions"
-description: "Twig Extensions."
+title: "Twig Extensions"
+description: "Details about Twig Extensions."
 url: "layout/templates/twig/extensions"
 aliases:
     - /en/layout/templates/twig/extensions/

--- a/docs/manual/layout/templates/twig/inheritance.de.md
+++ b/docs/manual/layout/templates/twig/inheritance.de.md
@@ -1,0 +1,47 @@
+---
+title: "Template vererben"
+description: "Die Template Vererbung."
+url: "layout/templates/twig/vererbung"
+aliases:
+    - /de/layout/templates/twig/vererbung/
+weight: 40
+---
+
+
+Contao erlaubt das Vererben von Templates. Dabei kann ein Template nicht nur komplett überschrieben, sondern auch gezielt
+einzelne Teilbereiche (Blöcke) angepasst werden. 
+
+
+### Blöcke anpassen
+
+Zur Gliederung umschließen viele Templates ihre Inhalte bereits in Teilbereiche (Blöcke). 
+Nur Inhalte, die in solchen Blöcken liegen, können angepasst werden.
+
+{{< version "4.12" >}}
+
+Um eine bestehende Vorlage zu erweitern (anstatt diese komplett zu ersetzen), verwende das Schlüsselwort `extends`. Anzupassende Blöcke
+können dann, wie im originalen Template, durch Einschließen in `{% block name-des-blocks %}` und `{% endblock %}` angegeben 
+und ihre Inhalte überschrieben werden.
+
+Mittels `{{ parent() }}` lässt sich der originale Inhalt des Blocks ausgeben.
+
+
+```twig
+{# /templates/fe_page.html.twig #}
+
+{% extends '@Contao/fe_page' %}
+
+{% block main %}
+  <h1>Hello from Twig!</h1>
+  {{ parent() }}
+{% endblock %}
+```
+
+{{% notice note %}}
+Es ist möglich, PHP-Templates aus den Twig-Templates heraus zu erweitern. Du kannst Twig-Templates aber nicht aus PHP-Templates 
+heraus erweitern, nur umgekehrt.
+{{% /notice %}}
+
+{{% notice tip %}}
+Contao stellt für Twig-Templates spezielle Namensräume zur Verfügung. Detaillierte Informationen findest du [hier](/de/layout/templates/twig/namespace/).
+{{% /notice %}}

--- a/docs/manual/layout/templates/twig/inheritance.en.md
+++ b/docs/manual/layout/templates/twig/inheritance.en.md
@@ -1,0 +1,43 @@
+---
+title: 'Inherit templates'
+description: 'The template inheritance.'
+aliases:
+    - /en/layout/templates/twig/template-inheritance/
+weight: 40
+---
+
+Contao template inheritance (instead of completely replacing it) allows overwriting certain sections of a template (blocks).
+
+
+### Adjust blocks
+
+Many templates already structure their contents. Only contents wrapped in such blocks can be adjusted.
+First, the base template must be declared. Then you can provide new block content.
+
+{{< version "4.12" >}}
+
+To extend an existing template (instead of completely replacing it) use the `extends` keyword. Then you can provide new block 
+content by wrapping it in `{% block name-of-the-block %}` and  `{% endblock %}` statements like in the original
+template.
+
+The original block content is available via `{{ parent() }}`.
+
+```twig
+{# /templates/fe_page.html.twig #}
+
+{% extends '@Contao/fe_page' %}
+
+{% block main %}
+  <h1>Hello from Twig!</h1>
+  {{ parent() }}
+{% endblock %}
+```
+
+{{% notice note %}}
+It’s possible to extend Contao PHP templates from within your Twig templates. You cannot extend Twig templates from within 
+PHP templates only the other way round.
+{{% /notice %}}
+
+{{% notice tip %}}
+Contao provides special namespaces for Twig templates. You can find detailed information [here](/en/layout/templates/twig/namespace/).
+{{% /notice %}}

--- a/docs/manual/layout/templates/twig/insertion.de.md
+++ b/docs/manual/layout/templates/twig/insertion.de.md
@@ -1,0 +1,42 @@
+---
+title: "Template mischen"
+description: "Ein Template mischen."
+url: "layout/templates/twig/insertion"
+aliases:
+    - /de/layout/templates/twig/insertion/
+weight: 50
+---
+
+
+Ein Template kann in ein anderes Template eingefügt werden. Wir erstellen ein Template `image_copyright.html.twig` mit folgendem Inhalt:
+
+```twig
+{# /templates/image_copyright.html.twig #}
+
+<small>Fotografiert von {{ name }}, lizenziert als {{ license }}.</small>
+```
+
+Dieses Template lässt sich nun an beliebiger Stelle wiederverwenden. Hier fügen wir z.&nbsp;B. dem `content` Block des
+`ce_image.html.twig` Templates unseren Copyright-Hinweis (`image_copyright.html.twig`) hinzu:
+
+
+```twig
+{# templates/ce_image.html.twig #}
+
+{% extends '@Contao/ce_image' %}
+
+{% block content %}
+    {{ parent() }}
+    
+    {% include 'image_copyright.html.twig' with {name: 'Dona Evans A', license: 'Creative Commons B'} only %}
+
+{% endblock %}
+```
+
+### Ausgabe
+
+Wird das Template ausgegeben, erscheint nun unter dem Bild:
+
+```html
+Fotografiert von Donna Evans, lizenziert als Creative Commons.
+```

--- a/docs/manual/layout/templates/twig/insertion.en.md
+++ b/docs/manual/layout/templates/twig/insertion.en.md
@@ -1,0 +1,41 @@
+---
+title: 'Mix templates'
+description: 'Mix a template.'
+aliases:
+    - /en/layout/templates/twig/template-insertion/
+weight: 50
+---
+
+
+A template can be inserted into another template. We create a template `image_copyright.html.twig` with the following content:
+
+```twig
+{# /templates/image_copyright.html.twig #}
+
+<small>Photographed by {{ name }}, licensed as {{ license }}.</small>
+```
+
+This template can now be reused anywhere. Here, for example, we add our copyright notice (`image_copyright.html.twig`) 
+to the content block of the `ce_image.html.twig` template:
+
+```twig
+{# templates/ce_image.html.twig #}
+
+{% extends '@Contao/ce_image' %}
+
+{% block content %}
+    {{ parent() }}
+    
+    {% include 'image_copyright.html.twig' with {name: 'Dona Evans A', license: 'Creative Commons B'} only %}
+
+{% endblock %}
+```
+
+
+### Output
+
+When rendered, the template now shows:
+
+```html
+Photographed by Donna Evans, licensed as Creative Commons.
+```

--- a/docs/manual/layout/templates/twig/manage.de.md
+++ b/docs/manual/layout/templates/twig/manage.de.md
@@ -1,0 +1,37 @@
+---
+title: "Templates verwalten"
+description: "Die Verwaltung der Template-Dateien."
+url: "layout/templates/twig/verwaltung"
+aliases:
+    - /de/layout/templates/twig/verwaltung/
+weight: 20
+---
+
+## Ordnerstruktur
+
+Du kannst Templates im  `/templates` Ordner ablegen. 
+
+{{< version-tag "4.13" >}} Diese können im Backend, etwa bei der Konfiguration eines Inhaltselements, ausgewählt werden.
+
+* Templates, die dabei direkt im **Hauptverzeichnis** liegen, werden als `global` gekennzeichnet.
+* Im [Theme-Manager](../../theme-manager/themes-verwalten) kannst du ein vorhandenes **Unterverzeichnis** mit einem
+  Theme verknüpfen. Template-Dateien aus diesem Ordner werden bei der Auswahl dann mit dem jeweiligen `Theme-Namen`
+  gekennzeichnet.
+
+{{% notice note %}}
+Es kann derzeit entweder **eine** Twig- **oder** eine PHP-Variante des gleichen Templates am gleichen Ort geben.
+{{% /notice %}}
+
+
+## Dateinamen
+
+Die Template-Dateien werden zur Erkennung mit einem Präfix versehen. Beispielsweise deutet `ce_` auf ein
+Inhaltselement (**c**ontent **e**lement) hin. 
+
+Möchte man z.&nbsp;B. die Ausgabe des Inhaltselements vom Typ »Text« ändern, kann man das Template `ce_text.html.twig` 
+hierzu verwenden. In diesem Fall haben die Template-Änderungen Auswirkung auf alle Inhaltselemente vom Typ »Text«. 
+
+{{< version-tag "4.13" >}} Dies ist nicht immer erwünscht. Zur gezielten Nutzung kann man das Template individuell bezeichnen. Hierbei muss die 
+jeweils vorgegebene Template-Bezeichnung beibehalten und lediglich erweitert werden: also z.&nbsp;B. `ce_text.html.twig` 
+umbenennen nach `ce_text_individuell.html.twig`. Dieses Template kann dann gezielt zur Ausgabe für ein (o. mehrere) Inhaltselement(e) 
+vom Typ »Text« genutzt werden.

--- a/docs/manual/layout/templates/twig/manage.en.md
+++ b/docs/manual/layout/templates/twig/manage.en.md
@@ -1,0 +1,34 @@
+---
+title: 'Manage templates'
+description: 'The management of the template files.'
+aliases:
+    - /en/layout/templates/twig/manage-template/
+weight: 20
+---
+
+## Directory structure
+
+You can put templates in the `/templates` directory. 
+
+{{< version-tag "4.13" >}} These can be selected in the backend, for example when configuring a content element.
+
+* Templates that reside in the **main directory** will be marked as `global`.
+* Using the [theme manager](/en/layout/theme-manager/manage-themes/), you can link an existing **subdirectory** to a
+  theme. The template files in this directory will then be marked with the appropriate `Theme-Name`.
+
+{{% notice note %}}
+There can either be **one** Twig **or** a PHP variant of the same template in the same location.
+{{% /notice %}}
+
+
+## File names
+
+Template file names contain a prefix that let you identify their type: `ce_`, for example, stands for **c**ontent
+**e**lement.
+
+If you want to adjust the output of the "Text" content element, you would use the `ce_text.html.twig` template. In this case, 
+changes to the template will affect all content elements of type "Text". 
+
+{{< version-tag "4.13" >}} If this isn't what you're after, you can also provide a specific variant template by appending an individual suffix to 
+the existing name: `ce_text.html.twig` would then become `ce_text_specific.html.twig` for instance. This template will then be specifically 
+selectable in any of the "Text" content elements.

--- a/docs/manual/layout/templates/twig/namespace.de.md
+++ b/docs/manual/layout/templates/twig/namespace.de.md
@@ -1,0 +1,137 @@
+---
+title: "Namensräume"
+description: "Namensräume für Twig-Templates."
+url: "layout/templates/twig/namespace"
+aliases:
+    - /de/layout/templates/twig/namespace/
+weight: 80
+---
+
+
+Twig-Vorlagen existieren in Namensräumen wie `@Foo/my_template.html.twig` (*Foo*) oder
+`@ContaoCore/Image/Studio/figure.html.twig` (*ContaoCore*). Contao registriert automatisch die Vorlagen aus den verschiedenen 
+Verzeichnissen in ihren jeweiligen Namensräumen:
+
+
+| Verzeichnis | Namensraum | | Prio.<sup>*</sup>
+|-|-|-|-|
+| `/vendor/…/templates`<br>`/vendor/foo/bar/contao/templates` | `@Contao_<bundle>`<br>`@Contao_FooBarBundle` | Jedes Bundle-Vorlagen/Views-Verzeichnis. | 1 |
+| `/contao/templates`<br>`/src/Resources/contao/templates`<br>`/app/Resources/contao/templates` | `@Contao_App` | Vorlagen-Verzeichnis der Anwendung. | 2 |
+| `/templates` | `@Contao_Global` | Globales Vorlagen-Verzeichnis. | 3 |
+| `/templates/<theme>`<br>`/templates/foo/theme` | `@Contao_Theme_<theme>`<br>`@Contao_Theme_foo_theme` | Ein beliebiges Theme-Verzeichnis. Der Pfad (`foo/theme`) wird in einen Slug (`foo_theme`) umgewandelt und als Suffix angehängt. | 4 |
+
+<sup>* Höhere Prioritätswerte bedeuten "Zuerst als Vorlagenkandidat betrachten".</sup>
+
+{{% notice note %}}
+Du kannst auf der Konsole `contao-console debug:contao-twig` ausführen, um eine Liste aller registrierten Namensräume zu erhalten. Wenn du auch Theme-Vorlagen auflisten möchtest, füge die Option `-t` mit dem Pfad oder Slug des Themes hinzu. Um nach bestimmten Vorlagen zu filtern, gebe deren Namen oder Präfix als Argument an, z. B.: `contao-console debug:contao-twig ce_text -t my/theme`.
+{{% /notice %}}
+
+Darüber hinaus existiert ein **verwalteter `@Contao`-Namensraum**, den du verwenden solltest, wenn du den genauen Namensraum nicht kennst. 
+Dieser Namensraum wird beim Kompilieren der Templates durch einen bestimmten Namensraum ersetzt. In jeder Situation wählen wir die **nächste verfügbare** Vorlage, die eine **niedrigere Priorität** hat als die aktuelle.
+
+Du könntest dies durchaus zum Erweitern, Einbetten oder Einfügen von Vorlagen verwenden. Schau dir das folgende Beispiel an.
+
+
+## Hierarchie Beispiel
+
+In diesem Beispiel haben wir es mit vier Manifestationen der gleichen Vorlage `card.html.twig` zu tun.
+
+{{< tabs groupId="template-hierarchy-example">}}
+{{% tab name="a) card-bundle" %}}
+Die ursprüngliche Vorlage `card-bundle`:
+
+```twig
+{# /vendor/foo/card-bundle/contao/templates/card.html.twig #}
+
+{% import '@ContaoCore/Image/Studio/_macros.html.twig' as studio %}
+
+<section class="card">
+  {% block card %}
+    <header class="title">
+      {% block title %}{{ title }}{% endblock %}
+    </header>     
+    <main>
+      {% block content %}
+        {{ studio.figure(figure) }}
+        {{ description|raw }}
+      {% endblock %}
+    </main>
+    <footer>
+      {% block footer %}<p class="author">by {{ author }}</p>{% endblock %}
+    </footer
+  {% endblock %}
+</section>
+```
+{{% /tab %}}
+
+{{% tab name="b) card-time-bundle" %}} 
+Ein `card-time-bundle`, das das Original erweitert und Informationen in der Fußzeile hinzufügt.
+Dieses Bundle wurde *nach* dem `card-bundle` geladen, daher ist es weiter oben in unserer Vorlagen-Hierarchie:
+
+```twig
+{# /vendor/bar/card-time-bundle/contao/templates/card.html.twig #}
+
+{% extends '@Contao/card' %}
+
+{% block footer %}
+  {{ parent() }}
+  <p class="last-modified">edited at {{ modified_at|ago }}</p>
+{% endblock %}
+```
+{{% /tab %}}
+
+{{% tab name="c) global template" %}}
+Die `card` Vorlage des globalen Vorlagen Ordners, die einige Wrapper hinzufügt, denn man kann nicht genug *Divs* haben.
+
+```twig
+{# /templates/card.html.twig #}
+
+{% extends '@Contao/card' %}
+
+{% block title %}<div class="inner">{{ parent() }}</div>{% endblock %}
+{% block card %}<div class="inner">{{ parent() }}</div>{% endblock %}
+```
+{{% /tab %}}
+
+{{% tab name="d) emoji theme" %}}
+Und schließlich das "Emoji"-Thema der Anwendung.
+
+```twig
+{# /templates/emoji/card.html.twig #}
+   
+{% extends '@Contao/card' %}
+
+{% block title %}🤩 {{ parent() }} 🤯{% endblock %}
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Wenn man alles in der richtigen Reihenfolge auflöst, erhält man die folgende Vorlage. Beachte, dass jede Stufe Blöcke anpassen/mitgestalten 
+kann ohne die anderen kennen zu müssen, denn es wird der verwaltete `@Contao`-Namensraum verwendet:
+
+
+```twig
+{% import '@ContaoCore/Image/Studio/_macros.html.twig' as studio %}
+
+<section class="card">
+  <div class="inner">
+    <header class="title">
+      🤩 <div class="inner">{{ title }}</div> 🤯
+    </header>     
+    <main>
+      {{ studio.figure(figure) }}
+      {{ description|raw }}
+    </main>
+    <footer>
+     <p class="author">by {{ author }}</p>
+     <p class="last-modified">edited at {{ modified_at|ago }}</p>
+    </footer
+  </div>>
+</section>
+```
+
+{{% notice note %}}
+Beim Erweitern, Einfügen oder Einbetten von Vorlagen aus dem `@Contao`-Namensraum, wird die Dateierweiterung nicht berücksichtigt. 
+Das bedeutet, dass `@Contao/card.html.twig` auf die gleiche Vorlage zeigt wie `@Contao/card.html5`. Aus diesem Grund kannst du die 
+Dateierweiterung in diesem Fall komplett weglassen.
+{{% /notice %}}

--- a/docs/manual/layout/templates/twig/namespace.en.md
+++ b/docs/manual/layout/templates/twig/namespace.en.md
@@ -1,0 +1,148 @@
+---
+title: 'Namespaces'
+description: 'Namespaces for Twig templates'
+aliases:
+    - /en/layout/templates/twig/namespace/
+weight: 80
+---
+
+
+Twig templates live in namespaces like `@Foo/my_template.html.twig` (*Foo*) or
+`@ContaoCore/Image/Studio/figure.html.twig` (*ContaoCore*). We are
+automatically registering templates from the various Contao template
+directories in their respective namespaces:
+
+| Folder | Namespace | | Prio.<sup>*</sup>
+|-|-|-|-|
+| `/vendor/…/templates`<br>`/vendor/foo/bar/contao/templates` | `@Contao_<bundle>`<br>`@Contao_FooBarBundle` | Any bundle template/views directory. | 1 |
+| `/contao/templates`<br>`/src/Resources/contao/templates`<br>`/app/Resources/contao/templates` | `@Contao_App` | Template directory of the application. | 2 |
+| `/templates` | `@Contao_Global` | Global template directory. | 3 |
+| `/templates/<theme>`<br>`/templates/foo/theme` | `@Contao_Theme_<theme>`<br>`@Contao_Theme_foo_theme` | Any theme directory. The path (`foo/theme`) will be transformed into a slug (`foo_theme`) and appended as a suffix. | 4 |
+
+<sup>* Higher priority values mean "considered as template candidate first".</sup>
+
+{{% notice note %}}
+You can run `contao-console debug:contao-twig` to get a list of all registered
+namespaces. If you want to list theme templates as well add the `-t` option with
+your theme path or slug. To filter for certain templates enter their name or
+prefix as an argument, e.g.: `contao-console debug:contao-twig ce_text -t my/theme`.
+{{% /notice %}}
+
+On top, we're also providing a **managed `@Contao` namespace** which you should
+use whenever you do not know the exact namespace beforehand. This namespace
+will be substituted with a specific namespace when the templates are compiled.
+In each situation we're choosing the **next available** template that has a 
+**lower priority** than the current one.
+
+And yes, you can totally use this to extend, embed or include templates. Have a
+look at the following example to get an idea.
+
+
+## Template hierarchy example
+
+In this example, we're dealing with four manifestations of the same
+`card.html.twig` template: two in bundles, two more in the application.  
+
+{{< tabs groupId="template-hierarchy-example">}}
+{{% tab name="a) card-bundle" %}}
+The original template of the `card-bundle`:
+
+```twig
+{# /vendor/foo/card-bundle/contao/templates/card.html.twig #}
+
+{% import '@ContaoCore/Image/Studio/_macros.html.twig' as studio %}
+
+<section class="card">
+  {% block card %}
+    <header class="title">
+      {% block title %}{{ title }}{% endblock %}
+    </header>     
+    <main>
+      {% block content %}
+        {{ studio.figure(figure) }}
+        {{ description|raw }}
+      {% endblock %}
+    </main>
+    <footer>
+      {% block footer %}<p class="author">by {{ author }}</p>{% endblock %}
+    </footer
+  {% endblock %}
+</section>
+```
+{{% /tab %}}
+
+{{% tab name="b) card-time-bundle" %}} 
+A `card-time-bundle` extending the original bundle and adding information to
+the footer - this bundle was loaded *after* the `card-bundle`, therefore it is
+further up in our template hierarchy:
+
+```twig
+{# /vendor/bar/card-time-bundle/contao/templates/card.html.twig #}
+
+{% extends '@Contao/card' %}
+
+{% block footer %}
+  {{ parent() }}
+  <p class="last-modified">edited at {{ modified_at|ago }}</p>
+{% endblock %}
+```
+{{% /tab %}}
+
+{{% tab name="c) global template" %}}
+The `card` template of the global template folder adding some wrappers, 
+because, you know, you can't have enough *divs*.
+
+```twig
+{# /templates/card.html.twig #}
+
+{% extends '@Contao/card' %}
+
+{% block title %}<div class="inner">{{ parent() }}</div>{% endblock %}
+{% block card %}<div class="inner">{{ parent() }}</div>{% endblock %}
+```
+{{% /tab %}}
+
+{{% tab name="d) emoji theme" %}}
+And finally the application's `emoji` theme adding, well, …
+
+```twig
+{# /templates/emoji/card.html.twig #}
+   
+{% extends '@Contao/card' %}
+
+{% block title %}🤩 {{ parent() }} 🤯{% endblock %}
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Resolving all *extends* in the right order would effectively yield the
+following template - note how each stage can adjust/contribute to blocks
+without the need to know about the others because every *extend* uses the
+managed `@Contao` namespace:
+
+```twig
+{% import '@ContaoCore/Image/Studio/_macros.html.twig' as studio %}
+
+<section class="card">
+  <div class="inner">
+    <header class="title">
+      🤩 <div class="inner">{{ title }}</div> 🤯
+    </header>     
+    <main>
+      {{ studio.figure(figure) }}
+      {{ description|raw }}
+    </main>
+    <footer>
+     <p class="author">by {{ author }}</p>
+     <p class="last-modified">edited at {{ modified_at|ago }}</p>
+    </footer
+  </div>>
+</section>
+```
+
+{{% notice note %}}
+When extending, including or embedding templates from the `@Contao` namespace,
+the file extension is not considered. This means `@Contao/card.html.twig` will
+target the same template as `@Contao/card.html5`. For this reason you can omit
+the extension completely in that case. 
+{{% /notice %}}


### PR DESCRIPTION
The Twig manual based on #967 and some reviews form #914 (regarding #894).

| **Watch for status :** |
| :--- |
| [Allow providing Twig templates alongside PHP templates #3538](https://github.com/contao/contao/pull/3538) |
| [Asset Definition/Integration and Twig Template #3834 ](https://github.com/contao/contao/issues/3834) |
| ~~[Allow selecting Twig templates in every back end dropdown #3274 ](https://github.com/contao/contao/issues/3274) see [PR #4121](https://github.com/contao/contao/pull/4121)~~ |
| ~~[Using the dump() Twig function in prod produces an error #3853](https://github.com/contao/contao/issues/3853)~~ |
| ~~[Keep insert tags as chunked text and handle them in the HTML escaper #3606](https://github.com/contao/contao/pull/3606)~~ |
| ~~[Support nested template paths in Twig #3973](https://github.com/contao/contao/pull/3973)~~ |
| ~~[Add a HtmlAttributes class and Twig function #4203 (Milestone 5)](https://github.com/contao/contao/pull/4203)~~ |

Maybe the german Title translations for "Namespacing" and "Encoding/Escaping" are not helpful 
and we should adopt the English original?

Maybe the topic "Namespaces" is too much for the manual and we should just [link this](https://docs.contao.org/dev/framework/templates/twig/#namespace-magic) instead?
