### PR TITLE
Fix typo in asset component package name to snake case

### DIFF
--- a/docs/dev/framework/asset-management.md
+++ b/docs/dev/framework/asset-management.md
@@ -230,9 +230,9 @@ There are several use cases of using the asset helper within Contao:
   of the asset component).
 
     - By default, a bundle does not have a version, so no version suffix is added. 
-      The asset component resolves `{{asset::foobar.min.js::fooexample}}` to `web/bundles/fooexample/foobar.min.js`.
+      The asset component resolves `{{asset::foobar.min.js::foo_example}}` to `web/bundles/fooexample/foobar.min.js`.
     - If the `public` folder has a `manifest.json` in its root, that file is used 
-      to generate a *manifest.json version strategy*. For `{{asset::foobar.js::fooexample}}` 
+      to generate a *manifest.json version strategy*. For `{{asset::foobar.js::foo_example}}` 
       the asset component will look up `foobar.js` in the `manifest.json` and output 
       that path. This is useful when using e.g. [Webpack Encore][WebpackEncore] 
       to generate the assets, as hashed file names are resolved to `web/bundles/fooexample/foobar-1ussdg71.js`.


### PR DESCRIPTION
https://github.com/contao/contao/blob/da29e67bce609711c1e1f358598613ff90cfe5f3/core-bundle/src/DependencyInjection/Compiler/AddAssetsPackagesPass.php#L166