### PR TITLE
Make the access key documentation browser-aware

### DIFF
--- a/docs/manual/administration-area/back-end-keyboard-shortcuts.de.md
+++ b/docs/manual/administration-area/back-end-keyboard-shortcuts.de.md
@@ -16,62 +16,57 @@ nach unten gescrollt wurde.
 Normalerweise ist das kein Problem, denn während des Ausfüllen eines Formulars arbeitet man sich ja sowieso von oben
 nach unten durch die Seite. Will man aber später nur einen einzelnen Wert am Anfang des Formulars ändern, ist die
 Schaltfläche nicht ohne Scrollaufwand erreichbar. In diesem Fall gelangt der geübte Contao-Benutzer mit dem
-Tastaturkürzel `[Alt]+[S]` auch ohne zu scrollen ans Ziel.
+Tastaturkürzel {{< accesskey "s" >}} auch ohne zu scrollen ans Ziel.
 
 
 ## Allgemeine Tastaturkürzel {#allgemeine-tastaturkuerzel}
 
 Folgende Tastaturkürzel stehen in Contao zur Verfügung:
 
-| Tastaturkürzel    | Schaltfläche            | Erklärung                                                                           |
-|:------------------|:------------------------|:------------------------------------------------------------------------------------|
-| `[Alt]+[h]`       | Startseite              | Führt zur Startseite des Backend (**H**ome).                                        |
-| `[Alt]+[q]`       | Abmelden                | Beendet die aktuelle Backend-Sitzung (**Q**uit).                                    |
-| `[Alt]+[t]`       | Nach oben               | Springt zum Anfang der Seite (**T**op).                                             |
-| `[Alt]+[b]`       | Zurück                  | Zurück zur vorherigen Seite (**B**ack).                                             |
-| `[Alt]+[n]`       | Neuer Datensatz         | Legt einen neuen Datensatz an (**N**ew).                                            |
-| `[Alt]+[e]`       | Mehrere bearbeiten      | Wechselt in den »mehrere bearbeiten«-Modus (**E**dit multiple).                     |
-| `[Alt]+[f]`       | Frontend-Vorschau       | Öffnet die Frontend-Vorschau in einem neuen Fenster (**F**ront end preview).        |
+| Tastaturkürzel        | Schaltfläche            | Erklärung                                                                           |
+|:----------------------|:------------------------|:------------------------------------------------------------------------------------|
+| {{< accesskey "h" >}} | Startseite              | Führt zur Startseite des Backend (**H**ome).                                        |
+| {{< accesskey "q" >}} | Abmelden                | Beendet die aktuelle Backend-Sitzung (**Q**uit).                                    |
+| {{< accesskey "t" >}} | Nach oben               | Springt zum Anfang der Seite (**T**op).                                             |
+| {{< accesskey "b" >}} | Zurück                  | Zurück zur vorherigen Seite (**B**ack).                                             |
+| {{< accesskey "n" >}} | Neuer Datensatz         | Legt einen neuen Datensatz an (**N**ew).                                            |
+| {{< accesskey "e" >}} | Mehrere bearbeiten      | Wechselt in den »mehrere bearbeiten«-Modus (**E**dit multiple).                     |
+| {{< accesskey "f" >}} | Frontend-Vorschau       | Öffnet die Frontend-Vorschau in einem neuen Fenster (**F**ront end preview).        |
 
 
 ## Tastaturkürzel im Bearbeitungsmodus {#tastaturkuerzel-im-bearbeitungsmodus}
 
 Im Bearbeitungsmodus stehen zusätzlich folgende Kürzel zur Verfügung:
 
