### PR TITLE
Add hint for public dir to hosting config

### DIFF
--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -229,7 +229,7 @@ automatisch anstelle von `/public` verwendet.)
 Pro Contao-Installation wird deshalb eine eigene (Sub)Domain benötigt.
 {{% /notice %}}
 
-({{< version-tag "4.13" >}} Wenn du noch den `/web`-Ordner verwendest,
+{{< version-tag "4.13" >}} Wenn du noch den `/web`-Ordner verwendest,
 dann definiere diesen entsprechend, um für zukünftige Contao Versionen gerüstet zu sein:
 
 ```json

--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -229,6 +229,19 @@ automatisch anstelle von `/public` verwendet.)
 Pro Contao-Installation wird deshalb eine eigene (Sub)Domain benötigt.
 {{% /notice %}}
 
+({{< version-tag "4.13" >}} Wenn du noch den `/web`-Ordner verwendest,
+dann definiere diesen entsprechend, um für zukünftige Contao Versionen gerüstet zu sein:
+
+```json
+{
+  "extra": {
+    "public-dir": "web"
+  }
+}
+```
+
+siehe auch: https://symfony.com/doc/current/configuration/override_dir_structure.html#override-the-public-directory
+
 ## Providerspezifische Einstellungen
 
 Es gibt ein paar wenige große Internet Service Provider, die spezielle Einstellungen für den Betrieb von Contao 

--- a/docs/manual/installation/system-requirements.en.md
+++ b/docs/manual/installation/system-requirements.en.md
@@ -222,6 +222,18 @@ Example: `example.com` points to the directory `/www/example/web`
 Therefore, a separate (sub)domain is required for each Contao installation.
 {{% /notice %}}
 
+({{< version-tag "4.13" >}} When your installation is still using the folder `/web` as public directory, please explicitly set it in the `composer.json`
+of the project, to be prepared for future version of contao:
+
+```json
+{
+  "extra": {
+    "public-dir": "web"
+  }
+}
+```
+see also: https://symfony.com/doc/current/configuration/override_dir_structure.html#override-the-public-directory
+
 ## Provider-specific settings
 
 There are a few major Internet service providers that offer special settings for running Contao. Fortunately, they are 

--- a/docs/manual/installation/system-requirements.en.md
+++ b/docs/manual/installation/system-requirements.en.md
@@ -222,8 +222,8 @@ Example: `example.com` points to the directory `/www/example/web`
 Therefore, a separate (sub)domain is required for each Contao installation.
 {{% /notice %}}
 
-({{< version-tag "4.13" >}} When your installation is still using the folder `/web` as public directory, please explicitly set it in the `composer.json`
-of the project, to be prepared for future version of contao:
+{{< version-tag "4.13" >}} If your installation is still using the folder `/web` as its public directory, explicitly set it in the `composer.json`
+of the project in order to be prepared for future versions of contao:
 
 ```json
 {

--- a/docs/manual/installation/system-requirements.en.md
+++ b/docs/manual/installation/system-requirements.en.md
@@ -232,6 +232,7 @@ of the project in order to be prepared for future versions of contao:
   }
 }
 ```
+
 see also: https://symfony.com/doc/current/configuration/override_dir_structure.html#override-the-public-directory
 
 ## Provider-specific settings


### PR DESCRIPTION
At the latest for Contao 5 you will need the config of the `public-dir`