### PR TITLE
Document `pageModel` request attribute in general

### DIFF
--- a/docs/dev/framework/content-elements.md
+++ b/docs/dev/framework/content-elements.md
@@ -330,7 +330,7 @@ $GLOBALS['TL_LANG']['CTE']['my_content_element'] = [
 If you used a custom category for your content element, its label can also be translated there.
 
 
-## PageModel
+## Page Model
 
 {{< version "4.9.10" >}}
 

--- a/docs/dev/framework/front-end-modules.md
+++ b/docs/dev/framework/front-end-modules.md
@@ -346,7 +346,7 @@ $GLOBALS['TL_LANG']['FMD']['my_frontend_module'] = [
 If you used a custom category for your front end module, its label can also be translated there.
 
 
-## PageModel
+## Page Model
 
 {{< version "4.9.10" >}}
 

--- a/docs/dev/framework/routing.md
+++ b/docs/dev/framework/routing.md
@@ -292,6 +292,51 @@ class ExampleController
 ```
 
 
+### Page Model
+
+{{< version "5.0" >}}
+
+The `Contao\PageModel` instance for a regular Contao page request is available under the `pageModel` request attribute.
+This allows you to access any current and inherited attributes of the current page.
+
+```php
+// src/ExampleService.php
+namespace App;
+
+use Contao\PageModel;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class ExampleService
+{
+    public function __construct(private readonly RequestStack $requestStack)
+    {
+    }
+
+    public function __invoke(): void
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        /** @var PageModel $page */
+        if ($page = $request->attributes->get('pageModel')) {
+            $title = $page->title;
+
+            // …
+        }
+    }
+}
+```
+
+{{% notice "note" %}}
+This is also available in Contao **4.9** and later. However, prior to Contao **5** the `pageModel` attribute might also
+just be an integer ID rather than a `PageModel` instance (specifically in fragment subrequests). The attribute might
+also not be available at all, depending on the request's circumstances. As explained in the respective articles you can
+use the `getPageModel()` method in fragment controller for content elements and fron end modules to retrieve the current
+`PageModel`. If you need this in a different service in Contao 4 then you will need to copy the
+[implementation](https://github.com/contao/contao/blob/705b8bcf18d3f30c967cf75a69c381b3397466f4/core-bundle/src/Controller/AbstractFragmentController.php#L50-L75)
+of that method.
+{{% /notice %}}
+
+
 [SymfonyRouting]: https://symfony.com/doc/current/routing.html
 [InvokableController]: https://symfony.com/doc/current/controller/service.html#invokable-controllers
 [FQCN]: https://www.php-fig.org/psr/psr-4/


### PR DESCRIPTION
Currently it is only mentioned how to retrieve the current `PageModel` instance in Page Controllers and Fragment Controllers. This explains the `pageModel` request attribute in general, which is now canon anyway.