-| Tastaturkürzel    | Schaltfläche                          | Erklärung                                                                                                                                                                                |
-|:------------------|:--------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `[Alt]+[s]`       | Speichern                             | Speichert das aktuelle Eingabeformular (**S**ave).                                                                                                                                       |
-| `[Alt]+[c]`       | Speichern und schließen               | Speichert und schließt das aktuelle Eingabeformular (Save and **c**lose). Du gelangst zurück zur vorherigen Seite.                                                                      |
-| `[Alt]+[n]`       | Speichern und neu                     | Speichert das aktuelle Eingabeformular und legt einen neuen Datensatz an (Save and **n**ew).                                                                                             |
-| `[Alt]+[d]`       | Speichern&nbsp;und&nbsp;duplizieren   | Speichert das aktuelle Eingabeformular und dupliziert den Datensatz (Save and **d**uplicate).                                                                                            |
-| `[Alt]+[e]`       | Speichern und bearbeiten              | Speichert das aktuelle Eingabeformular (Save and **e**dit) und wechselt zur Ansicht der Kind-Datensätze, z. B. beim Anlegen von Stylesheets.                                             |
-| `[Alt]+[g]`       | Speichern und zurück                  | Speichert und schließt das aktuelle Eingabeformular (Save and **g**o back). Du gelangst zurück zur übergeordneten Seite, z. B. von einem Inhaltselement direkt zur Artikelübersicht.    |
+| Tastaturkürzel        | Schaltfläche                          | Erklärung                                                                                                                                                                                |
+|:----------------------|:--------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| {{< accesskey "s" >}} | Speichern                             | Speichert das aktuelle Eingabeformular (**S**ave).                                                                                                                                       |
+| {{< accesskey "c" >}} | Speichern und schließen               | Speichert und schließt das aktuelle Eingabeformular (Save and **c**lose). Du gelangst zurück zur vorherigen Seite.                                                                      |
+| {{< accesskey "n" >}} | Speichern und neu                     | Speichert das aktuelle Eingabeformular und legt einen neuen Datensatz an (Save and **n**ew).                                                                                             |
+| {{< accesskey "d" >}} | Speichern&nbsp;und&nbsp;duplizieren   | Speichert das aktuelle Eingabeformular und dupliziert den Datensatz (Save and **d**uplicate).                                                                                            |
+| {{< accesskey "e" >}} | Speichern und bearbeiten              | Speichert das aktuelle Eingabeformular (Save and **e**dit) und wechselt zur Ansicht der Kind-Datensätze, z. B. beim Anlegen von Stylesheets.                                             |
+| {{< accesskey "g" >}} | Speichern und zurück                  | Speichert und schließt das aktuelle Eingabeformular (Save and **g**o back). Du gelangst zurück zur übergeordneten Seite, z. B. von einem Inhaltselement direkt zur Artikelübersicht.    |
 
 
 ## Tastaturkürzel im Modus »Mehrere bearbeiten« {#tastaturkuerzel-im-modus-mehrere-bearbeiten}
 
 Im Modus »Mehrere bearbeiten« kommen weitere Kürzel hinzu:
 
-| Tastaturkürzel    | Schaltfläche                             | Erklärung                                                                               |
-|:------------------|:-----------------------------------------|:----------------------------------------------------------------------------------------|
-| `[Alt]+[s]`       | Bearbeiten                               | Bearbeitet alle ausgewählten Felder im Modus »mehrere bearbeiten«.                      |
-| `[Alt]+[d]`       | Löschen                                  | Löscht alle ausgewählten Datensätze im Modus »mehrere bearbeiten« (**D**elete).         |
-| `[Alt]+[c]`       | Kopieren                                 | Kopiert alle ausgewählten Datensätze im Modus »mehrere bearbeiten« (**C**opy).          |
-| `[Alt]+[x]`       | Verschieben                              | Verschiebt alle ausgewählten Datensätze im Modus »mehrere bearbeiten«.                  |
-| `[Alt]+[v]`       | Überschreiben                            | Überschreibt alle ausgewählten Datensätze im Modus »mehrere bearbeiten«.                |
-| `[Alt]+[a]`       | Aliase generieren                        | Generiert den Alias aller ausgewählten Datensätze im Modus »mehrere bearbeiten« neu.    |
-| `[Shift]`         | Mehrere&nbsp;Checkboxen&nbsp;auswählen   | Wählt mehrere Checkboxen aus wenn die Shift-Taste gedrückt wird.                        |
+| Tastaturkürzel        | Schaltfläche                             | Erklärung                                                                               |
+|:----------------------|:-----------------------------------------|:----------------------------------------------------------------------------------------|
+| {{< accesskey "s" >}} | Bearbeiten                               | Bearbeitet alle ausgewählten Felder im Modus »mehrere bearbeiten«.                      |
+| {{< accesskey "d" >}} | Löschen                                  | Löscht alle ausgewählten Datensätze im Modus »mehrere bearbeiten« (**D**elete).         |
+| {{< accesskey "c" >}} | Kopieren                                 | Kopiert alle ausgewählten Datensätze im Modus »mehrere bearbeiten« (**C**opy).          |
+| {{< accesskey "x" >}} | Verschieben                              | Verschiebt alle ausgewählten Datensätze im Modus »mehrere bearbeiten«.                  |
+| {{< accesskey "v" >}} | Überschreiben                            | Überschreibt alle ausgewählten Datensätze im Modus »mehrere bearbeiten«.                |
+| {{< accesskey "a" >}} | Aliase generieren                        | Generiert den Alias aller ausgewählten Datensätze im Modus »mehrere bearbeiten« neu.    |
+| `[Shift]`             | Mehrere&nbsp;Checkboxen&nbsp;auswählen   | Wählt mehrere Checkboxen aus wenn die Shift-Taste gedrückt wird.                        |
 
 
 ## Tastaturkürzel unter Windows, Linux und Mac {#tastaturkuerzel-unter-windows-linux-und-mac}
 
