### PR TITLE
docs(DDEV): remove mutagen notice

### DIFF
--- a/docs/manual/guides/local-installation/ddev.de.md
+++ b/docs/manual/guides/local-installation/ddev.de.md
@@ -6,7 +6,7 @@ url: "anleitungen/lokale-installation/ddev"
 aliases:
     - /de/anleitungen/lokale-installation/ddev/
 weight: 10
-tags: 
+tags:
    - "Installation"
 ---
 
@@ -16,8 +16,8 @@ DDEV erstellt eine `config.yml`, die alle Einstellungen für dein Projekt enthä
 
 {{% notice note %}}
 Um DDEV nutzen zu können, muss _Docker_ auf deinem System installiert sein. Falls das noch
-nicht der Fall ist, kannst du dir die 
-[DDEV Dokumentation](https://ddev.readthedocs.io/en/stable/users/install/docker-installation/) für 
+nicht der Fall ist, kannst du dir die
+[DDEV Dokumentation](https://ddev.readthedocs.io/en/stable/users/install/docker-installation/) für
 mehr Informationen zur Installation dieser Programme durchlesen.
 {{% /notice %}}
 
@@ -44,14 +44,6 @@ Seine Installation sollte man auch regelmäßig updaten.
 ```shell
 brew upgrade ddev
 ```
-
-{{% notice note %}}
-DDEV empfiehlt unter macOS, Mutagen zu aktivieren, um die beste Leistung zu erzielen.
-
-```shell
-ddev config global --mutagen-enabled
-```
-{{% /notice %}}
 
 
 ### Beispiel: Installation unter Debian/Ubuntu

--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -6,7 +6,7 @@ url: "guides/local-installation/ddev"
 aliases:
     - /en/guides/local-installation/ddev/
 weight: 10
-tags: 
+tags:
    - "Installation"
 ---
 
@@ -16,8 +16,8 @@ DDEV creates a `config.yml`, this contains all settings for your project. This c
 
 {{% notice note %}}
 To use the DDEV, _Docker_ must be installed on your system. If this is not yet
-the case, you can download the 
-[DDEV documentation](https://ddev.readthedocs.io/en/stable/users/install/docker-installation/) for 
+the case, you can download the
+[DDEV documentation](https://ddev.readthedocs.io/en/stable/users/install/docker-installation/) for
 more information about installing these programs.
 {{% /notice %}}
 
@@ -44,14 +44,6 @@ You should also update your installation regularly.
 ```shell
 brew upgrade ddev
 ```
-
-{{% notice note %}}
-DDEV recommends enabling Mutagen on macOS for best performance:
-
-```shell
-ddev config global --mutagen-enabled
-```
-{{% /notice %}}
 
 
 ### Example: Installation on Debian/Ubuntu


### PR DESCRIPTION
Since DDEV v1.22.0:

>Mutagen is now enabled by default on macOS and traditional Windows.
>
>https://github.com/ddev/ddev/releases/tag/v1.22.0

Therefore, the notice is removed.

The other changed lines are removed trailing whitespaces by auto formatting.
If you don't like unrelated changes, I can revert it.
