### PR TITLE
Add information about nonce value to replaceDynamicScriptTags hook

### DIFF
--- a/docs/dev/reference/hooks/replaceDynamicScriptTags.md
+++ b/docs/dev/reference/hooks/replaceDynamicScriptTags.md
@@ -46,6 +46,7 @@ A string containing the (modified) bufffer content.
 // src/EventListener/ReplaceDynamicScriptTagsListener.php
 namespace App\EventListener;
 
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 
 /**

--- a/docs/dev/reference/hooks/replaceDynamicScriptTags.md
+++ b/docs/dev/reference/hooks/replaceDynamicScriptTags.md
@@ -22,7 +22,9 @@ JavaScript & CSS files etc. for the current page.
 The hook allows you to replace these script tags yourself, or execute other custom
 code before the replacement.
 
-{{% notice info %}} Since Contao 4.13 a nonce value is added to the tag names resulting in tag names like `[[TL_CSS_686b97e15f9e04213c87e53db3d7a8bd]]`. The nonce value value can be retrived from `ContaoFramework::getNonce()`. {{% /notice %}}
+{{% notice info %}}
+Since Contao 4.13 a nonce value is added to the tag names resulting in tag names like `[[TL_CSS_686b97e15f9e04213c87e53db3d7a8bd]]`. The nonce value value can be retrieved from `ContaoFramework::getNonce()`.
+{{% /notice %}}
 
 
 ## Parameters

--- a/docs/dev/reference/hooks/replaceDynamicScriptTags.md
+++ b/docs/dev/reference/hooks/replaceDynamicScriptTags.md
@@ -22,6 +22,8 @@ JavaScript & CSS files etc. for the current page.
 The hook allows you to replace these script tags yourself, or execute other custom
 code before the replacement.
 
+{{% notice info %}} Since Contao 4.13 a nonce value is added to the tag names resulting in tag names like `[[TL_CSS_686b97e15f9e04213c87e53db3d7a8bd]]`. The nonce value value can be retrived from `ContaoFramework::getNonce()`. {{% /notice %}}
+
 
 ## Parameters
 
@@ -51,9 +53,11 @@ class ReplaceDynamicScriptTagsListener
 {
     public function __invoke(string $buffer): string
     {
-        // Modify $buffer here …
-
-        return $buffer;
+        $nonce = '';
+        if (method_exists(ContaoFramework::class, 'getNonce')) {
+            $nonce = '_'.ContaoFramework::getNonce();
+        }
+        return str_replace("[[TL_CSS$nonce]]", "[[TL_CSS$nonce]]".'<link rel="stylesheet" href="assets/custom.css">', $buffer);
     }
 }
 ```

--- a/docs/dev/reference/hooks/replaceDynamicScriptTags.md
+++ b/docs/dev/reference/hooks/replaceDynamicScriptTags.md
@@ -56,9 +56,11 @@ class ReplaceDynamicScriptTagsListener
     public function __invoke(string $buffer): string
     {
         $nonce = '';
+
         if (method_exists(ContaoFramework::class, 'getNonce')) {
             $nonce = '_'.ContaoFramework::getNonce();
         }
+
         return str_replace("[[TL_CSS$nonce]]", "[[TL_CSS$nonce]]".'<link rel="stylesheet" href="assets/custom.css">', $buffer);
     }
 }


### PR DESCRIPTION
This PR add information about the introduction of the nonce value to the script tags in contao 4.13. It also updates the example with code where the nonce value is used, if supported.