### PR TITLE
Update compileDefinition.md

### DIFF
--- a/docs/dev/reference/hooks/compileDefinition.md
+++ b/docs/dev/reference/hooks/compileDefinition.md
@@ -12,6 +12,9 @@ The `compileDefinition` hook is triggered when a format definition of an interna
 style sheet is written. It passes the database record of the style definition as 
 an array and expects a string as return value.
 
+{{% notice info %}}
+Using the `sendNewsletter` hook has been deprecated and will no longer work in Contao 5.0.
+{{% /notice %}}
 
 ## Parameters
 

--- a/docs/dev/reference/hooks/compileDefinition.md
+++ b/docs/dev/reference/hooks/compileDefinition.md
@@ -13,7 +13,7 @@ style sheet is written. It passes the database record of the style definition as
 an array and expects a string as return value.
 
 {{% notice info %}}
-Using the `sendNewsletter` hook has been deprecated and will no longer work in Contao 5.0.
+Using the `compileDefinition` hook has been deprecated and will no longer work in Contao 5.0. There is no replacement as the internal stylesheet functionality has been removed in Contao 5.0.
 {{% /notice %}}
 
 ## Parameters


### PR DESCRIPTION
Hinweis eingefügt, dass es den Hook unter Contao 5 nicht mehr gibt.