### PR TITLE
Update guide for installing the latest Release Candidate (5.4)

### DIFF
--- a/docs/manual/guides/install-test-versions.de.md
+++ b/docs/manual/guides/install-test-versions.de.md
@@ -50,29 +50,29 @@ werden.
 ## Release Candidates installieren
 
 Release Candidates nutzen eine spezifische Form von sogenannten »Release-Tags«.
-Der erste Release Candidate von Contao `4.9` heißt z. B. `4.9.0-RC1`. Normalerweise
+Der erste Release Candidate von Contao `5.4` heißt z. B. `5.4.0-RC1`. Normalerweise
 würde Composer nur _stabile_ Versionen installieren und daher solche Release Candidates
 nicht beachten.
 
 Um die Installation von Release Candidates zu erlauben, muss die `minimum-stability`
 auf `RC` in der `composer.json` runter gesetzt werden. Außerdem sollte man Composer
-anweisen, dass bei jedem Paket _stabile_ Versionen bevorzugt werden, damit die auch
-die offiziell veröffentlichten Versionen von Contao automatisch installiert werden,
-sobald verfügbar. Schließlich muss noch die angeforderte Version von Contao selbst,
-also genau genommen des `contao/manager-bundle` auf `4.9.*` geändert werden, so
-wie bei jedem Update auf eine neuere Contao Version.
+anweisen, dass bei jedem Paket _stabile_ Versionen bevorzugt werden, damit auch die
+offiziell veröffentlichten Versionen von Contao automatisch installiert werden, sobald
+diese verfügbar sind. Schließlich muss noch die angeforderte Version von Contao selbst,
+also genau genommen des `contao/manager-bundle` auf `5.4.*` geändert werden, so wie bei
+jedem Update auf eine neuere Contao Version.
 
 ```json
 {
     "require": {
-        "contao/manager-bundle": "4.9.*"
+        "contao/manager-bundle": "5.4.*"
     },
     "minimum-stability": "RC",
     "prefer-stable": true
 }
 ```
 
-Hier ist ein komplettes Beispiel, um die neueste Contao `4.9` Version installieren
+Hier ist ein komplettes Beispiel, um die neueste Contao `5.4` Version installieren
 zu lassen, _inklusive_ den neuesten Release Candidates (wenn vorhanden):
 
 ```json
@@ -82,39 +82,36 @@ zu lassen, _inklusive_ den neuesten Release Candidates (wenn vorhanden):
     "license": "LGPL-3.0-or-later",
     "type": "project",
     "require": {
-        "contao/calendar-bundle": "^4.9",
-        "contao/comments-bundle": "^4.9",
+        "contao/calendar-bundle": "^5.4",
+        "contao/comments-bundle": "^5.4",
         "contao/conflicts": "@dev",
-        "contao/core-bundle": "^4.9",
-        "contao/faq-bundle": "^4.9",
-        "contao/installation-bundle": "^4.9",
-        "contao/listing-bundle": "^4.9",
-        "contao/manager-bundle": "4.9.*",
-        "contao/news-bundle": "^4.9",
-        "contao/newsletter-bundle": "^4.9"
+        "contao/core-bundle": "^5.4",
+        "contao/faq-bundle": "^5.4",
+        "contao/listing-bundle": "^5.4",
+        "contao/manager-bundle": "5.4.*",
+        "contao/news-bundle": "^5.4",
+        "contao/newsletter-bundle": "^5.4"
     },
     "minimum-stability": "RC",
     "prefer-stable": true,
-    "conflict": {
-        "contao-components/installer": "<1.3"
-    },
     "config": {
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
             "contao-community-alliance/composer-plugin": true,
             "contao-components/installer": true,
-            "contao/manager-plugin": true
+            "contao/manager-plugin": true,
+            "php-http/discovery": true
         }
     },
     "extra": {
-        "contao-component-dir": "assets"
+        "contao-component-dir": "public/assets"
     },
     "scripts": {
         "post-install-cmd": [
-            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
+            "@php vendor/bin/contao-setup"
         ],
         "post-update-cmd": [
-            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
+            "@php vendor/bin/contao-setup"
         ]
     }
 }
@@ -123,8 +120,8 @@ zu lassen, _inklusive_ den neuesten Release Candidates (wenn vorhanden):
 {{% notice tip %}}
 Die angeforderten Versionen der anderen Contao Bundles muss nicht unbedingt von
 deren ursprünglichen Angaben geändert werden. Zum Beispiel erlaubt eine Angabe von
-`^4.4` (wie es der Fall wäre, wenn man von einer Contao 4.4 LTS Version aktualisieren
-würde) auch die Installation aller `4.9` Versionen. Siehe dazu auch die Dokumentation
+`^5.3` (wie es der Fall wäre, wenn man von einer Contao 5.3 LTS Version aktualisieren
+würde) auch die Installation aller `5.4` Versionen (oder höher). Siehe dazu auch die Dokumentation
 von Composer über diese spezielle [Versions Syntax](https://getcomposer.org/doc/articles/versions.md).
 Nur die Version des `contao/manager-bundle` muss angepasst werden.
 {{% /notice %}}
@@ -142,7 +139,7 @@ Git-Repository von Contao verlangt. Die aktuell entwickelte »Minor« Version vo
 einen »Entwicklungszweig (Branch)« dessen Namen der aktuellen »Major« Version entspricht, z. B.
 `5.x` seit Anfang 2022. Dieser Branch muss als `5.x-dev` in Composer verlangt werden.
 
-Eine komplettes Beispiel einer `composer.json`, wo der Entwicklungszweig von Contao's nächster
+Ein komplettes Beispiel einer `composer.json`, wo der Entwicklungszweig von Contao's nächster
 Version wird, sieht so aus:
 
 ```json
