### PR TITLE
Add contao.sanitizer config

### DIFF
--- a/docs/dev/reference/config.md
+++ b/docs/dev/reference/config.md
@@ -174,6 +174,20 @@ contao:
 
         # Allows to configure the default HttpClient options (useful for proxy settings, SSL certificate validation and more).
         default_http_client_options: []
+
+    # Allows to configure which URL protocols can be used in Contao, as they are encoded by default for security reasons.
+    sanitizer:
+        allowed_url_protocols:
+
+            # Defaults:
+            - http
+            - https
+            - ftp
+            - mailto
+            - tel
+            - data
+            - skype
+            - whatsapp
 ```
 
 

--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -453,6 +453,20 @@ contao:
 
         # Allows to configure the default HttpClient options (useful for proxy settings, SSL certificate validation and more).
         default_http_client_options: []
+
+    # Allows to configure which URL protocols can be used in Contao, as they are encoded by default for security reasons.
+    sanitizer:
+        allowed_url_protocols:
+
+            # Defaults:
+            - http
+            - https
+            - ftp
+            - mailto
+            - tel
+            - data
+            - skype
+            - whatsapp
 ```
 
 

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -441,6 +441,20 @@ contao:
 
         # Allows to configure the default HttpClient options (useful for proxy settings, SSL certificate validation and more).
         default_http_client_options: []
+
+    # Allows to configure which URL protocols can be used in Contao, as they are encoded by default for security reasons.
+    sanitizer:
+        allowed_url_protocols:
+
+            # Defaults:
+            - http
+            - https
+            - ftp
+            - mailto
+            - tel
+            - data
+            - skype
+            - whatsapp
 ```
 
 


### PR DESCRIPTION
See https://github.com/contao/docs/issues/840

The config is available since 4.9.25, 4.12.6 and 4.13. I don't think this info is needed here, right?

I can add the comment to the ConfigTreeBuilder afterwards.