### PR TITLE
Integrate the meta description

### DIFF
--- a/page/layouts/partials/meta.html
+++ b/page/layouts/partials/meta.html
@@ -1,3 +1,4 @@
 <meta name="docsearch:manualtype" content="{{ .Site.Params.algolia_selector }}{{ if eq .Site.Params.algolia_selector "manual" }}_{{ .Page.Language | default "en" }}{{ end }}">
 <link rel="preconnect" href="https://KDZKB9K935-dsn.algolia.net" crossorigin>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3">
+<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}">


### PR DESCRIPTION
We noticed on the Contao camp that the docs are currently delivered without a meta description (see https://github.com/contao/docs/issues/1196). The meta template overwrites the original meta template (see https://github.com/matcornic/hugo-theme-learn/blob/master/layouts/partials/meta.html), so I have added the description again (I don't know if it is possible to implement template inheritance in Hugo ;-)).