### PR TITLE
Update Deployer guide

### DIFF
--- a/docs/manual/guides/deployer.de.md
+++ b/docs/manual/guides/deployer.de.md
@@ -21,7 +21,7 @@ Zuerst musst du Deployer installieren: [https://deployer.org/docs/][1]
 Du kannst Deployer entweder global oder per Projekt (mit Composer) installieren. Der Kommandozeilenbefehl lautet
 entsprechend `dep` oder `./vendor/bin/dep`.
 
-Bevor du weitermachst, stelle sicher, dass du mindestens Version _7.0.0-rc.5_ installiert hast (`dep --version`).
+Bevor du weitermachst, stelle sicher, dass du mindestens Version _7.0_ installiert hast (`dep --version`).
 
 Jetzt kannst du deine `deploy.php`-Datei in dem Projekt erstellen:
 

--- a/docs/manual/guides/deployer.de.md
+++ b/docs/manual/guides/deployer.de.md
@@ -178,14 +178,6 @@ before('deploy:publish', 'contao:manager:download');
 after('contao:manager:download', 'contao:manager:lock');
 ```
 
-Verwendest du Contao Manager nicht, dann kannst du den leeren Ordner von "Shared folders" ausschließen:
-
-```php
-// deploy.php
-
-set('shared_dirs', array_diff(get('shared_dirs'), ['contao-manager']));
-```
-
 
 ### Probleme mit dem Symlink und OPCache / APCu
 

--- a/docs/manual/guides/deployer.de.md
+++ b/docs/manual/guides/deployer.de.md
@@ -18,10 +18,11 @@ Diese Anleitung bezieht sich auf die Deployer-Version >=7.0 und Contao-Version >
 
 Zuerst musst du Deployer installieren: [https://deployer.org/docs/][1]
 
-Du kannst Deployer entweder global oder per Projekt (mit Composer) installieren. Der Kommandozeilenbefehl lautet
-entsprechend `dep` oder `./vendor/bin/dep`.
+```bash
+composer require --dev deployer/deployer
+```
 
-Bevor du weitermachst, stelle sicher, dass du mindestens Version _7.0_ installiert hast (`dep --version`).
+Bevor du weitermachst, stelle sicher, dass du mindestens Version _7.0_ installiert hast (`vendor/bin/dep --version`).
 
 Jetzt kannst du deine `deploy.php`-Datei in dem Projekt erstellen:
 
@@ -148,7 +149,7 @@ before('deploy', 'encore:compile');
 
 ## Und nun: Deployen!
 
-Nachdem wir alles konfiguriert haben, können wir jetzt `dep deploy` ausführen und das Projekt auf den Webserver
+Nachdem wir alles konfiguriert haben, können wir jetzt `vendor/bin/dep deploy` ausführen und das Projekt auf den Webserver
 deployen.
 
 

--- a/docs/manual/guides/deployer.de.md
+++ b/docs/manual/guides/deployer.de.md
@@ -113,8 +113,9 @@ hinter Deployer ist, dass es keine Downtime bei Updates gibt. Deswegen werden ro
 Document-Root von deinem vHost musst du entsprechend auf `/current/public` (bzw. `/current/web`) einstellen. Ein
 komplettes Beispiel für einen Document-Root wäre: `/var/www/foobar/html/example.org/current/public`.
 
-Contao migriert langsam zum `/public`-Ordner als Web-Root. Wenn du in Contao 4.13 noch den `/web`-Ordner verwendest,
-dann definiere diesen entsprechend, damit Deployer das auch weiß.
+{{% notice "info" %}}
+Standardmäßig verwendet Contao `/public`-Ordner als Web-Root. Wenn deine Contao-Installation noch den Legacy `/web`-Ordner
+verwendet, dann definiere diesen entsprechend in `composer.json`, damit Deployer das auch weiß.
 
 ```json
 {
@@ -123,7 +124,7 @@ dann definiere diesen entsprechend, damit Deployer das auch weiß.
   }
 }
 ```
-
+{{% /notice %}}
 
 ## Projektspezifische Tasks
 

--- a/docs/manual/guides/deployer.de.md
+++ b/docs/manual/guides/deployer.de.md
@@ -176,6 +176,14 @@ before('deploy:publish', 'contao:manager:download');
 after('contao:manager:download', 'contao:manager:lock');
 ```
 
+Verwendest du Contao Manager nicht, dann kannst du den leeren Ordner von "Shared folders" ausschließen:
+
+```php
+// deploy.php
+
+set('shared_dirs', array_diff(get('shared_dirs'), ['contao-manager']));
+```
+
 
 ### Probleme mit dem Symlink und OPCache / APCu
 

--- a/docs/manual/guides/deployer.de.md
+++ b/docs/manual/guides/deployer.de.md
@@ -109,8 +109,8 @@ für die Konfiguration findest du hier: [nutshell-framework/deployer-recipes][4]
 
 ## Webserver einrichten
 
-Wie du aus der [Contao-Doku][5] weißt, musst du den Document-Root auf `/public` (bzw. `/web`) einstellen. Die Idee
-hinter Deployer ist, dass es keine Downtime bei Updates gibt. Deswegen werden rollierende Symlinks eingesetzt. Den
+Wie du aus der [Contao-Doku][5] weißt, musst du den Document-Root auf `/public` (bzw. `/web`) einstellen. Die Idee hinter 
+Deployer ist, dass es eine möglichst kurze Downtime bei Updates gibt. Deswegen werden rollierende Symlinks eingesetzt. Den
 Document-Root von deinem vHost musst du entsprechend auf `/current/public` (bzw. `/current/web`) einstellen. Ein
 komplettes Beispiel für einen Document-Root wäre: `/var/www/foobar/html/example.org/current/public`.
 

