### PR TITLE
Color Proposal for <code> (light-theme)

### DIFF
--- a/page/static/css/theme-contao.css
+++ b/page/static/css/theme-contao.css
@@ -34,8 +34,8 @@
     --PROGRESS-BORDER-color: #ECECEC; /* Border color of the jumpTo navigation */
 
     --CODE-TEXT-COLOR: #5e5e5e; /* <code> */
-    --CODE-BG-color: #FFF7DD;
-    --CODE-BORDER-color: #fbf0cb;
+    --CODE-BG-color: #F6F6F6;
+    --CODE-BORDER-color: #F6F6F6;
 
     --BLOCK-QUOTE-BORDER-color: #F0F2F4; /* Border color of the left border for block quotes */
 


### PR DESCRIPTION
I like the unobtrusive color combination for code block in the dark theme. Hence a suggestion for the light theme.


![image](https://github.com/contao/docs/assets/7679799/7d0afbf2-feae-4c64-8210-ac2819c1599f)
vs
![image](https://github.com/contao/docs/assets/7679799/8646fa08-d908-4d5d-8eae-9cf4581b45b4)
