### PR TITLE
Clarify FAQ entry for `public-dir`

### DIFF
--- a/docs/manual/faq/_index.de.md
+++ b/docs/manual/faq/_index.de.md
@@ -83,9 +83,9 @@ Es handelt sich um einen Hinweis wie du den Strict Mode aktivieren kannst. Weite
 ## Konfiguration und Einstellung
 
 {{% expand "Kann ich das Verzeichnis »web« nach »public« ändern?" %}}
-Ja. Du mußt dazu das Verzeichnis umbenennen. Überprüfe ob in der »composer.json« der Eintrag `"public-dir": "web"` existiert 
-und entferne diesen. Starte anschließend über den Manager oder der Konsole `composer install`. Setze dann dieses Verzeichnis 
-als Document Root über das Admin-Panel deines Hosting-Providers.
+Ja. Du mußt dazu das Verzeichnis umbenennen. Überprüfe ob in der »composer.json« der Eintrag `"public-dir": "web"` existiert und entferne 
+diesen oder ändere den Eintrag auf `public`. Setze dann dieses Verzeichnis als Document Root über das Admin-Panel deines Hosting-Providers. 
+Starte anschließend über den Manager oder der Konsole `composer install`.
 {{% /expand %}}
 
 {{% expand "Wie kann ich den Contao Backend-Pfad ändern?" %}}

--- a/docs/manual/faq/_index.en.md
+++ b/docs/manual/faq/_index.en.md
@@ -81,7 +81,9 @@ This is a hint how to activate the strict mode. More information can be found [h
 ## Configuration and adjustment
 
 {{% expand "Can I change the directory »web« to »public«?" %}}
-Yes. You have to rename the directory. Check if the entry `"public-dir": "web"` exists in the "composer.json" and remove it. Then start `composer install` from the manager or the console. Set this directory as document root via the admin panel of your hosting provider.
+Yes. You have to rename the directory. Check if the entry `"public-dir": "web"` exists in the "composer.json" and remove it or change it to
+`public`. Then set this directory as the document root via the admin panel of your hosting provider. Afterwards execute `composer install` 
+from the manager or the console. 
 {{% /expand %}}
 
 {{% expand "How can I change the Contao backend path?" %}}


### PR DESCRIPTION
The current FAQ entry for changing the `public-dir` has an error: if you do not change the `DocumentRoot` before executing `composer install` you won't actually be able to execute `composer install` via the Contao Manager (as the Contao Manager would not be reachable).