### PR TITLE
Fix wrong method usage in Response Context docs

### DIFF
--- a/docs/dev/framework/response-context.md
+++ b/docs/dev/framework/response-context.md
@@ -149,7 +149,7 @@ use Spatie\SchemaOrg\ImageObject;
 $schemaManager = new JsonLdManager(new ResponseContext());
 
 // This is how you would access it from the current context (in case it exists)
-$schemaManager = $this->responseContextAccessor->getCurrentContext()->get(JsonLdManager::class);
+$schemaManager = $this->responseContextAccessor->getResponseContext()->get(JsonLdManager::class);
 
 // Get the graph for schema.org
 $graph = $schemaManager->getGraphForSchema(JsonLdManager::SCHEMA_ORG);


### PR DESCRIPTION
This PR change the method name from `getCurrentContext` to `getResponseContext` in JsonLd example code.