### PR TITLE
Feature/faq schema json ld

### DIFF
--- a/docs/manual/faq/_index.de.md
+++ b/docs/manual/faq/_index.de.md
@@ -15,42 +15,43 @@ deine Vorschläge hinzufügen kannst. Anschließend kannst du über GitHub einen
 
 
 ## Allgemein
+FRAGE
 
-{{% expand "Ich habe mein Administrator-Passwort vergessen, wie kann ich es zurücksetzen?" %}}
+{{% faq "Ich habe mein Administrator-Passwort vergessen, wie kann ich es zurücksetzen?" %}}
 Falls es in der Datenbank-Tabelle »tl_user« mehrere Datensätze gibt, bei denen das Admin-Flag gesetzt ist, kannst du den Wert 
 zunächst bei allen zurücksetzen, um anschließend im Contao [Install-Tool](/de/installation/contao-installtool/) 
 einen neuen Administrator anzulegen.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Ich habe das Install-Tool Passwort vergessen, wie kann ich es zurücksetzen?" %}}
+{{% faq "Ich habe das Install-Tool Passwort vergessen, wie kann ich es zurücksetzen?" %}}
 Entferne in der Datei »system/config/localconfig.php« die Zeile beginnend mit `$GLOBALS['TL_CONFIG']['installPassword']`
 vollständig. Anschließend kannst du über das [Install-Tool](/de/installation/contao-installtool/) ein neues Passwort vergeben.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Kann ich mit Contao mehrere Webseiten pflegen?" %}}
+{{% faq "Kann ich mit Contao mehrere Webseiten pflegen?" %}}
 Ja. Contao unterstützt den [Multidomain-Betrieb](/de/layout/seitenstruktur/multidomain-betrieb/) und 
 [Mehrsprachige Webseiten](/de/layout/seitenstruktur/mehrsprachige-webseiten/).
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Kann ich mit Contao »Mehrsprachige Webseiten« pflegen?" %}}
+{{% faq "Kann ich mit Contao »Mehrsprachige Webseiten« pflegen?" %}}
 Ja. Contao unterstützt [Mehrsprachige Webseiten](/de/layout/seitenstruktur/mehrsprachige-webseiten/).
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Wie aktiviere ich den Contao Debug-Modus?" %}}
+{{% faq "Wie aktiviere ich den Contao Debug-Modus?" %}}
 Du kannst den [Contao Debug-Modus](/de/system/debug-modus/) über das Backend aktivieren.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Wo finde ich weitere Contao-Ressourcen?" %}}
