### PR TITLE
Was mir gefehlt hatte...

### DIFF
--- a/docs/manual/installation/move-contao.de.md
+++ b/docs/manual/installation/move-contao.de.md
@@ -77,18 +77,28 @@ Gib dein Passwort ein, wenn du danach gefragt wirst.
 {{< /tabs >}}
 
 
+## Einstellungen notieren
+Deine Einstellungen unter `System / Einstellungen` oder im Seitenroot notierst du dir am besten und trägst sie später erneut ein.
+
+{{% notice tip %}}
+Wenn du deine [Einstellungen in einer Umgebungsvariablen ablegst](https://docs.contao.org/manual/de/system/einstellungen/#umgebungsvariablen), entfällt dieser Schritt.
+{{% /notice %}} 
+
 ## Dateien übertragen
 Die folgenden Dateien und Ordner müssen vom Quell- zum Zielserver übertragen werden:
 
 - `files`
 - `templates`
 - `composer.json`
-- `composer.lock`
 
-Falls du noch alte Erweiterungen unter `system/modules` abgelegt hast, alte Konfigurationen unter `system/config`,
-eine `config.yml` im Verzeichnis `config/` (bzw. **vor Contao 4.8** `app/config/`) oder Contao Anpassungen unter
-`contao/` (bzw. **vor Contao 4.8**  `app/Resources/contao/`) angelegt hast, müssen diese auch auf deinen Server
-übertragen werden.
+Die folgenden Dateien und Ordner sollten - sofern genutzt - vom Quell- zum Zielserver übertragen werden:
+
+- `config`  (bzw. **vor Contao 4.8** `app/config/`)
+- `contao`  (bzw. **vor Contao 4.8** `app/Resources/contao/`
+- `src`
+- `.env*`
+
+Falls du noch alte Erweiterungen unter `system/modules` abgelegt hast, alte Konfigurationen unter `system/config` angelegt hast, müssen diese auch auf deinen Server übertragen werden.
 
 Du kannst dazu entweder einen FTP-Client verwenden oder – falls du die Konsole bevorzugst – das Programm `scp`:
 

--- a/docs/manual/installation/move-contao.de.md
+++ b/docs/manual/installation/move-contao.de.md
@@ -93,7 +93,7 @@ Die folgenden Dateien und Ordner sollten - sofern genutzt - vom Quell- zum Ziels
 - `src`
 - `.env*`
 
-Falls du noch alte Erweiterungen unter `system/modules` abgelegt hast oder alte Konfigurationen unter `system/config` angelegt hast, müssen diese auch auf deinen Server übertragen werden.
+Falls du noch alte Erweiterungen unter `system/modules` oder alte Konfigurationen unter `system/config` angelegt hast, müssen diese auch auf deinen Server übertragen werden.
 
 Du kannst dazu entweder einen FTP-Client verwenden oder – falls du die Konsole bevorzugst – das Programm `scp`:
 

--- a/docs/manual/installation/move-contao.de.md
+++ b/docs/manual/installation/move-contao.de.md
@@ -77,28 +77,23 @@ Gib dein Passwort ein, wenn du danach gefragt wirst.
 {{< /tabs >}}
 
 
-## Einstellungen notieren
-Deine Einstellungen unter `System / Einstellungen` oder im Seitenroot notierst du dir am besten und trägst sie später erneut ein.
-
-{{% notice tip %}}
-Wenn du deine [Einstellungen in einer Umgebungsvariablen ablegst](https://docs.contao.org/manual/de/system/einstellungen/#umgebungsvariablen), entfällt dieser Schritt.
-{{% /notice %}} 
-
 ## Dateien übertragen
 Die folgenden Dateien und Ordner müssen vom Quell- zum Zielserver übertragen werden:
 
-- `files`
-- `templates`
-- `composer.json`
+- `files`                           (deine Dateien)
+- `templates`                       (angepasste templates)
+- `composer.json`                   (die gewünschten Abhängigkeiten)
+- `composer.lock`                   (die aktuell installierten Abhängigkeiten)
+- `system/config/localconfig.php`   (deine Einstellungen)
 
 Die folgenden Dateien und Ordner sollten - sofern genutzt - vom Quell- zum Zielserver übertragen werden:
 
-- `config`  (bzw. **vor Contao 4.8** `app/config/`)
+- `config`  (bzw. **vor Contao 4.8** `app/config/`)         
 - `contao`  (bzw. **vor Contao 4.8** `app/Resources/contao/`
 - `src`
 - `.env*`
 
-Falls du noch alte Erweiterungen unter `system/modules` abgelegt hast, alte Konfigurationen unter `system/config` angelegt hast, müssen diese auch auf deinen Server übertragen werden.
+Falls du noch alte Erweiterungen unter `system/modules` abgelegt hast oder alte Konfigurationen unter `system/config` angelegt hast, müssen diese auch auf deinen Server übertragen werden.
 
 Du kannst dazu entweder einen FTP-Client verwenden oder – falls du die Konsole bevorzugst – das Programm `scp`:
 

--- a/docs/manual/installation/move-contao.en.md
+++ b/docs/manual/installation/move-contao.en.md
@@ -74,14 +74,21 @@ Enter your database password if asked for.
 ## Transferring the files
 The following files and folders need to be transferred from the source to the target machine.
 
-- `files`
-- `templates`
-- `composer.json`
-- `composer.lock`
+- `files`                           (your files)
+- `templates`                       (your templates)
+- `composer.json`                   (wished dependencies)
+- `composer.lock`                   (actually installed dependencies)
+- `system/config/localconfig.php`   (your preferences)
 
-If you still have old extensions within `system/modules/` or if you have created a `config.yml` in the directory
-`config/` (or **before Contao 4.8** `app/config/`) or if you created Contao adjustments under `contao/` (or **before 
-Contao 4.8** `app/Resources/contao/`), then they have to be transferred as well.
+The following files and folders need to be transferred from the source to the target machine, if applicable.
+
+- `config`  (or **before Contao 4.8** `app/config/`)         
+- `contao`  (or **before Contao 4.8** `app/Resources/contao/`
+- `src`
+- `.env*`
+
+If you still have old extensions within `system/modules/` or if you have old configurations in the directory
+`system/config/`, then they have to be transferred as well.
 
 You can use an FTP client for this task or, if you prefer the command line, use `scp`:
 


### PR DESCRIPTION
composer.lock braucht nicht nach meiner Erfahrung. Weitere Ordner und Dateien machen ggf. Sinn.
Hinweis auf .env.