### PR TITLE
New insert tag system

### DIFF
--- a/docs/dev/framework/insert-tags.md
+++ b/docs/dev/framework/insert-tags.md
@@ -74,7 +74,8 @@ content, depending on the page's language, e.g.:
 ```
 
 When implementing a block insert tag your function receives the wrapped content as a `ParsedSequence` object in addition
-to your `InsertTag`. Your function is then expected to return a `ParsedSequence` again - which could be empty in
+to your `InsertTag`. The `ParsedSequence` object consists of strings and other parsed (but not yet resolved)
+insert tags. Your function is then expected to return a `ParsedSequence` again - which could be empty in
 case your block insert tag should not output anything (e.g. in the `iflng` example if the language does not match).
 
 The following example implements a `{{ifmembergroup::*}}…{{endifmembergroup}}` block insert tag with which you can

--- a/docs/dev/framework/insert-tags.md
+++ b/docs/dev/framework/insert-tags.md
@@ -8,12 +8,161 @@ aliases:
 
 Insert tags are a Contao specific way to replace specific tokens in your templates
 and database fields with content. They follow the format `{{TAG_NAME}}`. In most
-cases they contain a payload after the tag name, ie: `{{TAG_NAME::PAYLOAD}}`.
+cases they contain parameters after the tag name, ie: `{{TAG_NAME::PARAMETERS}}`.
 
 A list of readily available insert tags can be found in the [user manual][UserManualInsertTags].
 
+## Register custom insert tags
 
-## Create a custom Insert Tag
+{{< version-tag "5.2" >}} Custom insert tags can be registered using the PHP attributes
+`AsInsertTag` and `AsBlockInsertTag` or their corresponding service tags
+`contao.insert_tag` and `contao.block_insert_tag`. The following options are 
+supported for these service tags:
+
+| Option              | Description                                                                                                                   |
+|---------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| `name`              | The name of the insert tag. Has to be in lowercase.                                                                           |
+| `resolveNestedTags` | `true` will resolve all nested tags before passing it to the method. `false` will keep nested tags unreplaced.                |
+| `priority`          | For multiple insert tags with the same name only the one with the highest priority will be executed.                          |
+| `method`            | Will default to `__invoke` or the name of the method the attribute is attached to. Otherwise a method name has to be defined. |
+| `asFragment`        | If enabled the insert tag will be rendered as a fragment via an `<esi>` tag. Only for regular (not block) insert tags.        |
+| `endTag`            | The name of the end tag. Has to be in lowercase. Only for block insert tags.                                                  |
+
+The following example will provide an insert tag which transforms a string with
+the `str_rot13` function provided by PHP.
+
+```php
+// src/InsertTags/Rot13InsertTag.php
+namespace App\InsertTags;
+
+use Contao\CoreBundle\DependencyInjection\Attribute\AsInsertTag;
+use Contao\CoreBundle\InsertTag\InsertTagResult;
+use Contao\CoreBundle\InsertTag\OutputType;
+use Contao\CoreBundle\InsertTag\ResolvedInsertTag;
+use Contao\CoreBundle\InsertTag\Resolver\InsertTagResolverNestedResolvedInterface;
+
+#[AsInsertTag('rot13')]
+class Rot13InsertTag implements InsertTagResolverNestedResolvedInterface
+{
+    public function __invoke(ResolvedInsertTag $insertTag): InsertTagResult
+    {
+        if (null === $insertTag->getParameters()->get(0)) {
+            throw new InvalidInsertTagException('Missing parameters for insert tag.');
+        }
+        
+        $parameter = $insertTag->getParameters()->get(0);
+        
+        $rotated = str_rot13($parameter);
+        
+        return new InsertTagResult($rotated, OutputType::text);
+    }
+}
+```
+
+Now the insert tag `{{rot13::Contao}}` will be replaced with `Pbagnb`.
+
+An example for a block insert tag can be found in the Contao core bundle: 
+[`IfLanguageInsertTag`][IfLanguageInsertTag].
+
+### `InsertTag` and `InsertTagParameters` objects
+
+An insert tag resolver gets an `InsertTag` object passed, either as `ParsedInsertTag` 
+or as `ResolvedInsertTag` depending on the `resolveNestedTags` attribute setting.
+A _parsed_ insert tag can still include other nested insert tags in its parameters
+while in a _resolved_ insert tag all parameters are directly available. For an
+insert tag like `{{tag::foo{{nested}}bar}}` these objects would look like:
+
+```php
+/** @var ResolvedInsertTag $tag */
+$tag->getParameters()->get(0); // "foonestedbar"
+
+/** @var ParsedInsertTag $tag */
+$tag->getParameters()->get(0); // object(ParsedSequence)
+$tag->getParameters()->get(0)->get(0); // "foo"
+$tag->getParameters()->get(0)->get(1); // object(ParsedInsertTag)
+$tag->getParameters()->get(0)->get(2); // "bar"
+```
+
+The parameters objects can be used to access named, scalar or array parameters if 
+desired:
+
+```php
+// {{tag::key=value}}
+$tag->getParameters()->get('key'); // "value"
+$tag->getParameters()->get(0); // "key=value"
+
+// {{tag::key=value1::key=value2}}
+$tag->getParameters()->all('key'); // ["value1", "value2"]
+
+// {{tag::int=1::float=1.2::string=value}}
+$tag->getParameters()->getScalar('int'); // 1
+$tag->getParameters()->getScalar('float'); // 1.2
+$tag->getParameters()->getScalar('string'); // "value"
+```
+
+
+## Register custom insert tag flags
+
+{{< version-tag "5.2" >}} Custom [insert tag flags][InsertTagFlags] can be registered
+using the PHP attribute `AsInsertTagFlag` or the corresponding service tag
+`contao.insert_tag_flag`. The following options are supported for this service tag:
+
+| Option              | Description                                                                                                                   |
+|---------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| `name`              | The name of the insert tag flag. Has to be in lowercase.                                                                      |
+| `priority`          | For multiple insert tag flags with the same name only the one with the highest priority will be executed.                     |
+| `method`            | Will default to `__invoke` or the name of the method the attribute is attached to. Otherwise a method name has to be defined. |
+
+The following example will provide an insert tag flag which transforms the output
+of the tag or the previous flag with the `str_rot13` function provided by PHP.
+
+```php
+// src/InsertTags/Rot13InsertTagFlag.php
+namespace App\InsertTags;
+
+use Contao\CoreBundle\DependencyInjection\Attribute\AsInsertTagFlag;
+use Contao\CoreBundle\InsertTag\InsertTagResult;
+use Contao\CoreBundle\InsertTag\OutputType;
+use Contao\CoreBundle\InsertTag\ResolvedInsertTag;
+use Contao\CoreBundle\InsertTag\Flag\InsertTagFlagInterface;
+
+#[AsInsertTagFlag('rot13')]
+class Rot13InsertTagFlag implements InsertTagFlagInterface
+{
+    public function __invoke(InsertTagFlag $flag, InsertTagResult $result): InsertTagResult
+    {
+        return $result
+            ->withValue(str_rot13($result->getValue()))
+            ->withOutputType(OutputType::text) // Switch to text here as rot13 results in unsafe HTML.
+        ;
+    }
+}
+```
+
+Now the insert tag `{{label::MSC:reset|rot13}}` will be replaced with `Erfrg`.
+
+
+## Formal syntax (EBNF)
+
+The formal syntax of insert tags is defined as follows:
+
+```bnf
+   InsertTag ::= "{{" Name Parameter * Flag * "}}"
+        Name ::= [a-z#x80-#xFF] [a-z0-9_#x80-#xFF] *
+   Parameter ::= "::" ( KeyValuePair | Value )
+        Flag ::= "|" [^{}|] *
+KeyValuePair ::= Key "=" Value
+         Key ::= [^{}|=] *
+       Value ::= ( [^{}|] | InsertTag ) *
+```
+
+
+## Create a custom Insert Tag hook
+
+{{% notice note %}}
+This section applies to Contao versions prior to **5.2**. For later versions use the
+attributes mentioned above instead.
+{{% /notice %}}
 
 Custom insert tags can be replaced by creating a service tagged with the `contao.hook`
 tag and registering a specific Hook. This service will be called whenever the replacement 
@@ -56,7 +205,12 @@ The Hook provides many additional parameters. See the [reference article][Replac
 for this Hook for more information about the possible parameters.
 
 
-## Cache behaviour
+## Cache behaviour of legacy insert tags
+
+{{% notice note %}}
+This section applies to Contao versions prior to **5.2**. For later versions take
+a look at the setting `asFragment` from above.
+{{% /notice %}}
 
 Generally, replaced insert tags will be cached and stored in the public cache.
 However, there are some exemptions worth noting.
@@ -85,6 +239,8 @@ add the `uncached` flag whenever used.
 Using the `uncached` flag is deprecated and doesn’t work in Contao 5.0 anymore. Use the `{{fragment::*}}` insert tag instead.
 {{% /notice %}}
 
+[InsertTagFlags]: https://docs.contao.org/manual/en/article-management/insert-tags/#insert-tag-flags
+[IfLanguageInsertTag]: https://github.com/contao/contao/blob/5.x/core-bundle/src/InsertTag/Resolver/IfLanguageInsertTag.php
 [ReplaceInsertTagsHook]: /reference/hooks/replaceInsertTags/
 [FrameworkHooks]: /framework/hooks/
 [UserManualInsertTags]: https://docs.contao.org/manual/en/article-management/insert-tags/

--- a/docs/dev/framework/insert-tags.md
+++ b/docs/dev/framework/insert-tags.md
@@ -36,6 +36,7 @@ the `str_rot13` function provided by PHP.
 namespace App\InsertTag;
 
 use Contao\CoreBundle\DependencyInjection\Attribute\AsInsertTag;
+use Contao\CoreBundle\InsertTag\Exception\InvalidInsertTagException;
 use Contao\CoreBundle\InsertTag\InsertTagResult;
 use Contao\CoreBundle\InsertTag\OutputType;
 use Contao\CoreBundle\InsertTag\ResolvedInsertTag;

--- a/docs/dev/framework/insert-tags.md
+++ b/docs/dev/framework/insert-tags.md
@@ -93,7 +93,7 @@ use Contao\CoreBundle\InsertTag\Resolver\BlockInsertTagResolverNestedResolvedInt
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Symfony\Bundle\SecurityBundle\Security;
 
-#[AsBlockInsertTag('ifmembergroup', 'endifmembergroup')]
+#[AsBlockInsertTag('ifmembergroup', endTag: 'endifmembergroup')]
 class IfMemberGroupInsertTag implements BlockInsertTagResolverNestedResolvedInterface
 {
     public function __construct(private readonly Security $security)


### PR DESCRIPTION
See #1379

Do we usually link to source code on github for examples?
Should we add more links to such examples here? (currently only the `IfLanguageInsertTag` is linked to).