### PR TITLE
Update maintenance-template.de.md

### DIFF
--- a/docs/manual/guides/maintenance-template.de.md
+++ b/docs/manual/guides/maintenance-template.de.md
@@ -89,7 +89,7 @@ WICHTIG: Alle Änderungen wirken sich sowohl beim Wartungstemplate als auch auf 
 
 Das machen wir in diesem Beispiel für alle Errortemplates. Für eine updatesichere Anpassung kopieren wir uns das Originaltemplate `vendor/contao/core-bundle/src/Resources/views/Error/layout.html.twig` nach `/templates/bundles/ContaoCoreBundle/Error/`
 
-In Contao 5.1 befindet sich das Originaltemplate unter `vendor/contao/core-bundle/templates/Error/layout.html.twig`
+{{< version-tag "5.1" >}} befindet sich das Originaltemplate unter `vendor/contao/core-bundle/templates/Error/layout.html.twig`
 
 Dort setzen wir unser eigenes Logo innerhalb des DIV's mit der Klasse `header-logo` ein. Du kannst dafür ein normales image-Tag verwenden oder wie im Originaltemplate ein Inline-SVG.
 

--- a/docs/manual/guides/maintenance-template.de.md
+++ b/docs/manual/guides/maintenance-template.de.md
@@ -89,6 +89,8 @@ WICHTIG: Alle Änderungen wirken sich sowohl beim Wartungstemplate als auch auf 
 
 Das machen wir in diesem Beispiel für alle Errortemplates. Für eine updatesichere Anpassung kopieren wir uns das Originaltemplate `vendor/contao/core-bundle/src/Resources/views/Error/layout.html.twig` nach `/templates/bundles/ContaoCoreBundle/Error/`
 
+In Contao 5.1 befindet sich das Originaltemplate unter `vendor/contao/core-bundle/templates/Error/layout.html.twig`
+
 Dort setzen wir unser eigenes Logo innerhalb des DIV's mit der Klasse `header-logo` ein. Du kannst dafür ein normales image-Tag verwenden oder wie im Originaltemplate ein Inline-SVG.
 
 Beispiel für ein angepasstes Logo:


### PR DESCRIPTION
Add note about different template path in Contao 5.1.
Apparently the path has changed since 4.9 which is mentioned explicitly in this document.