### PR TITLE
Add ext-fileinfo to system requirements

### DIFF
--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -24,19 +24,20 @@ empfohlen, diese immer zu verwenden.
 
 ### PHP-Erweiterungen
 
-| Name der Erweiterung                      | Contao 4.4                   | Contao 4.9                                     |
-|:------------------------------------------|:-----------------------------|:-----------------------------------------------|
-| [DOM][ext-dom] (`ext-dom`)                | **erforderlich**             | **erforderlich**                               |
-| [PCRE][ext-pcre] (`ext-pcre`)             | **erforderlich**             | **erforderlich**                               |
-| [Intl][ext-intl] (`ext-intl`)             | empfohlen                    | **erforderlich**                               |
-| [PDO][ext-pdo] (`ext-pdo`)                | **erforderlich**             | **erforderlich**                               |
-| [ZLIB][ext-zlib] (`ext-zlib`)             | **erforderlich**             | **erforderlich**                               |
-| [JSON][ext-json] (`ext-json`)             | **erforderlich**             | **erforderlich**                               |
-| [Curl][ext-curl] (`ext-curl`)             | **erforderlich**             | **erforderlich**                               |
-| [Mbstring][ext-mbstring] (`ext-mbstring`) | **erforderlich**             | **erforderlich**                               |
-| [GD][ext-gd] (`ext-gd`)                   | **erforderlich**<sup>1</sup> | **erforderlich**<sup>1</sup> |
-| [Imagick][ext-imagick] (`ext-imagick`)    | empfohlen<sup>1</sup>        | erfordert GD, Imagick oder Gmagick<sup>1</sup> |
-| [Gmagick][ext-gmagick] (`ext-gmagick`)    | empfohlen<sup>1</sup>        | erfordert GD, Imagick oder Gmagick<sup>1</sup> |
+| Name der Erweiterung                      | ab Contao 4.4                | ab Contao 4.9                                  | ab Contao 4.13                                 |
+|:------------------------------------------|:-----------------------------|:-----------------------------------------------|:-----------------------------------------------|
+| [DOM][ext-dom] (`ext-dom`)                | **erforderlich**             | **erforderlich**                               | **erforderlich**                               |
+| [PCRE][ext-pcre] (`ext-pcre`)             | **erforderlich**             | **erforderlich**                               | **erforderlich**                               |
+| [Intl][ext-intl] (`ext-intl`)             | empfohlen                    | **erforderlich**                               | **erforderlich**                               |
+| [PDO][ext-pdo] (`ext-pdo`)                | **erforderlich**             | **erforderlich**                               | **erforderlich**                               |
+| [ZLIB][ext-zlib] (`ext-zlib`)             | **erforderlich**             | **erforderlich**                               | **erforderlich**                               |
+| [JSON][ext-json] (`ext-json`)             | **erforderlich**             | **erforderlich**                               | **erforderlich**                               |
+| [Curl][ext-curl] (`ext-curl`)             | **erforderlich**             | **erforderlich**                               | **erforderlich**                               |
+| [Mbstring][ext-mbstring] (`ext-mbstring`) | **erforderlich**             | **erforderlich**                               | **erforderlich**                               |
+| [GD][ext-gd] (`ext-gd`)                   | **erforderlich**<sup>1</sup> | **erforderlich**<sup>1</sup>                   | **erforderlich**<sup>1</sup>                   |
+| [Imagick][ext-imagick] (`ext-imagick`)    | empfohlen<sup>1</sup>        | erfordert GD, Imagick oder Gmagick<sup>1</sup> | erfordert GD, Imagick oder Gmagick<sup>1</sup> |
+| [Gmagick][ext-gmagick] (`ext-gmagick`)    | empfohlen<sup>1</sup>        | erfordert GD, Imagick oder Gmagick<sup>1</sup> | erfordert GD, Imagick oder Gmagick<sup>1</sup> |
+| [File Information][ext-fileinfo] (`ext-fileinfo`) | -                    | -                                              | **erforderlich**                               |
 
 {{% notice note %}}
 <sup>1</sup> Contao wählt automatisch eine Bildverarbeitungsbibliothek je nach Verfügbarkeit aus.