+{{% faq "Wo finde ich weitere Contao-Ressourcen?" %}}
 Weitere Contao-Ressourcen findest du auf der [Projektwebseite](https://contao.org/de/netzwerk.html).
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Darf ich Contao für kommerzielle Projekte verwenden?" %}}
+{{% faq "Darf ich Contao für kommerzielle Projekte verwenden?" %}}
 Ja, die [GNU Lesser General Public License](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html) (LGPL), unter der 
 Contao seit der Version 2.5 lizenziert ist, erlaubt die Verwendung des Systems für kommerzielle Projekte. Beachte jedoch, 
 dass die Copyright-Hinweise in den Contao-Dateien gemäß den Lizenzbedingungen nicht entfernt oder verändert werden dürfen.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Wie kann ich über die Konsole den »Anwendungs-Cache« erneuern?" %}}
+{{% faq "Wie kann ich über die Konsole den »Anwendungs-Cache« erneuern?" %}}
 Falls du den »Anwendungs-Cache« erneuern möchtest kannst du dies über die 
 [Konsole](https://docs.contao.org/dev/reference/commands/) durchführen: 
 
@@ -58,37 +59,37 @@ Falls du den »Anwendungs-Cache« erneuern möchtest kannst du dies über die
 vendor/bin/contao-console cache:clear --no-warmup
 vendor/bin/contao-console cache:warmup
 ```
-{{% /expand %}}
+{{% /faq %}}
 
 
 ## Template
 
-{{% expand "Wie kann ich alle Variablen meines Templates anzeigen?" %}}
+{{% faq "Wie kann ich alle Variablen meines Templates anzeigen?" %}}
 Die Information hierzu findest du unter [Template-Daten anzeigen](/de/layout/templates/php/data/).
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Wie kann ich den TinyMCE-Editor konfigurieren?" %}}
+{{% faq "Wie kann ich den TinyMCE-Editor konfigurieren?" %}}
 Die Information hierzu findest du unter [TinyMCE-Editor Konfiguration](/de/anleitungen/tinymce-konfiguration/).
-{{% /expand %}}
+{{% /faq %}}
 
 
 ## Installation
 
-{{% expand "Meldung: Ihr Datenbank-Server läuft nicht im Strict-Mode!" %}}
+{{% faq "Meldung: Ihr Datenbank-Server läuft nicht im Strict-Mode!" %}}
 Es handelt sich um einen Hinweis wie du den Strict Mode aktivieren kannst. Weitere Informationen findest du 
 [hier](../installation/systemvoraussetzungen/#mysql-mindestanforderungen).
-{{% /expand %}}
+{{% /faq %}}
 
 
 ## Konfiguration und Einstellung
 
-{{% expand "Kann ich das Verzeichnis »web« nach »public« ändern?" %}}
+{{% faq "Kann ich das Verzeichnis »web« nach »public« ändern?" %}}
 Ja. Du mußt dazu das Verzeichnis umbenennen. Überprüfe ob in der »composer.json« der Eintrag `"public-dir": "web"` existiert und entferne 
 diesen oder ändere den Eintrag auf `public`. Setze dann dieses Verzeichnis als Document Root über das Admin-Panel deines Hosting-Providers. 
 Starte anschließend über den Manager oder der Konsole `composer install`.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Wie kann ich den Contao Backend-Pfad ändern?" %}}
+{{% faq "Wie kann ich den Contao Backend-Pfad ändern?" %}}
 {{< version-tag "4.13" >}} Du kannst in der [config.yml](/de/system/einstellungen/#config-yml) den Eintrag `route_prefix` hinzufügen.
 Anschließend musst du über den Contao-Manager (»Systemwartung« > »Prod.-Cache erneuern«) oder über die Konsole 
 einmalig den Anwendungs-Cache leeren.
@@ -99,22 +100,22 @@ contao:
     backend:
         route_prefix: '/myadmin'
 ```
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Es wird keine E-Mail über mein Formular versendet, was muss ich machen?" %}}
+{{% faq "Es wird keine E-Mail über mein Formular versendet, was muss ich machen?" %}}
 Überprüfe in der `parameters.yml` die [SMTP-Angaben](/de/system/einstellungen/#e-mail-versand-konfiguration) deines Hosters oder 
 füge diese hinzu. Anschließend musst du über den Contao-Manager (»Systemwartung« > »Prod.-Cache erneuern«) oder über die 
 Konsole einmalig den Anwendungs-Cache leeren.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Kann ich eine andere E-Mail-Adresse als Absender für Formulare benutzen?" %}}
+{{% faq "Kann ich eine andere E-Mail-Adresse als Absender für Formulare benutzen?" %}}
 Die im Bereich »Einstellungen > E-Mail-Adresse des Systemadministrators« gesetzte E-Mail-Adresse wird u. a. auch als
 Absender für Formulare herangezogen. Du kannst im Bereich »Seitenstruktur« für den Seitentyp »Startpunkt einer Webseite«
 eine zusätzliche E-Mail-Adresse eintragen. Anschließend wird diese dann als Absender genutzt.
 Ab Contao 4.10 kannst du dies [konfigurieren](/de/system/einstellungen/#verschiedene-e-mail-konfigurationen-und-absenderadressen).
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Wie kann ich das Sprachkürzel der URL hinzufügen?" %}}
+{{% faq "Wie kann ich das Sprachkürzel der URL hinzufügen?" %}}
 Du kannst in der [config.yml](/de/system/einstellungen/#config-yml) den Eintrag `prepend_locale: true` hinzufügen.
 Anschließend musst du über den Contao-Manager (»Systemwartung« > »Prod.-Cache erneuern«) oder über die Konsole 
 einmalig den Anwendungs-Cache leeren.
@@ -124,9 +125,9 @@ einmalig den Anwendungs-Cache leeren.
 contao:
     prepend_locale: true
 ```
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Kann man die URL Suffix ».html« entfernen?" %}}
+{{% faq "Kann man die URL Suffix ».html« entfernen?" %}}
 Du kannst in der [config.yml](/de/system/einstellungen/#config-yml) den Eintrag `url_suffix: ''` hinzufügen. 
 Anschließend musst du über den Contao-Manager (»Systemwartung« > »Prod.-Cache erneuern«) oder über die Konsole 
 einmalig den Anwendungs-Cache leeren.
@@ -136,73 +137,73 @@ einmalig den Anwendungs-Cache leeren.
 contao:
     url_suffix: ''
 ```
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Warum werden meine HTML-Angaben im TinyMCE-Editor nicht übernommen?" %}}
+{{% faq "Warum werden meine HTML-Angaben im TinyMCE-Editor nicht übernommen?" %}}
 Antworten findest du im Bereich [TinyMCE-Editor Konfiguration](/de/anleitungen/tinymce-konfiguration/).
-{{% /expand %}}
+{{% /faq %}}
 
 ## Dateiverwaltung
 
-{{% expand "Meine Bilder werden im Frontend nicht angezeigt, was kann ich machen?" %}}
+{{% faq "Meine Bilder werden im Frontend nicht angezeigt, was kann ich machen?" %}}
 Überprüfe in der [Dateiverwaltung](/de/dateiverwaltung/), ob das Verzeichnis mit deinen Bildern als »Öffentlich« 
 gekennzeichnet ist.
 Stelle außerdem sicher, dass sich keine veraltete `.htaccess` Datei im Order `/web` oder einem übergeordneten Ordner deiner Installation befindet.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Kann man die Suche in der Dateiverwaltung ausblenden?" %}}
+{{% faq "Kann man die Suche in der Dateiverwaltung ausblenden?" %}}
 Ja. Über einen DCA-Eintrag:
 
 ```php
     //contao/dca/tl_files.php
     unset($GLOBALS['TL_DCA']['tl_files']['list']['sorting']['panelLayout']);
 ```
-{{% /expand %}}
+{{% /faq %}}
 
 
 ## Theme
 
-{{% expand "Warum werden Änderungen an meinen SCSS-Dateien nicht übernommen?" %}}
+{{% faq "Warum werden Änderungen an meinen SCSS-Dateien nicht übernommen?" %}}
 Bei Änderungen an einer [SCSS Partial-Datei](/de/anleitungen/sass-less-integration#hinweis-i-umgang-mit-partials) musst 
 du im Anschluss in der »Systemwartung« den Scriptcache leeren.
-{{% /expand %}}
+{{% /faq %}}
 
 
 ## Contao Manager
 
-{{% expand "Wozu benötige ich den Contao Manager?" %}}
+{{% faq "Wozu benötige ich den Contao Manager?" %}}
 Du benötigst den Contao Manager, um Contao und Erweiterung zu installieren/aktualisieren/deinstallieren. Weiterführende Informationen findest du unter [Über den Contao Manager](/de/installation/contao-manager/).
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Kann ich den Contao Manager einer bestehenden Installation hinzufügen?" %}}
+{{% faq "Kann ich den Contao Manager einer bestehenden Installation hinzufügen?" %}}
 Ja, der [Contao Manager](/de/installation/contao-manager/#kann-der-contao-manager-zu-einer-bestehenden-installation-hinzugefuegt-werden) 
 erkennt bei der Installation deine bestehende Contao Installation.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Wie kann man den Contao Manager aktualisieren?" %}}
+{{% faq "Wie kann man den Contao Manager aktualisieren?" %}}
 Der [Contao Manager](/de/installation/contao-manager/#haeufige-fragen-zum-contao-manager) führt beim Aufruf automatisch 
 im Hintergrund eine Prüfung durch. Sollte eine neue Version verfügbar sein, aktualisiert sich der Contao Manager selbst.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Was ist die Composer Resolver Cloud?" %}}
+{{% faq "Was ist die Composer Resolver Cloud?" %}}
 Die [Composer Resolver Cloud](https://composer-resolver.cloud/) erlaubt die Installation von Composer-Abhängigkeiten 
 über den [Contao Manager](/de/installation/contao-manager/), selbst wenn dein Server nicht über genug Arbeitsspeicher verfügt.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Wie kann ich über den Contao-Manager den »Anwendungs-Cache« erneuern?" %}}
+{{% faq "Wie kann ich über den Contao-Manager den »Anwendungs-Cache« erneuern?" %}}
 Falls du den »Anwendungs-Cache« erneuern möchtest kannst du dies im [Contao Manager](/de/installation/contao-manager/) 
 im Bereich »Systemwartung/Anwendungs-Cache« durchführen.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Der Contao Manager hat sich »aufgehangen«" %}}
+{{% faq "Der Contao Manager hat sich »aufgehangen«" %}}
 Sollte es vorkommen, dass der Contao Manager nicht mehr reagiert, das Fenster der Konsolenausgabe sich nicht schließen lässt
 oder nach einem Reload der Manager-Seite man immer wieder zur selben Ausgabe kommt, lösche im Verzeichnis `contao-manager`
 die Datei `task.json`.
 
 Anschließend sollte der Contao Manager wieder laufen.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Kann ich die ».phar« Datei umbenennen?" %}}
+{{% faq "Kann ich die ».phar« Datei umbenennen?" %}}
 Ja. Du kannst einen beliebigen Dateinamen verwenden. Allerdings ist der Contao Manager dann nicht mehr über das Backend erreichbar.
 In diesem Fall kannst du die [config.yml](/de/system/einstellungen/#config-yml) entsprechend anpassen. Anschließend musst du über den 
 Contao Manager (»Systemwartung« > »Prod.-Cache erneuern«) oder über die Konsole einmalig den Anwendungs-Cache leeren.
@@ -212,4 +213,4 @@ Contao Manager (»Systemwartung« > »Prod.-Cache erneuern«) oder über die Kon
 contao_manager:
     manager_path: dein-name.phar.php
 ```
-{{% /expand %}}
+{{% /faq %}}

--- a/docs/manual/faq/_index.de.md
+++ b/docs/manual/faq/_index.de.md
@@ -15,7 +15,6 @@ deine Vorschläge hinzufügen kannst. Anschließend kannst du über GitHub einen
 
 
 ## Allgemein
-FRAGE
 
 {{% faq "Ich habe mein Administrator-Passwort vergessen, wie kann ich es zurücksetzen?" %}}
 Falls es in der Datenbank-Tabelle »tl_user« mehrere Datensätze gibt, bei denen das Admin-Flag gesetzt ist, kannst du den Wert 

--- a/docs/manual/faq/_index.en.md
+++ b/docs/manual/faq/_index.en.md
@@ -15,40 +15,40 @@ You can then use GitHub to create a pull request.
 
 ## General
 
-{{% expand "I have forgotten my administrator password, how can I reset it?" %}}
+{{% faq "I have forgotten my administrator password, how can I reset it?" %}}
 If there are multiple records in the database table "tl_user" for which the admin flag is set, you can reset the first 
 value for all of them to create a new administrator in the Contao [install toolbar](/en/installation/contao-installtool/).
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "I have forgotten the Install Tool password, how can I reset it?" %}}
+{{% faq "I have forgotten the Install Tool password, how can I reset it?" %}}
 Remove the line in the file "system/config/localconfig.php" starting with `$GLOBALS['TL_CONFIG']['installPassword']`. 
 Afterwards you can set a new password with the [Install-Tool](/en/installation/contao-installtool/).
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Can I maintain multiple websites with Contao?" %}}
+{{% faq "Can I maintain multiple websites with Contao?" %}}
 Yes Contao supports [multi-domain operation](/en/layout/site-structure/multi-domain-operation/) and 
 multilingual [websites](/en/layout/site-structure/multilingual-websites/).
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Can I maintain multilingual websites with Contao?" %}}
+{{% faq "Can I maintain multilingual websites with Contao?" %}}
 Yes Contao supports [multilingual websites](/en/layout/site-structure/multilingual-websites/).
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "How do I enable the Contao debug mode?" %}}
+{{% faq "How do I enable the Contao debug mode?" %}}
 You can activate the [Contao debug mode](/en/system/debug-mode/) via the backend.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Where can I find more Contao resources?" %}}
+{{% faq "Where can I find more Contao resources?" %}}
 You can find more Contao resources on the [project website](https://contao.org/en/network.html).
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "May I use Contao for commercial projects?" %}}
+{{% faq "May I use Contao for commercial projects?" %}}
 Yes, the [GNU Lesser General Public License](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html) (LGPL), 
 under which Contao has been licensed since version 2.5, allows you to use the system for commercial projects. 
 Please note that the copyright notices in the Contao files may not be removed or changed according to the license terms.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "How can I refresh the »Application Cache« from the console?" %}}
+{{% faq "How can I refresh the »Application Cache« from the console?" %}}
 If you want to refresh the »Application Cache« you can do this via the 
 [Console](https://docs.contao.org/dev/reference/commands/): 
 
@@ -56,37 +56,37 @@ If you want to refresh the »Application Cache« you can do this via the
 vendor/bin/contao-console cache:clear --no-warmup
 vendor/bin/contao-console cache:warmup
 ```
-{{% /expand %}}
+{{% /faq %}}
 
 
 
 ## Template
 
-{{% expand "How can I display all variables of my template?" %}}
+{{% faq "How can I display all variables of my template?" %}}
 The information about this can be found under [Show Template Data](/en/layout/templates/php/template-data/).
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "How can I configure the TinyMCE editor?" %}}
+{{% faq "How can I configure the TinyMCE editor?" %}}
 The information about this can be found under [TinyMCE Editor Configuration](/en/guides/tinymce-configuration/).
-{{% /expand %}}
+{{% /faq %}}
 
 
 ## Installation
 
-{{% expand "Notification: The database server is not running in strict mode!" %}}
+{{% faq "Notification: The database server is not running in strict mode!" %}}
 This is a hint how to activate the strict mode. More information can be found [here](../installation/system-requirements/).
-{{% /expand %}}
+{{% /faq %}}
 
 
 ## Configuration and adjustment
 
-{{% expand "Can I change the directory »web« to »public«?" %}}
+{{% faq "Can I change the directory »web« to »public«?" %}}
 Yes. You have to rename the directory. Check if the entry `"public-dir": "web"` exists in the "composer.json" and remove it or change it to
 `public`. Then set this directory as the document root via the admin panel of your hosting provider. Afterwards execute `composer install` 
 from the manager or the console. 
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "How can I change the Contao backend path?" %}}
+{{% faq "How can I change the Contao backend path?" %}}
 {{< version-tag "4.13" >}} You can add the entry `route_prefix` in config.yml and then you have to empty the application cache once using the Contao Manager or the console.
 
 ```yml
@@ -95,22 +95,22 @@ contao:
     backend:
         route_prefix: '/myadmin'
 ```
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "No e-mail is sent via my Form, what do I have to do?" %}}
+{{% faq "No e-mail is sent via my Form, what do I have to do?" %}}
 Check the [SMTP details](/en/system/settings/#e-mail-sending-configuration) of your hoster in your `parameters.yml` or add them if missing.
 Then you have to empty the application cache once via Contao Manager ("Maintenance" &gt; "Application Cache" &gt; "Rebuild Production Cache") 
 or via the console.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Can I use a different e-mail Address as sender for forms?" %}}
+{{% faq "Can I use a different e-mail Address as sender for forms?" %}}
 The e-mail address set in "Settings &gt; E-mail address of the system administrator" is also used as the sender for e-mails sent by the form generator. 
 You can enter an additional e-mail address in the "Site structure" section for the "Starting point of a website" page type. 
 This E-Mail address will then be used as the sender.
 Since Contao 4.10 you can [set different e-mail configurations](/en/system/settings/#different-e-mail-configurations-and-sender-addresses) per website starting point, form and newsletter channel.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "How can I add the language parameter to the URL?" %}}
+{{% faq "How can I add the language parameter to the URL?" %}}
 You can add the entry `prepend_locale: true` in [config.yml](/en/system/settings/#config-yml) and then you have to 
 empty the application cache once using the Contao Manager ("Maintenance" &gt; "Application Cache" &gt; "Rebuild Production Cache") or the console.
 Since Contao 4.10, you can freely define the URL prefix, independently of the language.
@@ -119,9 +119,9 @@ Since Contao 4.10, you can freely define the URL prefix, independently of the la
 contao:
     prepend_locale: true
 ```
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Can the URL suffix .html be removed?" %}}
+{{% faq "Can the URL suffix .html be removed?" %}}
 You can add the entry `url_suffix: ''` in [config.yml](/en/system/settings/#config-yml) and then you have to 
 empty the application cache once using the Contao Manager ("Maintenance" &gt; "Application Cache" &gt; "Rebuild Production Cache") or the console. 
 ```yml
@@ -129,73 +129,73 @@ empty the application cache once using the Contao Manager ("Maintenance" &gt; "A
 contao:
     url_suffix: ''
 ```
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Why is my HTML code not applied in the TinyMCE editor?" %}}
+{{% faq "Why is my HTML code not applied in the TinyMCE editor?" %}}
 Answers can be found in the [TinyMCE Editor Configuration](/en/guides/tinymce-configuration/) section.
-{{% /expand %}}
+{{% /faq %}}
 
 
 ## File management
 
-{{% expand "My pictures are not displayed in the frontend, what can I do?" %}}
+{{% faq "My pictures are not displayed in the frontend, what can I do?" %}}
 Check in the [file manager](/en/file-manager/) if the directory with your images is marked as "Public". Also make sure that there is no outdated `.htaccess` file in the `/web` folder or a parent folder of your installation.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Is it possible to hide the search in the file manager?" %}}
+{{% faq "Is it possible to hide the search in the file manager?" %}}
 Yes. Via a DCA entry:
 
 ```php
     //contao/dca/tl_files.php
     unset($GLOBALS['TL_DCA']['tl_files']['list']['sorting']['panelLayout']);
 ```
-{{% /expand %}}
+{{% /faq %}}
 
 
 ## Theme
 
-{{% expand "Why are changes to my SCSS files not applied?" %}}
+{{% faq "Why are changes to my SCSS files not applied?" %}}
 If you make changes to a [SCSS partial file](/en/guides/sass-less-integration/), 
 you must then empty the script cache in "System Maintenance". 
-{{% /expand %}}
+{{% /faq %}}
 
 
 ## Contao Manager
 
-{{% expand "Why do I need the Contao Manager?" %}}
+{{% faq "Why do I need the Contao Manager?" %}}
 You need the Contao Manager to install/upgrade/uninstall Contao and extensions. You can find more information 
 under [About Contao Manager](/en/installation/contao-manager/).
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Can I add the Contao Manager to an existing installation?" %}}
+{{% faq "Can I add the Contao Manager to an existing installation?" %}}
 Yes, the [Contao Manager recognizes](/en/installation/contao-manager/#can-contao-manager-be-added-to-an-existing-installation) 
 your existing Contao installation during the installation process. 
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "How to update the Contao Manager?" %}}
+{{% faq "How to update the Contao Manager?" %}}
 The [Contao Manager](/en/installation/contao-manager/#how-to-update-the-contao-manager) automatically performs 
 an update check when it is accessed. If a new version is available, Contao Manager will update itself.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "What is the Composer Resolver Cloud?" %}}
+{{% faq "What is the Composer Resolver Cloud?" %}}
 The [Composer Resolver Cloud](https://composer-resolver.cloud/) allows you to install Composer dependencies 
 via the [Contao Manager](/en/installation/contao-manager/) even if your server does not have enough memory.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "How can I renew the »Application Cache« via Contao Manager?" %}}
+{{% faq "How can I renew the »Application Cache« via Contao Manager?" %}}
 If you want to refresh the »Application Cache« you can do this in the 
 [Contao Manager](/en/installation/contao-manager/) »Maintenance/Application Cache« area.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "The Contao Manager has hung up" %}}
+{{% faq "The Contao Manager has hung up" %}}
 If the Contao Manager stops responding, the console output window does not close, or after a reload of the manager page
 or after a reload of the manager page you always get the same output, delete the file `contao-manager` in the directory `task.json`.
 delete the file `task.json`.
 
 After that, the Contao Manager should run again.
-{{% /expand %}}
+{{% /faq %}}
 
-{{% expand "Can I rename the ».phar« file?" %}}
+{{% faq "Can I rename the ».phar« file?" %}}
 Yes. You can use any file name you want. However, the Contao Manager is no longer accessible from the Backend. 
 In this case, you can change the [config.yml](/en/system/settings/#config-yml) accordingly. Afterwards, you have to empty the application cache 
 once using the Contao Manager ("Maintenance" &gt; "Application Cache" &gt; "Rebuild Production Cache") or the console.
@@ -204,4 +204,4 @@ once using the Contao Manager ("Maintenance" &gt; "Application Cache" &gt; "Rebu
 contao_manager:
     manager_path: your-name.phar.php
 ```
-{{% /expand %}}
+{{% /faq %}}

--- a/page/layouts/shortcodes/faq.html
+++ b/page/layouts/shortcodes/faq.html
@@ -34,4 +34,4 @@
         }
       }]
     }
-    </script>
+</script>

--- a/page/layouts/shortcodes/faq.html
+++ b/page/layouts/shortcodes/faq.html
@@ -1,0 +1,37 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+<div class="expand">
+    <div class="expand-label" style="cursor: pointer;" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fas fa-chevron-down' : 'fas fa-chevron-right';});});">
+        <i style="font-size:x-small;" class="fas fa-chevron-right"></i>
+        <span>
+        {{$expandMessage := T "Expand-title"}}
+    	{{ if .IsNamedParams }}
+    	{{.Get "default" | default $expandMessage}}
+    	{{else}}
+    	{{.Get 0 | default $expandMessage}}
+    	{{end}}
+    	</span>
+    </div>
+    <div class="expand-content" style="display: none;">
+        {{.Inner | safeHTML}}
+    </div>
+</div>
+
+<script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [{
+        "@type": "Question",
+        "name": "{{$expandMessage := T "Expand-title"}}
+            {{ if .IsNamedParams }}
+            {{.Get "default" | default $expandMessage}}
+            {{else}}
+            {{.Get 0 | default $expandMessage}}
+    	{{end}}",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "{{.Inner | safeHTML}}"
+        }
+      }]
+    }
+    </script>

--- a/page/layouts/shortcodes/faq.html
+++ b/page/layouts/shortcodes/faq.html
@@ -22,12 +22,7 @@
       "@type": "FAQPage",
       "mainEntity": [{
         "@type": "Question",
-        "name": "{{$expandMessage := T "Expand-title"}}
-            {{ if .IsNamedParams }}
-            {{.Get "default" | default $expandMessage}}
-            {{else}}
-            {{.Get 0 | default $expandMessage}}
-    	    {{end}}",
+        "name": "{{$expandMessage := T "Expand-title"}}{{ if .IsNamedParams }}{{.Get "default" | default $expandMessage}}{{else}}{{.Get 0 | default $expandMessage}}{{end}}",
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "{{.Inner | safeHTML}}"

--- a/page/layouts/shortcodes/faq.html
+++ b/page/layouts/shortcodes/faq.html
@@ -27,7 +27,7 @@
             {{.Get "default" | default $expandMessage}}
             {{else}}
             {{.Get 0 | default $expandMessage}}
-    	{{end}}",
+    	    {{end}}",
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "{{.Inner | safeHTML}}"


### PR DESCRIPTION
This adds a shortcode `faq.html` which replaces the `expand.html`.
It contains markup for faq schema in the JSON-LD format.

Though I am looking for a better approach to not have an independet faq schema on each shortcode, but to build a list of FAQs together in a single schema notation.
