### PR TITLE
Remove extra semicolon

### DIFF
--- a/docs/dev/framework/page-controllers.md
+++ b/docs/dev/framework/page-controllers.md
@@ -67,7 +67,6 @@ Next a palette for the back end should be defined for this page type:
 // contao/dca/tl_page.php
 $GLOBALS['TL_DCA']['tl_page']['palettes']['example'] =
     '{title_legend},title,alias,type;{publish_legend},published,start,stop';
-;
 ```
 
 A translation for the back end label should be defined to:


### PR DESCRIPTION
Typo fix for the 'contao/dca/tl_page.php' example code which currently has an extra semicolon.