-Die beschriebenen Tastaturkürzel funktionieren in dieser Form nur unter Windows und Linux. Mac-Nutzer müssen anstatt der
-`[Alt]`-Taste `[Ctrl]+[⌥ Opt]` in Verbindung mit dem jeweiligen Kürzel verwenden.
-
-Zudem weicht Firefox unter Windows und Linux leider vom gewohnten Standard ab, dort musst du `[Alt]+[Umsch]` in Verbindung mit
-dem gewünschten Kürzel drücken.
-
-Eine Übersicht, welche Tastenkombination unter welchem Betriebssystem und Browser benutzt werden muss, bietet
+Die beschriebenen Tastaturkürzel funktionieren in deinem aktuellen Browser, können aber auf anderen Betriebssystemen oder
+Browsern unterschiedlich sein. Eine Übersicht, welche Tastenkombination unter welchem Betriebssystem und Browser benutzt werden muss, bietet
 [dieser Artikel][MozillaAccesskey].
 
 

--- a/docs/manual/administration-area/back-end-keyboard-shortcuts.en.md
+++ b/docs/manual/administration-area/back-end-keyboard-shortcuts.en.md
@@ -13,7 +13,7 @@ it can only be clicked with the mouse when the page is completely scrolled down.
 
 Normally, this is not a problem, because when filling out a form you work from top to bottom. But 
 if you later want to change only a single value at the beginning of the form, the button is not accessible without scrolling. 
-In this case, you are able to access the keyboard shortcut `[Alt]+[S]` even without scrolling 
+In this case, you are able to access the keyboard shortcut {{< accesskey "s" >}} even without scrolling 
 to the destination.
 
 
@@ -21,53 +21,49 @@ to the destination.
 
 The following keyboard shortcuts are available in Contao:
 
-| Shortcut          | Button                  | Explanation                                                                         |
-|:------------------|:------------------------|:------------------------------------------------------------------------------------|
-| `[Alt]+[h]`       | **H**ome                | Go to the home page of the back end.                                                |
-| `[Alt]+[q]`       | **Q**uit                | Quit the current back end session (log out).                                        |
-| `[Alt]+[t]`       | **T**op                 | Go to the top of the page.                                                          |
-| `[Alt]+[b]`       | **B**ack                | Go back to the previous page.                                                       |
-| `[Alt]+[n]`       | **N**ew record          | Create a new record.                                                                |
-| `[Alt]+[e]`       | **E**dit multiple       | Switch to the "edit multiple" mode.                                                 |
-| `[Alt]+[f]`       | **F**ront end preview   | Open the front end preview in a new browser window.                                 |
+| Shortcut              | Button                  | Explanation                                                                         |
+|:----------------------|:------------------------|:------------------------------------------------------------------------------------|
+| {{< accesskey "h" >}} | **H**ome                | Go to the home page of the back end.                                                |
+| {{< accesskey "q" >}} | **Q**uit                | Quit the current back end session (log out).                                        |
+| {{< accesskey "t" >}} | **T**op                 | Go to the top of the page.                                                          |
+| {{< accesskey "b" >}} | **B**ack                | Go back to the previous page.                                                       |
+| {{< accesskey "n" >}} | **N**ew record          | Create a new record.                                                                |
+| {{< accesskey "e" >}} | **E**dit multiple       | Switch to the "edit multiple" mode.                                                 |
+| {{< accesskey "f" >}} | **F**ront end preview   | Open the front end preview in a new browser window.                                 |
 
 
 ## Keyboard shortcuts in edit mode
 
 The following abbreviations are also available in edit mode:
 