@@ -49,17 +50,18 @@ $ vendor/bin/contao-console debug:container contao.image.imagine
 ```
 {{% /notice %}}
 
-[ext-zlib]: https://www.php.net/manual/en/book.zlib.php
-[ext-dom]: https://www.php.net/manual/en/book.dom.php
-[ext-pcre]: https://www.php.net/manual/en/book.pcre.php
-[ext-intl]: https://www.php.net/manual/en/book.intl.php
-[ext-pdo]: https://www.php.net/manual/en/book.pdo.php
-[ext-json]: https://www.php.net/manual/en/book.json.php
-[ext-curl]: https://www.php.net/manual/en/book.curl.php
-[ext-mbstring]: https://www.php.net/manual/en/book.mbstring.php
-[ext-gd]: https://www.php.net/manual/en/book.image.php
-[ext-imagick]: https://www.php.net/manual/en/book.imagick.php
-[ext-gmagick]: https://www.php.net/manual/en/book.gmagick.php
+[ext-zlib]: https://www.php.net/manual/de/book.zlib.php
+[ext-dom]: https://www.php.net/manual/de/book.dom.php
+[ext-pcre]: https://www.php.net/manual/de/book.pcre.php
+[ext-intl]: https://www.php.net/manual/de/book.intl.php
+[ext-pdo]: https://www.php.net/manual/de/book.pdo.php
+[ext-json]: https://www.php.net/manual/de/book.json.php
+[ext-curl]: https://www.php.net/manual/de/book.curl.php
+[ext-mbstring]: https://www.php.net/manual/de/book.mbstring.php
+[ext-gd]: https://www.php.net/manual/de/book.image.php
+[ext-imagick]: https://www.php.net/manual/de/book.imagick.php
+[ext-gmagick]: https://www.php.net/manual/de/book.gmagick.php
+[ext-fileinfo]: https://www.php.net/manual/de/book.fileinfo.php
 
 Alle erforderlichen Erweiterungen sind in aktuellen PHP-Versionen standardmäßig aktiviert. Einige Hosting-Anbieter 
 deaktivieren sie jedoch explizit. Die Anforderungen werden bei der Installation durch 

--- a/docs/manual/installation/system-requirements.en.md
+++ b/docs/manual/installation/system-requirements.en.md
@@ -22,19 +22,20 @@ always use them.
 
 ### PHP Extensions
 
-| Extension Name | Contao 4.4 | Contao 4.9 |
-|:------------------------------------------|:-------------------------|:--------------------------------------------|
-| [DOM][ext-dom] (`ext-dom`)                | **required**             | **required**                                |
-| [PCRE][ext-pcre] (`ext-pcre`)             | **required**             | **required**                                |
-| [Intl][ext-intl] (`ext-intl`)             | recommended              | **required**                                |
-| [PDO][ext-pdo] (`ext-pdo`)                | **required**             | **required**                                |
-| [ZLIB][ext-zlib] (`ext-zlib`)             | **required**             | **required**                                |
-| [JSON][ext-json] (`ext-json`)             | **required**             | **required**                                |
-| [Curl][ext-curl] (`ext-curl`)             | **required**             | **required**                                |
-| [Mbstring][ext-mbstring] (`ext-mbstring`) | **required**             | **required**                                |
-| [GD][ext-gd] (`ext-gd`)                   | **required**<sup>1</sup> | **required**<sup>1</sup>                    |
-| [Imagick][ext-imagick] (`ext-imagick`)    | recommended<sup>1</sup>  | requires GD, Imagick or Gmagick<sup>1</sup> |
-| [Gmagick][ext-gmagick] (`ext-gmagick`)    | recommended<sup>1</sup>  | requires GD, Imagick or Gmagick<sup>1</sup> |
+| Extension Name                            | Contao 4.4 and up        | Contao 4.9 and up                           | Contao 4.13 and up                          |
+|:------------------------------------------|:-------------------------|:--------------------------------------------|:--------------------------------------------|
+| [DOM][ext-dom] (`ext-dom`)                | **required**             | **required**                                | **required**                                |
+| [PCRE][ext-pcre] (`ext-pcre`)             | **required**             | **required**                                | **required**                                |
+| [Intl][ext-intl] (`ext-intl`)             | recommended              | **required**                                | **required**                                |
+| [PDO][ext-pdo] (`ext-pdo`)                | **required**             | **required**                                | **required**                                |
+| [ZLIB][ext-zlib] (`ext-zlib`)             | **required**             | **required**                                | **required**                                |
+| [JSON][ext-json] (`ext-json`)             | **required**             | **required**                                | **required**                                |
+| [Curl][ext-curl] (`ext-curl`)             | **required**             | **required**                                | **required**                                |
+| [Mbstring][ext-mbstring] (`ext-mbstring`) | **required**             | **required**                                | **required**                                |
+| [GD][ext-gd] (`ext-gd`)                   | **required**<sup>1</sup> | **required**<sup>1</sup>                    | **required**<sup>1</sup>                    |
+| [Imagick][ext-imagick] (`ext-imagick`)    | recommended<sup>1</sup>  | requires GD, Imagick or Gmagick<sup>1</sup> | requires GD, Imagick or Gmagick<sup>1</sup> |
+| [Gmagick][ext-gmagick] (`ext-gmagick`)    | recommended<sup>1</sup>  | requires GD, Imagick or Gmagick<sup>1</sup> | requires GD, Imagick or Gmagick<sup>1</sup> |
+| [File Information][ext-fileinfo] (`ext-fileinfo`) | -                | -                                           | **required**                                |
 
 {{% notice note %}}
 <sup>1</sup> Contao automatically selects an image processing library depending on its availability.
@@ -58,6 +59,7 @@ $ vendor/bin/contao-console debug:container contao.image.imagine
 [ext-gd]: https://www.php.net/manual/en/book.image.php
 [ext-imagick]: https://www.php.net/manual/en/book.imagick.php
 [ext-gmagick]: https://www.php.net/manual/en/book.gmagick.php
+[ext-fileinfo]: https://www.php.net/manual/en/book.fileinfo.php
 
 All required extensions are enabled by default in current PHP versions. However, some hosting providers
 explicitly disable them. The requirements are automatically checked during installation via the


### PR DESCRIPTION
Through `league/flysystem` (which requires `league/mime-type-detection`) Contao 4.13 has a new system requirement for the `fileinfo` PHP extension.