### PR TITLE
Update callbacks.md

### DIFF
--- a/docs/dev/reference/dca/callbacks.md
+++ b/docs/dev/reference/dca/callbacks.md
@@ -626,7 +626,7 @@ class ExampleListOperationListener
     )
     {}
 
-    public function onButtonCallback(
+    public function __invoke(
         array $row,
         ?string $href,
         string $label,

--- a/docs/dev/reference/dca/callbacks.md
+++ b/docs/dev/reference/dca/callbacks.md
@@ -626,7 +626,7 @@ class ExampleListOperationListener
     )
     {}
 
-    public function onListCustomOperationCallback(
+    public function onButtonCallback(
         array $row,
         ?string $href,
         string $label,


### PR DESCRIPTION
If you try to use "onListCustomOperationCallback" as Function name, you will get the error message:

"The contao.callback definition for service XXX is invalid. Either specify a method name or implement the "onButtonCallback" or __invoke method."

Maybe this should be changed.