### PR TITLE
Add guide to using Deployer

### DIFF
--- a/docs/manual/guides/deployer.de.md
+++ b/docs/manual/guides/deployer.de.md
@@ -138,7 +138,7 @@ task('encore:compile', function () {
 before('deploy', 'encore:compile');
 ```
 
-## Und nun: Deploy!
+## Und nun: Deployen!
 
 Nachdem wir alles konfiguriert haben, können wir jetzt `dep deploy` ausführen und das Projekt auf den Webserver
 deployen.
@@ -150,12 +150,12 @@ deployen.
 Du kannst bestehende Recipes verwenden oder eigene Recipes erstellen, wenn du Logik extrahieren und wiederverwenden
 möchtest. Hier sind einige Beispiele dafür:
 
-- https://github.com/nutshell-framework/deployer-recipes
+- https://github.com/nutshell-framework/deployer-recipes/
 - https://github.com/terminal42/deployer-recipes/
 
 ### Contao-Manager
 
-Du kannst mit einem speziellen Task den Contao-Manager auf dem Webserver installieren:
+Du kannst mit einem Task den Contao-Manager auf dem Webserver installieren:
 
 ```php
 // deploy.php
@@ -170,12 +170,12 @@ after('contao:manager:download', 'contao:manager:lock');
 ### Probleme mit dem Symlink und OPCache / APCu
 
 Weil Deployer einen Symlink für die Document-Root verwendet (siehe oben), kann es Probleme mit internen Caches wie z. B.
-OpCode Cache geben. [Mehr Infos.][6]
+OpCode Caching geben. [Mehr Infos.][6]
 
 Schaue zuerst, welche Caches auf deinem Webserver aktiviert sind. Öffne dafür die Symfony-Toolbar, wenn die Webseite im
 Debug-Modus ist. Die aktiven Caches findest du in der unteren rechten Ecke mit einem grünen Haken (✅).
 
-Für diese Caches kannst du das »Cachetool«-Recipe verwenden:
+Zum Leeren dieser Caches kannst du das »Cachetool«-Recipe verwenden:
 
 ```php
 // deploy.php
@@ -196,7 +196,7 @@ after('deploy:success', 'cachetool:clear:apcu');
 ### Fehlerhafte Deployments
 
 Deployer aktiviert ein Release nur dann, wenn es fehlerfrei durchgelaufen ist. Wenn ein Deployment nun fehlerhaft ist,
-kann es sein, dass Contao im Wartungsmodus festsetzt. So kannst du die Installation automatisch wieder »freischalten«:
+kann es sein, dass Contao im Wartungsmodus festsitzt. So kannst du die Installation automatisch wieder »freischalten«:
 
 ```php
 // deploy.php

--- a/docs/manual/guides/deployer.de.md
+++ b/docs/manual/guides/deployer.de.md
@@ -1,0 +1,213 @@
+---
+title: "Deployment mit Deployer"
+description: "Wie du dein Contao-Projekt mit Deployer deployen kannst."
+aliases:
+    - /de/anleitungen/deployer/
+weight: 80
+tags: 
+    - "Deployer"
+    - "Deployment"
+---
+
+{{% notice note %}}
+Diese Anleitung bezieht sich auf die Deployer-Version >=7.0 und Contao-Version >=4.13.
+{{% /notice %}}
+
+## Install Deployer
+
+Zuerst musst du Deployer installieren: [https://deployer.org/docs/][1]
+
+Du kannst Deployer entweder global oder per Projekt (mit Composer) installieren. Der Kommandozeilenbefehl lautet
+entsprechend `dep` or `./vendor/bin/dep`.
+
+Bevor du weitermachst, stelle sicher, dass du mindestens Version _7.0.0-rc.5_ installiert hast (`dep --version`).
+
+Jetzt kannst du deine `deploy.php`-Datei in dem Projekt erstellen:
+
+```bash
+touch deploy.php
+```
+
+## `deploy.php`-Datei schreiben
+
+Es gibt zwei Möglichkeiten, das Projekt auf dem Webserver zu installieren. Standardmäßig verwendet Deployer dafür das
+Git-Repository.
+
+### Option 1: Deployment mit Git
+
+Um loszulegen, erstelle die folgende `deploy.php` in deinem Projekt:
+
+```php
+// deploy.php
+
+namespace Deployer;
+
+import('recipe/contao.php');
+
+host('example.org')
+    ->set('remote_user', 'foobar')
+    ->set('deploy_path', '/var/www/{{remote_user}}/html/{{hostname}}')
+    ->set('bin/php', 'php8.1')
+    ->set('bin/composer', '{{bin/php}} /var/www/{{remote_user}}/composer.phar')
+;
+
+set('repository', 'git@github.com:acme/example.org.git');
+
+set('keep_releases', 10);
+
+after('deploy:failed', 'deploy:unlock');
+```
+
+Vergesse nicht, die Konfiguration des Hosts (siehe [Dokumentation][2]) und die URL des Git-Repositories anzupassen.
+
+Das Deployment mit Git hat allerdings einige Nachteile. Zum Einen, musst du deinen lokalen Arbeitsstand immer committed
+und gepusht haben. Außerdem, wenn Agent Forwarding nicht funktioniert, musst du deinem Webserver Zugriff auf das
+Git-Repository geben (entweder mittels HTTPS oder SSH). Deswegen ist es oft einfacher, die notwendigen Dateien mit
+`rsync` auf dem Webserver hochzuladen.
+
+### Option 2: Deployment mit `rsync`
+
+Um `rsync` an Stelle des Git-Checkouts zu verwenden, müssen wir den Task  `deploy:update_code` überschreiben:
+
+```php
+// deploy.php
+
+/* Bestehende Einstellungen von »Option 1« */
+
+// Dies brauchen wir nicht mehr
+//-set('repository', 'git@github.com:acme/example.org.git');
+
+desc('Upload project files');
+task('deploy:update_code', function () {
+    foreach([
+        'config',
+        'contao',
+        'public/layout',
+        'public/favicon.ico',
+        'src',
+        '.env',
+        'composer.json',
+        'composer.lock',
+    ] as $src) {
+        upload($src, '{{release_path}}/', ['options' => ['--recursive', '--relative']]);
+    }
+});
+```
+
+-----
+
+Zur Info: Anstatt jede Datei, die du auf dem Webserver brauchst, manuell zu konfigurieren, kannst du auch den
+eingebauten `rsync`-Task verwenden. Der `rsync`-Task impliziert eine _»Exclude«-Strategie_ statt einer
+_»Include«-Strategie_, was bedeutet, dass du die Dateien definierst, die _nicht_ hochgeladen werden sollen. Ein Beispiel
+für die Konfiguration findest du hier: [nutshell-framework/deployer-recipes][4]
+
+## Webserver einrichten
+
+Wie du aus der [Contao-Doku][5] weißt, musst du den Document-Root auf `/public` (bzw. `/web`) einstellen. Die Idee
+hinter Deployer ist, dass es keine Downtime bei Updates gibt. Deswegen werden rollierende Symlinks eingesetzt. Den
+Document-Root von deinem vHost musst du entsprechend auf `/current/public` (bzw. `/current/web`) einstellen. Ein
+komplettes Beispiel für einen Document-Root wäre: `/var/www/foobar/html/example.org/current/public`.
+
+Contao migriert langsam zum `/public`-Ordner als Web-Root. Wenn du in Contao 4.13 noch den `/web`-Ordner verwendest,
+dann definiere diesen entsprechend, damit Deployer das auch weiß.
+
+```json
+{
+  "extra": {
+    "public-dir": "web"
+  }
+}
+```
+
+## Projektspezifische Tasks
+
+Sehr oft gibt es spezifische Tasks für dein Projekt. Diese kannst du deinem Deployment ergänzen:
+
+```php
+// deploy.php
+
+/* Your existing config */
+
+// Task to build the assets, i.e., run `yarn run build` on the local machine
+desc('Build assets')
+task('encore:compile', function () {
+    runLocally('yarn run build');
+});
+
+// Define that the assets should be generated before the project is going to be deployed
+before('deploy', 'encore:compile');
+```
+
+## Und nun: Deploy!
+
+Nachdem wir alles konfiguriert haben, können wir jetzt `dep deploy` ausführen und das Projekt auf den Webserver
+deployen.
+
+## Tipps
+
+### Eigene »Recipes«
+
+Du kannst bestehende Recipes verwenden oder eigene Recipes erstellen, wenn du Logik extrahieren und wiederverwenden
+möchtest. Hier sind einige Beispiele dafür:
+
+- https://github.com/nutshell-framework/deployer-recipes
+- https://github.com/terminal42/deployer-recipes/
+
+### Contao-Manager
+
+Du kannst mit einem speziellen Task den Contao-Manager auf dem Webserver installieren:
+
+```php
+// deploy.php
+
+/* Your existing deploy.php */
+
+before('deploy:publish', 'contao:manager:download');
+// Optionally lock the Contao Manager if you don't use the UI
+after('contao:manager:download', 'contao:manager:lock');
+```
+
+### Probleme mit dem Symlink und OPCache / APCu
+
+Weil Deployer einen Symlink für die Document-Root verwendet (siehe oben), kann es Probleme mit internen Caches wie z. B.
+OpCode Cache geben. [Mehr Infos.][6]
+
+Schaue zuerst, welche Caches auf deinem Webserver aktiviert sind. Öffne dafür die Symfony-Toolbar, wenn die Webseite im
+Debug-Modus ist. Die aktiven Caches findest du in der unteren rechten Ecke mit einem grünen Haken (✅).
+
+Für diese Caches kannst du das »Cachetool«-Recipe verwenden:
+
+```php
+// deploy.php
+
+// Add this recipe
+require 'contrib/cachetool.php';
+
+host('www.example.com')
+    // Add this option, change {{hostname}} to the actual URL when the hostname does not match the URL.
+    ->set('cachetool_args', '--web=SymfonyHttpClient --web-path=./{{public_path}} --web-url=https://{{hostname}}')
+;
+
+after('deploy:success', 'cachetool:clear:opcache');
+// bzw.
+after('deploy:success', 'cachetool:clear:apcu');
+```
+
+### Fehlerhafte Deployments
+
+Deployer aktiviert ein Release nur dann, wenn es fehlerfrei durchgelaufen ist. Wenn ein Deployment nun fehlerhaft ist,
+kann es sein, dass Contao im Wartungsmodus festsetzt. So kannst du die Installation automatisch wieder »freischalten«:
+
+```php
+// deploy.php
+
+after('deploy:failed', 'deploy:unlock');
+after('deploy:failed', 'contao:maintenance:disable');
+```
+
+[1]: https://deployer.org/docs/7.x/installation
+[2]: https://deployer.org/docs/7.x/hosts
+[3]: https://github.com/terminal42/deployer-recipes
+[4]: https://github.com/nutshell-framework/deployer-recipes/blob/main/recipe/contao-rsync.php
+[5]: /de/installation/systemvoraussetzungen/#hosting-konfiguration
+[6]: https://ma.ttias.be/php-opcache-and-symlink-based-deploys

--- a/docs/manual/guides/deployer.de.md
+++ b/docs/manual/guides/deployer.de.md
@@ -13,12 +13,13 @@ tags:
 Diese Anleitung bezieht sich auf die Deployer-Version >=7.0 und Contao-Version >=4.13.
 {{% /notice %}}
 
+
 ## Install Deployer
 
 Zuerst musst du Deployer installieren: [https://deployer.org/docs/][1]
 
 Du kannst Deployer entweder global oder per Projekt (mit Composer) installieren. Der Kommandozeilenbefehl lautet
-entsprechend `dep` or `./vendor/bin/dep`.
+entsprechend `dep` oder `./vendor/bin/dep`.
 
 Bevor du weitermachst, stelle sicher, dass du mindestens Version _7.0.0-rc.5_ installiert hast (`dep --version`).
 
@@ -28,10 +29,12 @@ Jetzt kannst du deine `deploy.php`-Datei in dem Projekt erstellen:
 touch deploy.php
 ```
 
+
 ## `deploy.php`-Datei schreiben
 
 Es gibt zwei Möglichkeiten, das Projekt auf dem Webserver zu installieren. Standardmäßig verwendet Deployer dafür das
 Git-Repository.
+
 
 ### Option 1: Deployment mit Git
 
@@ -63,11 +66,12 @@ Vergesse nicht, die Konfiguration des Hosts (siehe [Dokumentation][2]) und die U
 Das Deployment mit Git hat allerdings einige Nachteile. Zum Einen, musst du deinen lokalen Arbeitsstand immer committed
 und gepusht haben. Außerdem, wenn Agent Forwarding nicht funktioniert, musst du deinem Webserver Zugriff auf das
 Git-Repository geben (entweder mittels HTTPS oder SSH). Deswegen ist es oft einfacher, die notwendigen Dateien mit
-`rsync` auf dem Webserver hochzuladen.
+`rsync` auf den Webserver hochzuladen.
+
 
 ### Option 2: Deployment mit `rsync`
 
-Um `rsync` an Stelle des Git-Checkouts zu verwenden, müssen wir den Task  `deploy:update_code` überschreiben:
+Um `rsync` anstelle des Git-Checkouts zu verwenden, müssen wir den Task  `deploy:update_code` überschreiben:
 
 ```php
 // deploy.php
@@ -101,6 +105,7 @@ eingebauten `rsync`-Task verwenden. Der `rsync`-Task impliziert eine _»Exclude�
 _»Include«-Strategie_, was bedeutet, dass du die Dateien definierst, die _nicht_ hochgeladen werden sollen. Ein Beispiel
 für die Konfiguration findest du hier: [nutshell-framework/deployer-recipes][4]
 
+
 ## Webserver einrichten
 
 Wie du aus der [Contao-Doku][5] weißt, musst du den Document-Root auf `/public` (bzw. `/web`) einstellen. Die Idee
@@ -119,9 +124,10 @@ dann definiere diesen entsprechend, damit Deployer das auch weiß.
 }
 ```
 
+
 ## Projektspezifische Tasks
 
-Sehr oft gibt es spezifische Tasks für dein Projekt. Diese kannst du deinem Deployment ergänzen:
+Sehr oft gibt es spezifische Tasks für dein Projekt. Diese kannst du in deinem Deployment ergänzen:
 
 ```php
 // deploy.php
@@ -138,10 +144,12 @@ task('encore:compile', function () {
 before('deploy', 'encore:compile');
 ```
 
+
 ## Und nun: Deploy!
 
 Nachdem wir alles konfiguriert haben, können wir jetzt `dep deploy` ausführen und das Projekt auf den Webserver
 deployen.
+
 
 ## Tipps
 
@@ -152,6 +160,7 @@ möchtest. Hier sind einige Beispiele dafür:
 
 - https://github.com/nutshell-framework/deployer-recipes
 - https://github.com/terminal42/deployer-recipes/
+
 
 ### Contao-Manager
 
@@ -167,12 +176,13 @@ before('deploy:publish', 'contao:manager:download');
 after('contao:manager:download', 'contao:manager:lock');
 ```
 
+
 ### Probleme mit dem Symlink und OPCache / APCu
 
 Weil Deployer einen Symlink für die Document-Root verwendet (siehe oben), kann es Probleme mit internen Caches wie z. B.
 OpCode Cache geben. [Mehr Infos.][6]
 
-Schaue zuerst, welche Caches auf deinem Webserver aktiviert sind. Öffne dafür die Symfony-Toolbar, wenn die Webseite im
+Schaue zuerst, welche Caches auf deinem Webserver aktiviert sind. Öffne dafür die Symfony-Toolbar, wenn die Website im
 Debug-Modus ist. Die aktiven Caches findest du in der unteren rechten Ecke mit einem grünen Haken (✅).
 
 Für diese Caches kannst du das »Cachetool«-Recipe verwenden:
@@ -192,6 +202,7 @@ after('deploy:success', 'cachetool:clear:opcache');
 // bzw.
 after('deploy:success', 'cachetool:clear:apcu');
 ```
+
 
 ### Fehlerhafte Deployments
 

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -59,7 +59,7 @@ after('deploy:failed', 'deploy:unlock');
 Make sure to adjust the host configuration (see the [Documentation][2]) and repository URL as required.
 
 The deployment with Git repo has some downsides, though. First, you always need to have your local files committed and
-pushed. Second, in case your SSH clients do not support agent forwarding, your remote site needs to have read-access on
+pushed. Second, in case your SSH environments do not support agent forwarding, your remote site needs to have read-access on
 Git repository, which requires storing the HTTPS credentials or configuring SSH. Therefore, another favored approach is
 to use `rsync` instead of Git to deploy the project.
 

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -167,11 +167,39 @@ add('exclude', [
 ]);
 ```
 
-**Pro tip:** You can create your own set of re-usable Deployer recipes, and when doing so, you can move the 
-`contao-rsync.php` respectively. The [terminal42/deployer-recipes][3] repository is an excellent example of how to
-create re-usable recipes for your Contao projects.
+{{% /expand %}}
 
-### Provision web server
+### Option 3: Deploy with rsync but with using an "include" pattern
+
+In the rsync deployment described above we were using "exclude" to upload _everything_ expect some environment-specific
+files. There are some advocates, however, to defining only the actual files that you need upload.
+
+Then we make the following changes to the project’s `deploy.php`:
+
+{{% expand "deploy.php recipe" %}}
+
+```php
+<?php
+
+// deploy.php
+
+/* Your existing config from "Option 1" */
+
+// Not needed anymore
+//-set('repository', 'git@github.com:acme/example.org.git');
+
+desc('Upload project files');
+task('deploy:update_code', function () {
+    upload("config/config.yml", "{{release_or_current_path}}/config/");
+    upload("config/services.yml", "{{release_or_current_path}}/config/");
+    upload("src/", "{{release_or_current_path}}/");
+    upload("templates/", "{{release_or_current_path}}/");
+});
+```
+
+{{% /expand %}}
+
+## Provision web server
 
 As you know [from the Contao documentation]([4]), you have to set the document root of the server to `/public` (or
 `/web` in older versions) of the project. The idea of Deployer is to provide updates without downtime, and to realize

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -35,8 +35,7 @@ check out the Git repository with the current project on the remote server.
 To get started with Deployer, use the following file contents for the `deploy.php` in your project root:
 
 ```php
-<?php // /deploy.php
-
+// deploy.php
 namespace Deployer;
 
 import('recipe/contao.php');

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -201,6 +201,8 @@ deployment (to allow follow-up deployments) automatically and disable the Contao
 deployments:
 
 ```php
+// deploy.php
+
 after('deploy:failed', 'deploy:unlock');
 after('deploy:failed', 'contao:maintenance:disable');
 ```

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -11,6 +11,7 @@ tags:
 
 {{% notice note %}}
 The Deployer recipe is part of Deployer 7 and is intended to work for Contao 4.13 and higher.
+{{% /notice %}}
 
 ## Install Deployer
 

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -59,9 +59,9 @@ after('deploy:failed', 'deploy:unlock');
 Make sure to adjust the host configuration (see the [Documentation][2]) and repository URL as required.
 
 The deployment with Git repo has some downsides, though. First, you always need to have your local files committed and
-pushed. Second, your remote site needs to have read-access on Git repository, which requires storing the HTTPS
-credentials or configuring SSH. Therefore, another favored approach is to use `rsync` instead of Git to deploy the
-project.
+pushed. Second, in case your SSH clients do not support agent forwarding, your remote site needs to have read-access on
+Git repository, which requires storing the HTTPS credentials or configuring SSH. Therefore, another favored approach is
+to use `rsync` instead of Git to deploy the project.
 
 ### Option 2: Deploy with rsync
 

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -70,6 +70,8 @@ To use `rsync` instead of a Git checkout, we need to use the rsync recipe and ad
 
 First we create a new recipe solely for the rsync functionality:
 
+{{% expand "deploy-rsync.php recipe" %}}
+
 ```bash
 touch deploy-rsync.php
 ```
@@ -133,15 +135,25 @@ task('deploy:update_code', function () {
 });
 ```
 
+**Pro tip:** You can create your own set of re-usable Deployer recipes, and when doing so, you can move the
+`contao-rsync.php` respectively. The [terminal42/deployer-recipes][3] repository is an excellent example of how to
+create re-usable recipes for your Contao projects.
+
+{{% /expand %}}
+
 Then we make the following changes to the project’s `deploy.php`:
 
+{{% expand "deploy.php recipe" %}}
+
 ```php
-<?php // /deploy.php
+<?php 
+
+// deploy.php
 
 // Add this recipe, do not remove the contao.php recipe
-require __DIR__.'/deploy-rsync.php';
+import(__DIR__.'/deploy-rsync.php');
 
-/* Your existing config */
+/* Your existing config from "Option 1" */
 
 // Not needed anymore
 //-set('repository', 'git@github.com:acme/example.org.git');
@@ -167,10 +179,8 @@ this, Deployer utilizes rolling symlink releases. Consequently, you have to set 
 `/current/public` (or `/current/web` respectively). A full example for the document root might look like 
 `/var/www/foobar/html/example.org/current/public`.
 
----
-
-Contao is slowly migrating to use the “public” folder of the project as the document root. When your Contao 4.13
-installation is still using the folder “web” as public directory, please explicitly set it in the `composer.json`
+Contao is slowly migrating to use the `/public` folder of the project as the document root. When your Contao 4.13
+installation is still using the folder `/web` as public directory, please explicitly set it in the `composer.json`
 of the project:
 
 ```json
@@ -181,17 +191,15 @@ of the project:
 }
 ```
 
-### Finally: Deploy
-
-You are now all set to run `dep deploy`.
-
 ## Add build-task to deployment
 
 Often you have some additional build tasks tailored to your project. You can quickly add those tasks to the deployment
 process:
 
 ```php
-<?php // /deploy.php
+<?php
+
+// deploy.php
 
 /* Your existing config */
 
@@ -203,23 +211,23 @@ task('encore:compile', function () {
 
 // Define that the assets should be generated before the project is going to be deployed
 before('deploy', 'encore:compile');
-
-// When using rsync, we do not want to upload those files
-add('exclude', [
-    'package.json',
-    'package-lock.json',
-    'yarn.lock',
-    '/node_modules',
-]);
 ```
+
+## Finally: Deploy
+
+You are now all set to run `dep deploy`.
 
 ## Tips
 
 ### Custom recipes
 
-terminal42 provides some additional recipes under [terminal42/deployer-recipes/][3]. You can use one or many recipes in
-your project, and you are free to extract logic for your projects into own recipes as well (as described above for the
-rsync recipe).
+You can use one or many recipes in your project, and you are free to extract logic for your projects into own recipes as
+well (as described above for the rsync recipe).
+
+Here is a collection of Deployer recipes that you might give you an inspiration:
+
+- https://github.com/nutshell-framework/deployer-recipes
+- https://github.com/terminal42/deployer-recipes/
 
 ### Contao Manager
 

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -68,8 +68,6 @@ project.
 To use `rsync` instead of a Git checkout, we need to override the `deploy:update_code` task:
 
 ```php
-<?php
-
 // deploy.php
 
 /* Your existing config from "Option 1" */
@@ -126,8 +124,6 @@ Often you have some additional build tasks tailored to your project. You can qui
 process:
 
 ```php
-<?php
-
 // deploy.php
 
 /* Your existing config */
@@ -162,7 +158,7 @@ recipes):
 You can also provide a task to download the Contao Manager on each deploy:
 
 ```php
-<?php
+// deploy.php
 
 /* Your existing deploy.php */
 
@@ -182,7 +178,7 @@ To check what caches are in place, you can check the Symfony toolbar (lower righ
 For the caches being in place, this is an example to clear the caches:
 
 ```php
-<?php
+// deploy.php
 
 // Add this recipe
 require 'contrib/cachetool.php';

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -1,0 +1,278 @@
+---
+title: "Deploy with Deployer"
+description: "Learn how to deploy your project with Deployer."
+aliases:
+    - /en/guides/deployer/
+weight: 80
+tags: 
+    - "Deployer"
+    - "Deployment"
+---
+
+{{% notice note %}}
+The Deployer recipe is part of Deployer 7 and is intended to work for Contao 4.13 and greater.
+
+## Install Deployer
+
+If not done yet, install Deployer as described here: [https://deployer.org/docs/][1]
+
+Verify that you are running Deployer in the minimum version _7.0.0-rc.5_ by running `dep --version`.
+
+Once done, you can create a `deploy.php` file in your project:
+
+```bash
+touch deploy.php
+```
+
+## Write deploy.php file
+
+There are two ways to deploy your project to the remote site. The default approach to deploy files in Deployer is to
+check out the Git repository with the current project on the remote server.
+
+### Option 1: Deploy with Repository
+
+To get started with Deployer, use the following file contents for the `deploy.php` in your project root:
+
+```php
+<?php // /deploy.php
+
+namespace Deployer;
+
+import('recipe/contao.php');
+
+host('example.org')
+    ->set('remote_user', 'foobar')
+    ->set('deploy_path', '/var/www/{{remote_user}}/html/{{hostname}}')
+    ->set('bin/php', 'php8.1')
+    ->set('bin/composer', '{{bin/php}} /var/www/{{remote_user}}/composer.phar')
+;
+
+set('repository', 'git@github.com:acme/example.org.git');
+
+set('keep_releases', 10);
+
+after('deploy:failed', 'deploy:unlock');
+```
+
+Make sure to adjust the host configuration ([Documentation][2]) and repository URL as required.
+
+The deployment with Git repo has some downsides, though. First, you always need to have your local files committed
+and pushed. Second, your remote site needs to have read-access on Git repository, which requires storing the HTTPS
+credentials or configuring SSH. Therefore, another favored approach is to use `rsync` instead of Git to deploy the
+project.
+
+### Option 2: Deploy with rsync
+
+To use `rsync` instead of a Git checkout, we need to use the rsync recipe and add further configuration to the
+`deploy.php` file.
+
+First we create a new recipe solely for the rsync functionality:
+
+```bash
+touch deploy-rsync.php
+```
+
+```php
+<?php // /deploy-rsync.php
+
+namespace Deployer;
+
+import('contrib/rsync.php');
+
+set('rsync_dest','{{release_path}}');
+
+// The files in your Contao installation that should not be uploaded
+set('exclude', [
+    '.git',
+    '/.github',
+    '/.idea',
+    '/deploy.php',
+    '/.env.local',
+    '/.gitignore',
+    '/config/parameters.yml',
+    '/contao-manager',
+    '/tests',
+    '/var',
+    '/vendor',
+    '/app/Resources/contao/config/runonce*',
+    '/assets',
+    '/files',
+    '/system',
+    '/{{public_path}}/bundles',
+    '/{{public_path}}/assets',
+    '/{{public_path}}/files',
+    '/{{public_path}}/share',
+    '/{{public_path}}/system',
+    '/{{public_path}}/app.php',
+    '/{{public_path}}/app_dev.php',
+    '/{{public_path}}/index.php',
+    '/{{public_path}}/preview.php',
+    '/{{public_path}}/robots.txt',
+]);
+
+set('rsync', function () {
+    return [
+        'exclude' => array_unique(get('exclude', [])),
+        'exclude-file' => false,
+        'include' => [],
+        'include-file' => false,
+        'filter' => [],
+        'filter-file' => false,
+        'filter-perdir' => false,
+        'flags' => 'rz',
+        'options' => ['delete'],
+        'timeout' => 300,
+    ];
+});
+
+desc('Use rsync task to pull project files');
+task('deploy:update_code', function () {
+    invoke('rsync');
+});
+```
+
+Then we make the following changes to the project’s `deploy.php`:
+
+```php
+<?php // /deploy.php
+
+// Add this recipe, do not remove the contao.php recipe
+require __DIR__.'/deploy-rsync.php';
+
+/* Your existing config */
+
+// Not needed anymore
+//-set('repository', 'git@github.com:acme/example.org.git');
+
+// Set current dir (project root)
+set('rsync_src', __DIR__);
+
+// Project-specific files and folders that shall not be uploaded on deployment
+add('exclude', [
+   '/README.md',
+]);
+```
+
+**Pro tip:** You can create your own set of re-usable Deployer recipes, and when doing so, you can move the 
+`contao-rsync.php` respectively. The [terminal42/deployer-recipes][3] repository is an excellent example of how to
+create re-usable recipes for your Contao projects.
+
+### Provision web server
+
+As you know [from the Contao documentation]([4]), you have to set the document root of the server to `/public` (or
+`/web` in older versions) of the project. The idea of Deployer is to provide updates without downtime, and to realize
+this, Deployer utilizes rolling symlink releases. Consequently, you have to set the document root of your vHost to 
+`/current/public` (or `/current/web` respectively). A full example for the document root might look like 
+`/var/www/foobar/html/example.org/current/public`.
+
+---
+
+Contao is slowly migrating to use the “public” folder of the project as the document root. When your Contao 4.13
+installation is still using the folder “web” as public directory, please explicitly set it in the `composer.json`
+of the project:
+
+```json
+{
+  "extra": {
+    "public-dir": "web"
+  }
+}
+```
+
+### Finally: Deploy
+
+You are now all set to run `dep deploy`.
+
+## Add build-task to deployment
+
+Often you have some additional build tasks tailored to your project. You can quickly add those tasks to the deployment
+process:
+
+```php
+<?php // /deploy.php
+
+/* Your existing config */
+
+// Task to build the assets, i.e., run `yarn run build` on the local machine
+desc('Build assets')
+task('encore:compile', function () {
+    runLocally('yarn run build');
+});
+
+// Define that the assets should be generated before the project is going to be deployed
+before('deploy', 'encore:compile');
+
+// When using rsync, we do not want to upload those files
+add('exclude', [
+    'package.json',
+    'package-lock.json',
+    'yarn.lock',
+    '/node_modules',
+]);
+```
+
+## Tips
+
+### Custom recipes
+
+terminal42 provides some additional recipes under [terminal42/deployer-recipes/][3]. You can use one or many recipes in
+your project, and you are free to extract logic for your projects into own recipes as well (as described above for the
+rsync recipe).
+
+### Contao Manager
+
+You can also provide a task to download the Contao Manager on each deploy:
+
+```php
+<?php
+
+/* Your existing deploy.php */
+
+before('deploy:publish', 'contao:manager:download');
+// Optionally lock the Contao Manager if you don't use the UI
+after('contao:manager:download', 'contao:manager:lock');
+```
+
+### Symlink issues with OPCache / APCu
+
+As Deployer is using a symlink for the document root (as read above), issues might occur with internal caches like the
+OPCode Caching. [Read more here.][5]
+
+To check what caches are in place, you can check the Symfony toolbar (lower right corner) which should show a green tick
+(✅) for OPCache.
+
+For the caches being in place, this is an example to clear the caches:
+
+```php
+<?php
+
+// Add this recipe
+require 'contrib/cachetool.php';
+
+host('www.example.com')
+	  // Add this option, change {{hostname}} to the actual URL when the hostname does not match the URL.
+    ->set('cachetool_args', '--web=SymfonyHttpClient --web-path=./{{public_path}} --web-url=https://{{hostname}}')
+;
+
+after('deploy:success', 'cachetool:clear:opcache');
+// or
+after('deploy:success', 'cachetool:clear:apcu');
+```
+
+### Handle failed deployments
+
+Deployer only activates the new build when the deployment is without errors. However, when a deployment fails, you might
+find your deployment in a locked state and the Contao installation in maintenance mode. Therefore, feel free to unlock
+the deployment (to allow follow-up deployments) automatically and disable the Contao maintenance mode after failed 
+deployments:
+
+```php
+after('deploy:failed', 'deploy:unlock');
+after('deploy:failed', 'contao:maintenance:disable');
+```
+
+[1]: https://deployer.org/docs/7.x/getting-started
+[2]: https://deployer.org/docs/7.x/hosts
+[3]: https://github.com/terminal42/deployer-recipes
+[4]: /en/installation/system-requirements/#hosting-configuration
+[5]: https://ma.ttias.be/php-opcache-and-symlink-based-deploys

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -58,8 +58,8 @@ after('deploy:failed', 'deploy:unlock');
 
 Make sure to adjust the host configuration (see the [Documentation][2]) and repository URL as required.
 
-The deployment with Git repo has some downsides, though. First, you always need to have your local files committed
-and pushed. Second, your remote site needs to have read-access on Git repository, which requires storing the HTTPS
+The deployment with Git repo has some downsides, though. First, you always need to have your local files committed and
+pushed. Second, your remote site needs to have read-access on Git repository, which requires storing the HTTPS
 credentials or configuring SSH. Therefore, another favored approach is to use `rsync` instead of Git to deploy the
 project.
 
@@ -102,8 +102,8 @@ task. The `rsync` task implies an _exclude strategy_ rather than an _include str
 
 As you know [from the Contao documentation][5], you have to set the document root of the server to `/public` (or
 `/web` in older versions) of the project. The idea of Deployer is to provide updates without downtime, and to realize
-this, Deployer utilizes rolling symlink releases. Consequently, you have to set the document root of your vHost to 
-`/current/public` (or `/current/web` respectively). A full example for the document root might look like 
+this, Deployer utilizes rolling symlink releases. Consequently, you have to set the document root of your vHost to
+`/current/public` (or `/current/web` respectively). A full example for the document root might look like
 `/var/www/foobar/html/example.org/current/public`.
 
 Contao is slowly migrating to use the `/public` folder of the project as the document root. When your Contao 4.13
@@ -196,8 +196,8 @@ after('deploy:success', 'cachetool:clear:apcu');
 ### Handle failed deployments
 
 Deployer only activates the new build when the deployment is without errors. However, when a deployment fails, you might
-find your deployment in a locked state and the Contao installation in maintenance mode. Therefore, feel free to unlock
-the deployment (to allow follow-up deployments) automatically and disable the Contao maintenance mode after failed 
+find your deployment in a locked state and the Contao installation in maintenance mode. Therefore, you can unlock the
+deployment (to allow follow-up deployments) automatically and disable the Contao maintenance mode after failed
 deployments:
 
 ```php

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 {{% notice note %}}
-The Deployer recipe is part of Deployer 7 and is intended to work for Contao 4.13 and greater.
+The Deployer recipe is part of Deployer 7 and is intended to work for Contao 4.13 and higher.
 
 ## Install Deployer
 

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -94,13 +94,13 @@ task('deploy:update_code', function () {
 
 -----
 
-For the sake of completeness, instead of defining every(!) file in `upload()`, you can also use the `rsync` task. The
-`rsync` task implies an _exclude strategy_ rather than an _include strategy_. You can find an example and the
-`contao-rsync.php` recipe here: [nutshell-framework/deployer-recipes][6]
+For the sake of completeness, instead of defining every(!) file and folder in `upload()`, you can also use the `rsync`
+task. The `rsync` task implies an _exclude strategy_ rather than an _include strategy_. You can find an example and the
+`contao-rsync.php` recipe here: [nutshell-framework/deployer-recipes][4]
 
 ## Provision web server
 
-As you know [from the Contao documentation]([4]), you have to set the document root of the server to `/public` (or
+As you know [from the Contao documentation][5], you have to set the document root of the server to `/public` (or
 `/web` in older versions) of the project. The idea of Deployer is to provide updates without downtime, and to realize
 this, Deployer utilizes rolling symlink releases. Consequently, you have to set the document root of your vHost to 
 `/current/public` (or `/current/web` respectively). A full example for the document root might look like 
@@ -170,7 +170,7 @@ after('contao:manager:download', 'contao:manager:lock');
 ### Symlink issues with OPCache / APCu
 
 As Deployer is using a symlink for the document root (as read above), issues might occur with internal caches like the
-OPCode Caching. [Read more here.][5]
+OPCode Caching. [Read more here.][6]
 
 To check what caches are in place, you can check the Symfony toolbar (lower right corner) which should show a green tick
 (✅) for OPCache.
@@ -208,6 +208,6 @@ after('deploy:failed', 'contao:maintenance:disable');
 [1]: https://deployer.org/docs/7.x/installation
 [2]: https://deployer.org/docs/7.x/hosts
 [3]: https://github.com/terminal42/deployer-recipes
-[4]: /en/installation/system-requirements/#hosting-configuration
-[5]: https://ma.ttias.be/php-opcache-and-symlink-based-deploys
-[6]: https://github.com/nutshell-framework/deployer-recipes
+[4]: https://github.com/nutshell-framework/deployer-recipes/blob/main/recipe/contao-rsync.php
+[5]: /en/installation/system-requirements/#hosting-configuration
+[6]: https://ma.ttias.be/php-opcache-and-symlink-based-deploys

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -271,7 +271,7 @@ after('deploy:failed', 'deploy:unlock');
 after('deploy:failed', 'contao:maintenance:disable');
 ```
 
-[1]: https://deployer.org/docs/7.x/getting-started
+[1]: https://deployer.org/docs/7.x/installation
 [2]: https://deployer.org/docs/7.x/hosts
 [3]: https://github.com/terminal42/deployer-recipes
 [4]: /en/installation/system-requirements/#hosting-configuration

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -17,6 +17,8 @@ The Deployer recipe is part of Deployer 7 and is intended to work for Contao 4.1
 
 If not done yet, install Deployer as described here: [https://deployer.org/docs/][1]
 
+You can either install Deployer globally or per project and use the command `dep` or `./vendor/bin/dep` respectively.
+
 Verify that you are running Deployer in the minimum version _7.0.0-rc.5_ by running `dep --version`.
 
 Once done, you can create a `deploy.php` file in your project:

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -38,6 +38,7 @@ To get started with Deployer, use the following file contents for the `deploy.ph
 
 ```php
 // deploy.php
+
 namespace Deployer;
 
 import('recipe/contao.php');
@@ -59,9 +60,9 @@ after('deploy:failed', 'deploy:unlock');
 Make sure to adjust the host configuration (see the [Documentation][2]) and repository URL as required.
 
 The deployment with Git repo has some downsides, though. First, you always need to have your local files committed and
-pushed. Second, in case your SSH environments do not support agent forwarding, your remote site needs to have read-access on
-Git repository, which requires storing the HTTPS credentials or configuring SSH. Therefore, another favored approach is
-to use `rsync` instead of Git to deploy the project.
+pushed. Second, in case your SSH environments do not support agent forwarding, your remote site needs to have
+read-access on the Git repository, which requires storing the HTTPS credentials or configuring SSH. Therefore, another
+favored approach is to use `rsync` instead of Git to deploy the project.
 
 ### Option 2: Deploy with rsync
 


### PR DESCRIPTION
My Contao recipe for Deployer was merged in deployphp/deployer#2851. So now it is super easy to deploy a Contao project using Deployer and we should tell folks how to do so.

Merge only after Deployer 7.0.0-rc.5 was released! Enough time to proofread this PR.