-| Shortcut          | Button                                | Explanation                                                                                               |
-|:------------------|:--------------------------------------|:----------------------------------------------------------------------------------------------------------|
-| `[Alt]+[s]`       | **S**ave                              | Saves the current form.                                                                                   |
-| `[Alt]+[c]`       | Save and **c**lose                    | Saves the current form and redirects to the previous page.                                                |
-| `[Alt]+[n]`       | Save and **n**ew                      | Saves the current form and creates a new record.                                                          |
-| `[Alt]+[d]`       | Save&nbsp;and&nbsp;**d**uplicate      | Saves the current input form and duplicates the record.                                                   |
-| `[Alt]+[e]`       | Save and **e**dit                     | Saves the current form and redirects to the child records view, e.g. when creating style sheets.          |
-| `[Alt]+[g]`       | Save and **g**o back                  | Saves the current form and redirects to the parent page, e.g. from a content element to the article tree. |
+| Shortcut              | Button                             | Explanation                                                                                               |
+|:----------------------|:-----------------------------------|:----------------------------------------------------------------------------------------------------------|
+| {{< accesskey "s" >}} | **S**ave                           | Saves the current form.                                                                                   |
+| {{< accesskey "c" >}} | Save and **c**lose                 | Saves the current form and redirects to the previous page.                                                |
+| {{< accesskey "n" >}} | Save and **n**ew                   | Saves the current form and creates a new record.                                                          |
+| {{< accesskey "d" >}} | Save&nbsp;and&nbsp;**d**uplicate   | Saves the current input form and duplicates the record.                                                   |
+| {{< accesskey "e" >}} | Save and **e**dit                  | Saves the current form and redirects to the child records view, e.g. when creating style sheets.          |
+| {{< accesskey "g" >}} | Save and **g**o back               | Saves the current form and redirects to the parent page, e.g. from a content element to the article tree. |
 
 
 ## Keyboard shortcuts in "edit multiple" mode
 
 Further abbreviations are added in "Edit multiple" mode:
 
-| Shortcut          | Button                                      | Explanation                                                                                         |
-|:------------------|:--------------------------------------------|:----------------------------------------------------------------------------------------------------|
-| `[Alt]+[s]`       | Edit multiple                               | Edits all selected fields in "edit multiple" mode.                                                  |
-| `[Alt]+[d]`       | **D**elete multiple                         | Deletes all selected records in "edit multiple" mode.                                               |
-| `[Alt]+[c]`       | **C**opy multiple                           | Duplicates all selected records in "edit multiple" mode.                                            |
-| `[Alt]+[x]`       | Move multiple                          	    | Moves all selected records in "edit multiple" mode.                                                 |
-| `[Alt]+[v]`       | Override multiple                           | Overrides all selected records in "edit multiple" mode.                                             |
-| `[Alt]+[a]`       | Generate aliases                            | Regenerates the alias of all selected records in "edit multiple" mode.                              |
-| `[Shift]`         | Select&nbsp;several&nbsp;check&nbsp;boxes   | Selects several check boxes by holding down the shift key in "edit multiple" mode.                  |
+| Shortcut              | Button                                      | Explanation                                                                                         |
+|:----------------------|:--------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| {{< accesskey "s" >}} | Edit multiple                               | Edits all selected fields in "edit multiple" mode.                                                  |
+| {{< accesskey "d" >}} | **D**elete multiple                         | Deletes all selected records in "edit multiple" mode.                                               |
+| {{< accesskey "c" >}} | **C**opy multiple                           | Duplicates all selected records in "edit multiple" mode.                                            |
+| {{< accesskey "x" >}} | Move multiple                               | Moves all selected records in "edit multiple" mode.                                                 |
+| {{< accesskey "v" >}} | Override multiple                           | Overrides all selected records in "edit multiple" mode.                                             |
+| {{< accesskey "a" >}} | Generate aliases                            | Regenerates the alias of all selected records in "edit multiple" mode.                              |
+| `[Shift]`             | Select&nbsp;several&nbsp;check&nbsp;boxes   | Selects several check boxes by holding down the shift key in "edit multiple" mode.                  |
 
 
 ## Keyboard shortcuts under Windows, Linux and Mac
 
