### PR TITLE
Add missing files to the "prepareFormData" hook

### DIFF
--- a/docs/dev/reference/hooks/prepareFormData.md
+++ b/docs/dev/reference/hooks/prepareFormData.md
@@ -35,7 +35,42 @@ distribution or data storage.
 
 
 ## Example
+{{< tabs groupId="attribute-annotation-yaml-php" >}}
+{{% tab name="Since Contao 5.2" %}}
+```php
+// src/EventListener/PrepareFormDataListener.php
+namespace App\EventListener;
 
+use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
+use Contao\Form;
+
+#[AsHook('prepareFormData')]
+class PrepareFormDataListener
+{
+    public function __invoke(
+        array &$submittedData, 
+        array $labels, 
+        array $fields, 
+        Form $form, 
+        array $files
+        ): void
+    {
+        
+        // Add a custom file as attachment
+        $files[] = [
+            'name' => 'MyAttachmentFileName.txt',
+            'tmp_name' => 'path/to/MyAttachmentFileName.txt',
+            'type' => 'text/html'
+        ];
+    
+        // This calculates a deadline from a given timestamp
+        // and stores it as deadline in $submittedData.
+        $submittedData['deadline'] = strtotime('+1 hour', $submittedData['tstamp']);
+    }
+}
+```
+{{% /tab %}}
+{{% tab name="Before Contao 5.2" %}}
 ```php
 // src/EventListener/PrepareFormDataListener.php
 namespace App\EventListener;
@@ -54,8 +89,13 @@ class PrepareFormDataListener
     }
 }
 ```
+{{% /tab %}}
+{{< /tabs >}}
+
+
 
 
 ## References
 
 * [\Contao\Form#L309-L317](https://github.com/contao/contao/blob/4.9.13/core-bundle/src/Resources/contao/forms/Form.php#L309-L317)
+* [\Contao\Form#L394-L400](https://github.com/contao/contao/blob/5.x/core-bundle/contao/forms/Form.php#L394-L400)

--- a/docs/dev/reference/hooks/prepareFormData.md
+++ b/docs/dev/reference/hooks/prepareFormData.md
@@ -53,7 +53,7 @@ class PrepareFormDataListener
         array $fields, 
         Form $form, 
         array $files
-        ): void
+    ): void
     {
         
         // Add a custom file as attachment

--- a/docs/dev/reference/hooks/prepareFormData.md
+++ b/docs/dev/reference/hooks/prepareFormData.md
@@ -52,7 +52,7 @@ class PrepareFormDataListener
         array $labels, 
         array $fields, 
         Form $form, 
-        array $files
+        array &$files
     ): void
     {
         

--- a/docs/dev/reference/hooks/prepareFormData.md
+++ b/docs/dev/reference/hooks/prepareFormData.md
@@ -60,7 +60,7 @@ class PrepareFormDataListener
         $files[] = [
             'name' => 'MyAttachmentFileName.txt',
             'tmp_name' => 'path/to/MyAttachmentFileName.txt',
-            'type' => 'text/html'
+            'type' => 'text/plain',
         ];
     
         // This calculates a deadline from a given timestamp

--- a/docs/dev/reference/hooks/prepareFormData.md
+++ b/docs/dev/reference/hooks/prepareFormData.md
@@ -98,4 +98,4 @@ class PrepareFormDataListener
 ## References
 
 * [\Contao\Form#L309-L317](https://github.com/contao/contao/blob/4.9.13/core-bundle/src/Resources/contao/forms/Form.php#L309-L317)
-* [\Contao\Form#L394-L400](https://github.com/contao/contao/blob/5.x/core-bundle/contao/forms/Form.php#L394-L400)
+* [\Contao\Form#L393-L399](https://github.com/contao/contao/blob/5.2.7/core-bundle/contao/forms/Form.php#L393-L399)

--- a/docs/dev/reference/hooks/prepareFormData.md
+++ b/docs/dev/reference/hooks/prepareFormData.md
@@ -35,7 +35,7 @@ distribution or data storage.
 
 
 ## Example
-{{< tabs groupId="attribute-annotation-yaml-php" >}}
+{{< tabs groupId="prepareFormData-example" >}}
 {{% tab name="Since Contao 5.2" %}}
 ```php
 // src/EventListener/PrepareFormDataListener.php


### PR DESCRIPTION
Since Contao 5.2 (see https://github.com/contao/contao/pull/5584) the files array was added to the prepareFormData hook. This PR adds some additional example code to the docs.