### PR TITLE
Clarify SMTP configuration via `.env.local`

### DIFF
--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -785,7 +785,7 @@ dazu auch die Informationen in der offiziellen [Symfony Dokumentation][SymfonyMa
 Falls der Benutzername oder das Passwort Sonderzeichen verwendet, müssen diese »URL enkodiert« werden. Es gibt
 verschiedene Online-Services, mit denen man auf einfache Weise eine beliebige Zeichenfolgen URL-encoden kann, z. B.
 [urlencoder.org](https://www.urlencoder.org/). Enkodiere den Benutzernamen und das Passwort separat, nicht gemeinsam
-mit dem Doppelpunkt. Bei Verwendung der `config.yaml` muß die jeweilige Kodierung eines Sonderzeichen mit `%` eingeleitet werden: Also z.B. `%%23` für das Sonderzeichen `#`.
+mit dem Doppelpunkt. Bei Verwendung der `config.yaml` muß die jeweilige Kodierung eines Sonderzeichen mit `%` eingeleitet werden: Also z. B. `%%23` für das Sonderzeichen `#`.
 {{% /notice %}}
 
 {{% notice tip %}}

--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -708,7 +708,7 @@ parameters:
     mailer_transport: smtp
     mailer_host: host.example.com
     mailer_user: mail@example.com
-    mailer_password: 'my-password'
+    mailer_password: 'mein-passwort'
     mailer_port: 465
     mailer_encryption: ssl
 ```

--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -684,8 +684,8 @@ Diese Zugangsdaten können dann entweder in der `parameters.yml` oder über die 
 
 {{% tab name=".env.local" %}}
 {{< version-tag "4.9" >}}
-Der SMTP Server kann über die [`.env.local`](https://symfony.com/doc/current/configuration.html#overriding-environment-values-via-env-local)
-Datei der Contao Installation definiert werden (beachte, dass auch eine `.env` Datei vorhanden sein muss, damit die Definition der
+Der SMTP-Server kann über die [`.env.local`](https://symfony.com/doc/current/configuration.html#overriding-environment-values-via-env-local)
+Datei der Contao-Installation definiert werden (beachte, dass auch eine `.env` Datei vorhanden sein muss, damit die Definition der
 Umgebungsvariablen in der `.env.local` auch angewandt wird). In Contao **4.9** muss die `MAILER_URL` Umgebungsvariable benutzt werden,
 während ab Contao **4.10** die [`MAILER_DSN`](#mailer-dsn) Variable benutzt werden kann. Ab Contao **5.0** gilt nur mehr die `MAILER_DSN`
 Variable.
@@ -695,11 +695,11 @@ Variable.
 MAILER_DSN=smtp://benutzername:passwort@smtp.example.com:465?encryption=ssl
 ```
 
-Beachte, dass der _Benutzername_ und das _Password_ »URL enkodiert« sein müssen.
+Beachte, dass der _Benutzername_ und das _Password_ »[URL enkodiert](https://www.urlencoder.org/)« sein müssen.
 {{% /tab %}}
 
 {{% tab name="parameters.yml" %}}
-Bei der Nutzung der `parameters.yml` können die SMTP Zugangsdaten über die folgenden Parameter definiert werden:
+Bei der Nutzung der `parameters.yml` können die SMTP-Zugangsdaten über die folgenden Parameter definiert werden:
 
 ```yaml
 # This file has been auto-generated during installation

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -1018,4 +1018,3 @@ aforementioned `--time-limit=1` option will cause the process to exit after one 
 [SymfonyMessengerTransports]: https://symfony.com/doc/current/messenger.html#transport-configuration
 [SymfonyMessengerDoctrine]: https://symfony.com/doc/current/messenger.html#doctrine-transport
 [SmyonfyMailerMessenger]: https://symfony.com/doc/current/mailer.html#sending-messages-async
-[SymfonyDotEnv]: https://symfony.com/doc/current/configuration.html#overriding-environment-values-via-env-local

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -870,14 +870,12 @@ It is also possible to define translations for the descriptions of the options i
 
 ```yml
 # translations/mailer_transports.en.yml
-default: 'Default'
 website1: 'SMTP for Website 1'
 website2: 'SMTP for Website 2'
 ```
 
 ```yml
 # translations/mailer_transports.de.yml
-default: 'Standard'
 website1: 'SMTP für Webseite 1'
 website2: 'SMTP für Webseite 2'
 ```

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -828,7 +828,7 @@ Instead of using `smtp://` you can also `smtps://` to automatically use SSL encr
 framework:
     mailer:
         transports:
-            default: '%env(MAILER_URL)%'
+            application: smtps://exampleuser:examplepassword@example.com
             website1: smtps://email%%40example.org:foobar@example.org
             website2: smtps://email%%40example.de:foobar@example.de
 ```

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -730,7 +730,7 @@ Contao **5.0** and up only the `MAILER_DSN` environment variable will work.
 MAILER_DSN=smtp://username:password@smtp.example.com:465?encryption=ssl
 ```
 
-Keep in mind that the _username_ and _password_ (individually) need to be URL encoded.
+Keep in mind that the _username_ and _password_ (individually) need to be [URL encoded](https://www.urlencoder.org/).
 {{% /tab %}}
 
 {{% tab name="parameters.yml" %}}

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -593,7 +593,7 @@ applicable. The format of this variable is the following: `MAILER_DSN=smtp://use
 See the [Symfony Mailer Documentation][SymfonyMailer] for more information.
 
 {{% notice note %}}
-The variable was previously called `MAILER_URL`. Since Contao 5.0 only `MAILER_DSN` will be supported.
+The variable was previously called `MAILER_URL`. Since Contao **5.0** only `MAILER_DSN` will be supported.
 {{% /notice %}}
 
 
@@ -704,15 +704,37 @@ to the list of trusted proxies, you will get the host name that was requested in
 
 ## E-Mail sending configuration
 
-To set up the sending of e-mails via an SMTP server, you need the following information from your host:
+To set up the sending of e-mails via an SMTP server, you need the following information from your host (some of these might be optional,
+depending on the server):
 
 - The **hostname** of the SMTP server.
 - The **user name** for the SMTP server.
 - The **password** for the SMTP server.
-- The **port number of** the SMTP server (587 / 465)
-- The **encryption method** for the SMTP server (tls / ssl)
+- The **port number of** the SMTP server (587 / 465).
+- The **encryption method** for the SMTP server (tls / ssl).
 
-You will then insert this below the existing data in the `parameters.yml`
+These credentials can then either be added in the `parameters.yml` or configured via the [`MAILER_DSN`](#mailer-dsn) environment variable,
+e.g. via the `.env.local` of your Contao instance.
+
+{{< tabs groupId="smtp-config" >}}
+
+{{% tab name=".env.local" %}}
+{{< version-tag "4.9" >}}
+You can define the SMTP server via the [`.env.local`](https://symfony.com/doc/current/configuration.html#overriding-environment-values-via-env-local)
+of your Contao instance (note that the `.env` file must also exist in order for the `.env.local` to take effect). In Contao **4.9** you need
+to use the `MAILER_URL` environment variable, while in Contao **4.10** and up the [`MAILER_DSN`](#mailer-dsn) variable can be used. In 
+Contao **5.0** and up only the `MAILER_DSN` environment variable will work.
+
+```ini
+# .env.local
+MAILER_DSN=smtp://username:password@smtp.example.com:465?encryption=ssl
+```
+
+Keep in mind that the _username_ and _password_ (individually) need to be URL encoded.
+{{% /tab %}}
+
+{{% tab name="parameters.yml" %}}
+When using the `parameters.yml` the SMTP credentials can be added via the following parameters:
 
 ```yaml
 # This file has been auto-generated during installation
@@ -721,14 +743,16 @@ parameters:
     mailer_transport: smtp
     mailer_host: host.example.com
     mailer_user: mail@example.com
-    mailer_password: 'mein-passwort'
+    mailer_password: 'my-password'
     mailer_port: 465
     mailer_encryption: ssl
 ```
+{{% /tab %}}
+
+{{< /tabs >}}
 
 {{% notice warning %}}
-**Clear cache** 
-In order to enable these changes, the application cache must be rebuilt using the Contao Manager ("Maintenance" &gt; "Rebuild Production Cache") or alternatively via the command line. To do the latter you have to execute the following in the Contao installation directory:
+**Clear cache:** In order to enable these changes, the application cache must be rebuilt using the Contao Manager ("Maintenance" &gt; "Rebuild Production Cache") or alternatively via the command line. To do the latter you have to execute the following in the Contao installation directory:
 
 ```bash
 php vendor/bin/contao-console cache:clear --env=prod --no-warmup
@@ -738,13 +762,32 @@ php vendor/bin/contao-console cache:warmup --env=prod
 
 After that you can test the mail dispatch on the command line.
 
-```bash
-php vendor/bin/contao-console swiftmailer:email:send --from=absender@example.com --to=empfaenger@example.com --subject=testmail --body=testmail
-```
+{{< tabs groupId="mailer-test" >}}
 
-{{% notice info %}}
-This command is no longer available in Contao **4.10** and later.
-{{% /notice %}}
+{{% tab name="Contao 4.0 to 4.9" %}}
+```bash
+php vendor/bin/contao-console swiftmailer:email:send --from=sender@example.com --to=recipient@example.com --subject=testmail --body=testmail
+```
+{{% /tab %}}
+
+{{% tab name="Contao 4.13" %}}
+First you need to install the [`inspiredminds/contao-mailer-command`](https://packagist.org/packages/inspiredminds/contao-mailer-command)
+package. Then the following command can be used:
+
+```bash
+php vendor/bin/contao-console mailer:send --from=sender@example.com --to=recipient@example.com --subject=testmail --body=testmail
+```
+{{% /tab %}}
+
+{{% tab name="Contao 5.0 and up" %}}
+```bash
+php vendor/bin/contao-console mailer:send --from=sender@example.com --to=recipient@example.com --subject=testmail --body=testmail
+```
+{{% /tab %}}
+
+{{< /tabs >}}
+
+You can also omit the parameters. The command will then ask you for each parameter interactively.
 
 
 ### Different e-mail configurations and sender addresses
@@ -785,7 +828,7 @@ Instead of using `smtp://` you can also `smtps://` to automatically use SSL encr
 framework:
     mailer:
         transports:
-            application: smtps://exampleuser:examplepassword@example.com
+            default: '%env(MAILER_URL)%'
             website1: smtps://email%%40example.org:foobar@example.org
             website2: smtps://email%%40example.de:foobar@example.de
 ```
@@ -827,12 +870,14 @@ It is also possible to define translations for the descriptions of the options i
 
 ```yml
 # translations/mailer_transports.en.yml
+default: 'Default'
 website1: 'SMTP for Website 1'
 website2: 'SMTP for Website 2'
 ```
 
 ```yml
 # translations/mailer_transports.de.yml
+default: 'Standard'
 website1: 'SMTP für Webseite 1'
 website2: 'SMTP für Webseite 2'
 ```
@@ -975,3 +1020,4 @@ aforementioned `--time-limit=1` option will cause the process to exit after one 
 [SymfonyMessengerTransports]: https://symfony.com/doc/current/messenger.html#transport-configuration
 [SymfonyMessengerDoctrine]: https://symfony.com/doc/current/messenger.html#doctrine-transport
 [SmyonfyMailerMessenger]: https://symfony.com/doc/current/mailer.html#sending-messages-async
+[SymfonyDotEnv]: https://symfony.com/doc/current/configuration.html#overriding-environment-values-via-env-local


### PR DESCRIPTION
This clarifies the SMTP configuration via `.env.local` and also provides more detailed instructions on how to test the config via the command line.