-The described shortcuts work in this form only under Windows and Linux. Mac users have to use `[Ctrl]+[⌥ Opt]` instead of `[Alt]` 
-together with the keyboard shortcut.
-
-In addition, Firefox on Windows and Linux deviates from the standard: you have to press `[Alt]+[Shift]` instead of just `[Alt]`.
-
+The described shortcuts should work on your current browser, but might be different on other operating systems or browsers.
 See [this article][MozillaAccesskey] for an overview of which key combination to press on which operating system and 
 browser.
 

--- a/page/layouts/partials/custom-header.html
+++ b/page/layouts/partials/custom-header.html
@@ -1,3 +1,5 @@
+{{ $assetBusting := not .Site.Params.disableAssetsBusting }}
+<script type="text/javascript" src="{{"js/browser.js" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css">
 <script>
   var _paq = window._paq = window._paq || [];

--- a/page/layouts/shortcodes/accesskey.html
+++ b/page/layouts/shortcodes/accesskey.html
@@ -1,0 +1,10 @@
+{{ $.Scratch.Set "key" .Site.Params.currentContaoVersion }}
+{{ if len .Params | eq 1 }}
+{{ $key := .Get 0 }}
+{{ $.Scratch.Set "key" $key }}
+{{ end }}
+<code data-for="mac">[Control]+[Option]+[{{ $.Scratch.Get "key" }}]</code>
+<span data-for="!mac">
+  <code data-for="firefox">[Alt]+[Shift]+[{{ $.Scratch.Get "key" }}]</code>
+  <code data-for="!firefox">[Alt]+[{{ $.Scratch.Get "key" }}]</code>
+</span>

--- a/page/static/js/browser.js
+++ b/page/static/js/browser.js
@@ -1,0 +1,56 @@
+"use strict";
+
+(function () {
+    const props = {
+        win: navigator.platform.indexOf('Win') !== -1,
+        mac: navigator.platform.indexOf('Mac') !== -1,
+        linux: navigator.platform.indexOf('Linux') !== -1,
+        chrome: navigator.userAgent.indexOf('Chrome') !== -1,
+        safari: navigator.userAgent.indexOf('Apple') !== -1,
+        firefox: navigator.userAgent.indexOf('Firefox') !== -1,
+        ie: navigator.userAgent.indexOf('MSIE') !== -1,
+        opera: navigator.userAgent.indexOf('Opera') !== -1,
+    };
+
+    props.pother = !props.win && !props.mac && !props.linux;
+    props.bother = !props.chrome && !props.safari && !props.firefox && !props.ie && !props.opera;
+
+    function setup(node) {
+        node.querySelectorAll('[data-for]').forEach(function (el) {
+            const targets = el.getAttribute('data-for').split(' ');
+
+            for (let i = 0; i<targets.length; i++) {
+                let key = targets[i];
+
+                if (key.substring(0, 1) === '!') {
+                    if (!props[key.substring(1)]) {
+                        el.style.display = 'initial';
+                        return;
+                    }
+                } else if (props[key]) {
+                    el.style.display = 'initial';
+                    return;
+                }
+            }
+
+            el.style.display = 'none';
+        });
+    }
+
+    setup(document);
+    new MutationObserver(function (mutationsList) {
+        for(const mutation of mutationsList) {
+            if (mutation.type === 'childList') {
+                mutation.addedNodes.forEach(function (element) {
+                    if (element.querySelectorAll) {
+                        setup(element)
+                    }
+                })
+            }
+        }
+    }).observe(document, {
+        attributes: false,
+        childList: true,
+        subtree: true
+    });
+})();


### PR DESCRIPTION
I was annoyed that our accesskey documentation only works on Windows. So I built a small JS library that can toggle HTML tags based on browser or platform, and also added a shortcode for access keys. With this change, the docs will always show the correct access keys for the current browser (based on the Mozilla docs) 😎 

I'm not sure if there are more access keys in the docs, but they could easily be updated later