### PR TITLE
Document new operation mechanics

### DIFF
--- a/docs/dev/framework/security.md
+++ b/docs/dev/framework/security.md
@@ -136,6 +136,23 @@ $security->isGranted('contao_member.groups', $groupId);
 $security->isGranted('contao_member.groups', [/* array of group IDs */]);
 ```
 
+{{< version "5.0" >}}
+
+The `contao_dc.<data-container>` permission can be used to check whether a back end user has the right to perform 
+certain DCA actions. The subject in this case will be a `Contao\CoreBundle\Security\DataContainer\AbstractAction`.
+
+```php
+use Contao\CoreBundle\Security\DataContainer\CreateAction;
+use Contao\CoreBundle\Security\DataContainer\DeleteAction;
+use Contao\CoreBundle\Security\DataContainer\ReadAction;
+use Contao\CoreBundle\Security\DataContainer\UpdateAction;
+
+$security->isGranted('contao_dc.tl_foobar', new CreateAction('tl_foobar', $record));
+$security->isGranted('contao_dc.tl_foobar', new DeleteAction('tl_foobar', $record));
+$security->isGranted('contao_dc.tl_foobar', new ReadAction('tl_foobar', $record));
+$security->isGranted('contao_dc.tl_foobar', new UpdateAction('tl_foobar', $record));
+```
+
 {{% notice tip %}}
 Since Contao **4.10** there are class constants available for the various permission attributes, so that you do not have to remember them
 yourself and instead can use your IDE to find the correct attribute. For the Contao Core these constants are available in 

--- a/docs/dev/reference/dca/list.md
+++ b/docs/dev/reference/dca/list.md
@@ -128,3 +128,53 @@ $GLOBALS['TL_DCA']['tl_example']['list']['operations'] = [
 | Key             | Value                             | Description                                                                                                        |
 |-----------------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------|
 | route           | Symfony Route Name (`string`)     | The button will redirect to the given Symfony route.                                                               |
+
+{{% notice "note" %}}
+Since Contao **5.0** you do not have to define any settings for standard operations anymore. Instead you can give a list
+of which operations should be avilable for your data container. Contao will also check the appropriate
+[`contao_dc.<data-container>` permission](/framework/security/) for these operations.
+
+```php
+// contao/dca/tl_foobar.php
+$GLOBALS['TL_DCA']['tl_foobar']['config']['list']['operations'] = [
+    'edit',
+    'children',
+    'copy',
+    'cut',
+    'delete',
+    'toggle',
+    'show',
+    'toggle',
+];
+```
+{{% /notice %}}
+
+
+#### Toggle Operation
+
+{{< version-tag "5.0" >}} You can implement an automatic toggle operation for data containers that contain a boolean 
+field. This is typically used for fields that control a "published" state of a data record for example, but the use case 
+can be arbitrary.
+
+```php
+// contao/dca/tl_foobar.php
+$GLOBALS['TL_DCA']['tl_foobar']['config']['list']['operations'][] = 'toggle';
+
+$GLOBALS['TL_DCA']['tl_foobar']['fields']['published'] = [
+    'toggle' => true,
+    'inputType' => 'checkbox',
+    'sql' => ['type' => 'boolean', 'default' => false],
+];
+```
+
+{{% notice "note" %}}
+If the state of your field is reversed you can instead define `reverseToggle`:
+
+```php
+$GLOBALS['TL_DCA']['tl_foobar']['fields']['invisible'] = [
+    'reverseToggle' => true,
+    'inputType' => 'checkbox',
+    'sql' => ['type' => 'boolean', 'default' => false],
+];
+```
+{{% /notice %}}


### PR DESCRIPTION
This adds some basic documentation for the new operation mechanics in Contao 5.

_Note:_ I deliberately did not document (yet) how you could implement a toggle in Contao 4.9 or even 4.13, since it still requires some internal knowledge and I would still recommend to use Haste for toggles in Contao 4 for better DX.