### PR TITLE
Update system-requirements.de.md

### DIFF
--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -280,7 +280,7 @@ Contao 4.9 oder älter):
     <Directory /var/www/project/public>
         AllowOverride All
         Require all granted
-        Options FollowSymlinks
+        Options SymLinksIfOwnerMatch
     </Directory>
 </VirtualHost>
 ```


### PR DESCRIPTION
FollowSymlinks sollte durch SymLinksIfOwnerMatch ersetzt werden, was mehr Sicherheit für den Serverbetreiber bietet.