--- a/docs/manual/guides/deployer.de.md
+++ b/docs/manual/guides/deployer.de.md
@@ -114,7 +114,7 @@ Document-Root von deinem vHost musst du entsprechend auf `/current/public` (bzw.
 komplettes Beispiel für einen Document-Root wäre: `/var/www/foobar/html/example.org/current/public`.
 
 {{% notice "info" %}}
-Standardmäßig verwendet Contao `/public`-Ordner als Web-Root. Wenn deine Contao-Installation noch den Legacy `/web`-Ordner
+Contao verwendet standardmäßig den `/public`-Ordner als Web-Root. Wenn deine Contao-Installation noch den alten `/web`-Ordner
 verwendet, dann definiere diesen entsprechend in `composer.json`, damit Deployer das auch weiß.
 
 ```json

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -19,7 +19,7 @@ If not done yet, install Deployer as described here: [https://deployer.org/docs/
 
 You can either install Deployer globally or per project and use the command `dep` or `./vendor/bin/dep` respectively.
 
-Verify that you are running Deployer in the minimum version _7.0.0-rc.5_ by running `dep --version`.
+Verify that you are running Deployer in the minimum version _7.0_ by running `dep --version`.
 
 Once done, you can create a `deploy.php` file in your project:
 

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -104,9 +104,9 @@ task. The `rsync` task implies an _exclude strategy_ rather than an _include str
 ## Provision web server
 
 As you know [from the Contao documentation][5], you have to set the document root of the server to `/public` (or
-`/web` in older versions) of the project. The idea of Deployer is to provide updates without downtime, and to realize
-this, Deployer utilizes rolling symlink releases. Consequently, you have to set the document root of your vHost to
-`/current/public` (or `/current/web` respectively). A full example for the document root might look like
+`/web` in older versions) of the project. The idea of Deployer is to provide updates with the shortest possible downtime, 
+and to realize this, Deployer utilizes rolling symlink releases.  Consequently, you have to set the document root of your 
+vHost to`/current/public` (or `/current/web` respectively). A full example for the document root might look like
 `/var/www/foobar/html/example.org/current/public`.
 
 {{% notice "info" %}}

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -107,8 +107,9 @@ this, Deployer utilizes rolling symlink releases. Consequently, you have to set 
 `/current/public` (or `/current/web` respectively). A full example for the document root might look like
 `/var/www/foobar/html/example.org/current/public`.
 
-Contao is slowly migrating to use the `/public` folder of the project as the document root. When your Contao 4.13
-installation is still using the folder `/web` as public directory, please explicitly set it in the `composer.json`
+{{% notice "info" %}}
+By default, Contao uses the `/public` folder of the project as the document root. If your Contao
+installation is still using the legacy `/web` folder as public directory, please explicitly set it in the `composer.json`
 of the project:
 
 ```json
@@ -118,6 +119,7 @@ of the project:
   }
 }
 ```
+{{% /notice %}}
 
 ## Add build-task to deployment
 

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -15,11 +15,13 @@ The Deployer recipe is part of Deployer 7 and is intended to work for Contao 4.1
 
 ## Install Deployer
 
-If not done yet, install Deployer as described here: [https://deployer.org/docs/][1]
+If not done yet, install Deployer in your project as described [in the docs:][1]
 
-You can either install Deployer globally or per project and use the command `dep` or `./vendor/bin/dep` respectively.
+```bash
+composer require --dev deployer/deployer
+```
 
-Verify that you are running Deployer in the minimum version _7.0_ by running `dep --version`.
+Verify that you are running Deployer in the minimum version _7.0_ by running `vendor/bin/dep --version`.
 
 Once done, you can create a `deploy.php` file in your project:
 
@@ -143,7 +145,7 @@ before('deploy', 'encore:compile');
 
 ## Finally: Deploy
 
-You are now all set to run `dep deploy`.
+You are now all set to run `vendor/bin/dep deploy`.
 
 ## Tips
 

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -172,14 +172,6 @@ before('deploy:publish', 'contao:manager:download');
 after('contao:manager:download', 'contao:manager:lock');
 ```
 
-If you don't use Contao Manager, you can prevent empty folder from being deployed by excluding it from shared folders:
-
-```php
-// deploy.php
-
-set('shared_dirs', array_diff(get('shared_dirs'), ['contao-manager']));
-```
-
 ### Symlink issues with OPCache / APCu
 
 As Deployer is using a symlink for the document root (as read above), issues might occur with internal caches like the

--- a/docs/manual/guides/deployer.en.md
+++ b/docs/manual/guides/deployer.en.md
@@ -168,6 +168,14 @@ before('deploy:publish', 'contao:manager:download');
 after('contao:manager:download', 'contao:manager:lock');
 ```
 
+If you don't use Contao Manager, you can prevent empty folder from being deployed by excluding it from shared folders:
+
+```php
+// deploy.php
+
+set('shared_dirs', array_diff(get('shared_dirs'), ['contao-manager']));
+```
+
 ### Symlink issues with OPCache / APCu
 
 As Deployer is using a symlink for the document root (as read above), issues might occur with internal caches like the


### PR DESCRIPTION
Small updates to the article about using Deployer.

 * There's no need to reference an RC version, since Deployer 7 has been [released](https://github.com/deployphp/deployer/releases/tag/v7.0.0) (which also contains a [bug fix](https://github.com/deployphp/deployer/pull/3200) to Contao recipe).

 * An example on excluding folders from pre-set `shared_dirs` has been added. Not everybody uses Contao Manager and `parameters.yml`, but Contao recipe deploys them by default as empty directories.

 * I find the wording about Contao "slowly migrating towards using `public/` instead of `web/`" a little bit unfortunate. The guide claims to be intended for Contao 4.13 and up, yet `public/` is already a default since 4.12