### PR TITLE
Update template-data.de.md

### DIFF
--- a/docs/manual/layout/templates/php/template-data.de.md
+++ b/docs/manual/layout/templates/php/template-data.de.md
@@ -1,13 +1,13 @@
 ---
-title: "Template Variablen anzeigen"
-description: "Alle Template Variablen / Template Daten anzeigen."
+title: "Template-Variablen anzeigen"
+description: "Alle Template-Variablen bzw. Template-Daten anzeigen."
 url: "layout/templates/php/data"
 aliases:
     - /de/layout/templates/php/data/
 weight: 60
 ---
 
-Die verfügbaren Daten im Template (die Template Variablen) variieren je nach Quelle der Vorlage. In der Regel ist der vollständige 
+Die verfügbaren Daten im Template (die Template-Variablen) variieren je nach Quelle der Vorlage. In der Regel ist der vollständige 
 Datensatz der im Template verfügbaren Variablen über die Angabe von `$this->…` erreichbar.
 
 Du kannst dir alle verfügbaren Variablen eines Templates anzeigen lassen: 
@@ -17,10 +17,10 @@ Du kannst dir alle verfügbaren Variablen eines Templates anzeigen lassen:
 ```
 
 Die Anweisung verwendet die [Symfony VarDumper-Komponente](https://symfony.com/doc/current/components/var_dumper.html) 
-zur Anzeige der Template Variablen – im Debug-Modus wird die Ausgabe dabei an die Symfony Debug Toolbar umgeleitet.  
+zur Anzeige der Template-Variablen – im Debug-Modus wird die Ausgabe dabei an die Symfony Debug Toolbar umgeleitet.  
 
 {{% notice info %}}
-Falls du [Template-Vererbung]({{< ref "template-inheritance.de.md" >}}) nutzt, wird der Auszug der Template Variablen nur im 
+Falls du [Template-Vererbung]({{< ref "template-inheritance.de.md" >}}) nutzt, wird der Auszug der Template-Variablen nur im 
 [Debug-Modus]({{< ref "debug-mode.de.md" >}}) angezeigt oder wenn sich die Anweisung zwischen `$this->block(…)` und
 `$this->endblock()` befindet.
 {{% /notice %}}

--- a/docs/manual/layout/templates/php/template-data.de.md
+++ b/docs/manual/layout/templates/php/template-data.de.md
@@ -1,26 +1,26 @@
 ---
-title: "Template-Daten anzeigen"
-description: "Alle Template-Daten anzeigen."
+title: "Template Variablen anzeigen"
+description: "Alle Template Variablen / Template Daten anzeigen."
 url: "layout/templates/php/data"
 aliases:
     - /de/layout/templates/php/data/
 weight: 60
 ---
 
-Die verfügbaren Template-Daten variieren je nach Quelle der Vorlage. In der Regel ist der vollständige 
-Datensatz im Template über die Angabe von `$this->…` erreichbar.
+Die verfügbaren Daten im Template (die Template Variablen) variieren je nach Quelle der Vorlage. In der Regel ist der vollständige 
+Datensatz der im Template verfügbaren Variablen über die Angabe von `$this->…` erreichbar.
 
-Du kannst dir alle verfügbaren Daten eines Templates anzeigen lassen: 
+Du kannst dir alle verfügbaren Variablen eines Templates anzeigen lassen: 
 
 ```php
 <?php $this->dumpTemplateVars() ?>
 ```
 
 Die Anweisung verwendet die [Symfony VarDumper-Komponente](https://symfony.com/doc/current/components/var_dumper.html) 
-zur Anzeige der Template-Daten – im Debug-Modus wird die Ausgabe dabei an die Symfony Debug Toolbar umgeleitet.  
+zur Anzeige der Template Variablen – im Debug-Modus wird die Ausgabe dabei an die Symfony Debug Toolbar umgeleitet.  
 
 {{% notice info %}}
-Falls du [Template-Vererbung]({{< ref "template-inheritance.de.md" >}}) nutzt, wird der Auszug der Template-Daten nur im 
+Falls du [Template-Vererbung]({{< ref "template-inheritance.de.md" >}}) nutzt, wird der Auszug der Template Variablen nur im 
 [Debug-Modus]({{< ref "debug-mode.de.md" >}}) angezeigt oder wenn sich die Anweisung zwischen `$this->block(…)` und
 `$this->endblock()` befindet.
 {{% /notice %}}


### PR DESCRIPTION
To address SEO I would add `variablen` to the text. So `Template-Daten` becomes `Template Variablen` or sometimes an alternative of that.  
This should make the Google search strings `contao template variablen` or `contao tempalte daten` deliver results from the contao docs.