### PR TITLE
Update setNewPassword.md

### DIFF
--- a/docs/dev/reference/hooks/setNewPassword.md
+++ b/docs/dev/reference/hooks/setNewPassword.md
@@ -54,5 +54,5 @@ class SetNewPasswordListener
 ## References
 
 * [\tl_member#L537-L544](https://github.com/contao/contao/blob/4.7.6/core-bundle/src/Resources/contao/dca/tl_member.php#L537-L544)
-* [\Contao\ModuleChangePassword.php#L178-L186](https://github.com/contao/contao/blob/4.7.6/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php#L178-L1866)
+* [\Contao\ModuleChangePassword.php#L178-L186](https://github.com/contao/contao/blob/4.7.6/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php#L178-L186)
 * [\Contao\ModulePassword#L266-L274](https://github.com/contao/contao/blob/4.7.6/core-bundle/src/Resources/contao/modules/ModulePassword.php#L266-L274)


### PR DESCRIPTION
Falsche Zeilenangabe im Link zur Referenz \Contao\ModuleChangePassword.php#L178-L186 verbessert. Statt 1866 muss es 186 heißen.