### PR TITLE
Update fields.md

### DIFF
--- a/docs/dev/reference/dca/fields.md
+++ b/docs/dev/reference/dca/fields.md
@@ -222,8 +222,8 @@ can be [registered using a hook][3].
 | folderalias | expects a valid folder URL alias                                                                                  |
 | phone       | expects a valid phone number (numeric characters, space [ ], plus [+], minus [-], parentheses [()] and slash [/]) |
 | prcnt       | allows numbers between 0 and 100                                                                                  |
-| locale      | expects a valid locale (e.g. "de-CH")                                                                             |
-| language    | expects a valid language code                                                                                     |
+| locale      | expects a valid locale (e.g. "de_CH")                                                                             |
+| language    | expects a valid language code (e.g. "de-CH")                                                                      |
 | google+     | expects a Google+ ID or vanity name                                                                               |
 | fieldname   | expects a valid field name (added in version 3.5.16 / 4.2.3)                                                      |
 | httpurl     | {{< version "4.11" >}} expects a valid absolute URL (beginning with `http://` or `https://`)                      |


### PR DESCRIPTION
Beim regulären Ausdruck `locale` stand als Beispiel `de-CH`, es müsste aber `de_CH` heißen (mit Unterstrich, nicht mit Minus). Ich habe zusätzlich das Beispiel für `language` ergänzt. Dort ist `de-CH` richtig.

Für `locale` wird in [Validator.php#L235](https://github.com/contao/contao/blob/5.x/core-bundle/contao/library/Contao/Validator.php#L235) der Ausdruck `/^[a-z]{2}(_[A-Z]{2})?$/` verwendet, also mit Unterstrich.

Für `language` wird in [Validator.php#L247](https://github.com/contao/contao/blob/5.x/core-bundle/contao/library/Contao/Validator.php#L247) der Ausdruck `/^[a-z]{2}(-[A-Z]{2})?$/` verwendet, also mit Minus.

Getestet habe ich es mit Contao 4.13, sollte in 5.1 aber genau so sein, da der Validator die selben Ausdrücke verwendet.