@@ -175,7 +172,7 @@ Version wird, sieht so aus:
         }
     },
     "extra": {
-        "contao-component-dir": "assets"
+        "contao-component-dir": "public/assets"
     },
     "scripts": {
         "post-install-cmd": [
@@ -200,7 +197,7 @@ aus diesem Branch des öffentlichen Git Repositorys von Contao geholt.
 
 Jede vergangene und noch unterstützte »Minor« Version von Contao hat ebenfalls ihren eigenen
 Entwicklungs-Branch, z. B. `4.13.x-dev` für Contao `4.13`. Falls du also den aktuellen
-Entwicklungsstand testen möchtest ohne auf die Veröffentlichung einer neuen Version zu warten
+Entwicklungsstand testen möchtest, ohne auf die Veröffentlichung einer neuen Version zu warten,
 kann stattdessen dieser Branch in der oben erwähnten `composer.json` verlangt werden.
 
 
@@ -208,8 +205,8 @@ kann stattdessen dieser Branch in der oben erwähnten `composer.json` verlangt w
 
 Die Testversionen können auch ohne manuelle Änderung der `composer.json` direkt
 über den Contao Manager installiert werden. Dazu editiert man bei »Contao Open Source
-CMS« die angeforderte Versionsangabe entweder auf bspw. `4.9.*@RC`, um Release
-Candidates, oder `4.9.x-dev` um Entwicklerversionen installieren 
+CMS« die angeforderte Versionsangabe entweder auf bspw. `5.4.*@RC`, um Release
+Candidates, oder `5.4.x-dev` um Entwicklerversionen installieren 
 zu lassen.
 
 ![Contao Manager Versionsangabe]({{% asset "images/manual/guides/de/install-version/contao-manager-versionseingabe.gif" %}}?classes=shadow)

--- a/docs/manual/guides/install-test-versions.en.md
+++ b/docs/manual/guides/install-test-versions.en.md
@@ -46,26 +46,26 @@ the `composer.json`, a full package update needs to be executed of course.
 ## Installing Release Candidates
 
 Release candidates use a specific release version tag. For example the first release
-candidate of Contao `4.9` will have a release tag called `4.9.0-RC1`. Usually Composer
+candidate of Contao `5.4` will have a release tag called `5.4.0-RC1`. Usually Composer
 will only install _stable_ versions by default and thus skip any such release candidates.
 
 To allow the installation of release candidates, the `minimum-stability` needs to
 be lowered to `RC` in the `composer.json`. Additionally, we instruct Composer to
 always prefer _stable_ versions of each package, so that a stable release of Contao
-`4.9` gets installed, once available. Finally the requested Contao, i.e. the `contao/manager-bundle` 
-needs to be changed to `4.9.*`, as with any minor version update.
+`5.4` gets installed, once available. Finally, the requested Contao, i.e. the `contao/manager-bundle` 
+needs to be changed to `5.4.*`, as with any minor version update.
 
 ```json
 {
     "require": {
-        "contao/manager-bundle": "4.9.*"
+        "contao/manager-bundle": "5.4.*"
     },
     "minimum-stability": "RC",
     "prefer-stable": true
 }
 ```
 
-Here is a full example for installing the latest Contao `4.9` version, _including_
+Here is a full example for installing the latest Contao `5.4` version, _including_
 its latest release candidates (if there are any):
 
 ```json
@@ -75,39 +75,36 @@ its latest release candidates (if there are any):
     "license": "LGPL-3.0-or-later",
     "type": "project",
     "require": {
-        "contao/calendar-bundle": "^4.9",
-        "contao/comments-bundle": "^4.9",
+        "contao/calendar-bundle": "^5.4",
+        "contao/comments-bundle": "^5.4",
         "contao/conflicts": "@dev",
-        "contao/core-bundle": "^4.9",
-        "contao/faq-bundle": "^4.9",
-        "contao/installation-bundle": "^4.9",
-        "contao/listing-bundle": "^4.9",
-        "contao/manager-bundle": "4.9.*",
-        "contao/news-bundle": "^4.9",
-        "contao/newsletter-bundle": "^4.9"
+        "contao/core-bundle": "^5.4",
+        "contao/faq-bundle": "^5.4",
+        "contao/listing-bundle": "^5.4",
+        "contao/manager-bundle": "5.4.*",
+        "contao/news-bundle": "^5.4",
+        "contao/newsletter-bundle": "^5.4"
     },
     "minimum-stability": "RC",
     "prefer-stable": true,
-    "conflict": {
-        "contao-components/installer": "<1.3"
-    },
     "config": {
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
             "contao-community-alliance/composer-plugin": true,
             "contao-components/installer": true,
-            "contao/manager-plugin": true
+            "contao/manager-plugin": true,
+            "php-http/discovery": true
         }
     },
     "extra": {
-        "contao-component-dir": "assets"
+        "contao-component-dir": "public/assets"
     },
     "scripts": {
         "post-install-cmd": [
-            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
+            "@php vendor/bin/contao-setup"
         ],
         "post-update-cmd": [
-            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
+            "@php vendor/bin/contao-setup"
         ]
     }
 }
@@ -115,8 +112,8 @@ its latest release candidates (if there are any):
 
 {{% notice tip %}}
 The version requirement of the other bundles do not need to be changed from their
-default value. For example, a version requirement of `^4.4` (like if you would update 
-from the Contao 4.4 LTS version) also allows any `4.9` version. See Composer's documentation
+default value. For example, a version requirement of `^5.3` (like if you would update 
+from the Contao 5.3 LTS version) also allows any `5.4` version. See Composer's documentation
 on the [version requirement syntax](https://getcomposer.org/doc/articles/versions.md). 
 Only the requested version of the `contao/manager-bundle` needs to be adjusted.
 {{% /notice %}}
@@ -199,8 +196,8 @@ of development of the next bugfix version, you can require this branch in the ab
 
 These test versions can also be installed via the Contao Manager, without having
 to manually change the `composer.json`. You can edit the required version of "Contao
-Open Source CMS" to `4.9.*@RC` for example, in order to install release candidates.
-Or you can enter `4.9.x-dev` in order to install development versions.
+Open Source CMS" to `5.4.*@RC` for example, in order to install release candidates.
+Or you can enter `5.4.x-dev` in order to install development versions.
 
 ![Contao Manager Versionsangabe]({{% asset "images/manual/guides/en/install-version/contao-manager-enter-custom-version.gif" %}}?classes=shadow)
 


### PR DESCRIPTION
### Description

* Updates the installation guide for test versions _(were outdated and for 4.9)_

___Further notice:___
_I've already updated the assets folder to `public/assets` to match the structure in `^5.4`_