### PR TITLE
Add missing closing tabs tag

### DIFF
--- a/docs/dev/framework/filesystem/virtual-filesystem.md
+++ b/docs/dev/framework/filesystem/virtual-filesystem.md
@@ -174,6 +174,8 @@ class FilesListController extends AbstractContentElementController
     }
 }
 ```
+{{% /tab %}}
+{{< /tabs >}}
 
 ```twig
 {# templates/ce_files_list.html.twig #}


### PR DESCRIPTION
Seems that went missing in the last commits for the filesystem documentation… :see_no_evil: 