### PR TITLE
remove phpMyAdmin notice

### DIFF
--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -156,13 +156,3 @@ DDEV now offers [Services as Addon](https://ddev.readthedocs.io/en/latest/users/
 ```shell
 ddev get ddev/ddev-adminer && ddev restart
 ```
-
-You can also disable phpMyAdmin in the `.ddev/config.yml`. 
-
-```yml
-omit_containers: [dba]
-```
-
-```shell
-ddev restart
-```


### PR DESCRIPTION
Since https://github.com/ddev/ddev/releases/tag/v1.22.0:

> PhpMyAdmin has been removed from DDEV core, so ddev launch -p no longer works, etc. If you’d like to use PHPMyAdmin, ddev get ddev/ddev-phpmyadmin and use ddev phpmyadmin.

So, the notice about disabling it is not necessary. 