### PR TITLE
Use version tag more consistently

### DIFF
--- a/docs/dev/framework/caching.md
+++ b/docs/dev/framework/caching.md
@@ -274,7 +274,7 @@ You can register to the [`oninvalidate_cache_tags` callback][5] and add your own
 
 
 {{% notice "tip" %}}
-Since **Contao 4.13** you can also use the [EntityCacheTags helper service](/reference/services/#entitycachetags) to
+{{< version-tag "4.13" >}} You can also use the [EntityCacheTags helper service](/reference/services/#entitycachetags) to
 add and invalidate tags based on entity or model classes and instances.
 {{% /notice %}}
 

--- a/docs/dev/framework/manager-plugin.md
+++ b/docs/dev/framework/manager-plugin.md
@@ -596,7 +596,7 @@ before they hit the cache or are forwarded to Contao. For more information about
 please refer to [the FosHttpCache documentation][2].
 
 {{% notice note %}}
-This feature is available from **contao/manager-plugin 2.9.0** and **Contao 4.9.6**.
+{{< version-tag "4.9.6" >}} This feature is available from **contao/manager-plugin 2.9.0** and **Contao 4.9.6**.
 {{% /notice %}}
 
 

--- a/docs/dev/framework/page-controllers.md
+++ b/docs/dev/framework/page-controllers.md
@@ -344,7 +344,7 @@ represented by the `Contao\PageModel`. This class allows you to generate URLs to
 domain than the current one. The latter will always produce absolute URLs (including `http://` or `https://`).
 
 {{% notice "note" %}}
-Since Contao **5.0** `getFrontendUrl` will generate _path absolute_ URLs, not relative to the `<base>`.
+{{< version-tag "5.0" >}} `getFrontendUrl` will now generate _path absolute_ URLs, not relative to the `<base>`.
 {{% /notice %}}
 
 Both methods allow you to specify optional parameters as one string. These are _path_ parameters and are used when you

--- a/docs/dev/framework/request-tokens.md
+++ b/docs/dev/framework/request-tokens.md
@@ -86,7 +86,7 @@ class ExampleService
 ```
 
 {{% notice tip %}}
-Since Contao 4.13 you can omit getting the `%contao.csrf_token_name%` by explicitly using the `ContaoCsrfTokenManager`,
+{{< version-tag "4.13" >}} You can omit getting the `%contao.csrf_token_name%` by explicitly using the `ContaoCsrfTokenManager`,
 that now features a `getDefaultTokenValue()` method:
 
 ```php
@@ -110,7 +110,7 @@ handling as outlined above, if you need to disable the CSRF protection for some 
 * The localconfig configuration value `requestTokenWhitelist`. It can contain an exact hostname or regular expression.
   It will disable CSRF protection only on hostname match.
 
-Since Contao 4.13 using the `{{request_token}}` insert tag is deprecated as well. Instead, you should retrieve the value
+{{< version-tag "4.13" >}} Using the `{{request_token}}` insert tag is deprecated as well. Instead, you should retrieve the value
 from the CSRF token manager in your Controller and pass it on to the template.
 
 [OWASP_CSRF]: https://owasp.org/www-community/attacks/csrf

--- a/docs/dev/framework/security.md
+++ b/docs/dev/framework/security.md
@@ -162,7 +162,7 @@ $security->isGranted('contao_dc.tl_foobar', new UpdateAction('tl_foobar', $recor
 ```
 
 {{% notice tip %}}
-Since Contao **4.10** there are class constants available for the various permission attributes, so that you do not have to remember them
+{{< version-tag "4.10" >}} There are now class constants available for the various permission attributes, so that you do not have to remember them
 yourself and instead can use your IDE to find the correct attribute. For the Contao Core these constants are available in 
 `Contao\CoreBundle\Security\ContaoCorePermissions` while the permissions of the additional bundles are available in 
 `Contao\NewsBundle\Security\ContaoNewsPermissions`, `Contao\CalendarBundle\Security\ContaoCalendarPermissions`, 

--- a/docs/dev/guides/fragment-controllers.md
+++ b/docs/dev/guides/fragment-controllers.md
@@ -47,7 +47,7 @@ parameters (like `GET` and `POST` data), and they can return HTTP headers (like 
 or `Cache-Control`).
 
 {{% notice note %}}
-Since **Contao 4.9**, subrequests can generate [a response that modifies the cache time of
+{{< version-tag "4.9" >}} Subrequests can generate [a response that modifies the cache time of
 the main response](/framework/caching/#caching-fragments).
 {{% /notice %}}
 

--- a/docs/dev/reference/dca/fields.md
+++ b/docs/dev/reference/dca/fields.md
@@ -54,7 +54,7 @@ $GLOBALS['TL_DCA']['tl_example']['fields']['myfield'] = [
 | [xlabel](../callbacks/#fields-field-xlabel)                    | Callback functions (`array`)                    | These functions will be called when the widget is rendered and allows you to add additional html after the field label. Please specify each callback function as `['Class', 'Method']`.
 
 {{% notice tip %}}
-<sup>1</sup> Since Contao **4.9**, defining a label for a DCA field is optional. If
+<sup>1</sup> {{< version-tag "4.9" >}} defining a label for a DCA field is optional. If
 no label is defined, Contao will automatically look for a translation in `tl_example.field_name`,
 e.g. `$GLOBALS['TL_LANG']['tl_example']['field_name']`.
 {{% /notice %}}

--- a/docs/dev/reference/dca/fields.md
+++ b/docs/dev/reference/dca/fields.md
@@ -54,7 +54,7 @@ $GLOBALS['TL_DCA']['tl_example']['fields']['myfield'] = [
 | [xlabel](../callbacks/#fields-field-xlabel)                    | Callback functions (`array`)                    | These functions will be called when the widget is rendered and allows you to add additional html after the field label. Please specify each callback function as `['Class', 'Method']`.
 
 {{% notice tip %}}
-<sup>1</sup> {{< version-tag "4.9" >}} defining a label for a DCA field is optional. If
+<sup>1</sup> {{< version-tag "4.9" >}} Defining a label for a DCA field is optional. If
 no label is defined, Contao will automatically look for a translation in `tl_example.field_name`,
 e.g. `$GLOBALS['TL_LANG']['tl_example']['field_name']`.
 {{% /notice %}}

--- a/docs/dev/reference/dca/list.md
+++ b/docs/dev/reference/dca/list.md
@@ -39,7 +39,7 @@ $GLOBALS['TL_DCA']['tl_example']['list']['sorting'] = [
 | child_record_class    | CSS class (`string`)             | Allows you to add a CSS class to the parent view elements.                                                                                                                                                                                                                                                                                                                                             |
 
 {{% notice tip %}}
-Since Contao **4.13** the `Contao\DataContainer` class provides constants for the various sorting modes and flags, e.g.
+{{< version-tag "4.13" >}} The `Contao\DataContainer` class provides constants for the various sorting modes and flags, e.g.
 
 ```php
 // Displays the child records of a parent record (see content elements)
@@ -128,7 +128,7 @@ $GLOBALS['TL_DCA']['tl_example']['list']['operations'] = [
 | route           | Symfony Route Name (`string`)     | {{< version-tag "4.7" >}} The button will redirect to the given Symfony route.                                                               |
 
 {{% notice "note" %}}
-Since Contao **5.0** you do not have to define any settings for standard operations anymore. Instead you can give a list
+{{< version-tag "5.0" >}} You do not have to define any settings for standard operations anymore. Instead, you can give a list
 of which operations should be available for your data container. Contao will also check the appropriate
 [`contao_dc.<data-container>` permission](/framework/security/) for these operations.
 

--- a/docs/manual/installation/system-requirements.de.md
+++ b/docs/manual/installation/system-requirements.de.md
@@ -173,7 +173,7 @@ Es wird außerdem empfohlen, MySQL im "Strict Mode" zu betreiben, um korrupte od
 Daten zu verhindern und die Datenintegrität zu gewährleisten.
 
 {{% notice note %}}
-Ab **Contao 4.9** zeigt das Install-Tool eine Warnmeldung an, wenn der Datenbankserver nicht im
+{{< version-tag "4.9" >}} Das Install-Tool zeigt jetzt eine Warnmeldung an, wenn der Datenbankserver nicht im
 "Strict Mode" läuft.
 {{% /notice %}}
 

--- a/docs/manual/installation/system-requirements.en.md
+++ b/docs/manual/installation/system-requirements.en.md
@@ -167,7 +167,7 @@ It is further recommended to run MySQL in "strict mode" to prevent corrupt or tr
 data and to guarantee data integrity.
 
 {{% notice note %}}
-As of **Contao 4.9**, the install tool shows a warning if the database server is not running
+{{< version-tag "4.9" >}} the install tool now shows a warning if the database server is not running
 in strict mode.
 {{% /notice %}}
 

--- a/docs/manual/installation/system-requirements.en.md
+++ b/docs/manual/installation/system-requirements.en.md
@@ -167,7 +167,7 @@ It is further recommended to run MySQL in "strict mode" to prevent corrupt or tr
 data and to guarantee data integrity.
 
 {{% notice note %}}
-{{< version-tag "4.9" >}} the install tool now shows a warning if the database server is not running
+{{< version-tag "4.9" >}} The install tool now shows a warning if the database server is not running
 in strict mode.
 {{% /notice %}}
 


### PR DESCRIPTION
Now that `{{< version-tag "x.y" >}}` does not generate a new `<p>` anymore, we can use it in other places. I noticed it has been avoided especially in `{{% notice %}}` tags because this would have messed up the layout. This is now fixed, so let's have some more consistency 😊 