### PR TITLE
Update `contao-component-dir` path for 5.4.x

### DIFF
--- a/docs/manual/guides/install-test-versions.de.md
+++ b/docs/manual/guides/install-test-versions.de.md
@@ -104,7 +104,7 @@ zu lassen, _inklusive_ den neuesten Release Candidates (wenn vorhanden):
         }
     },
     "extra": {
-        "contao-component-dir": "public/assets"
+        "contao-component-dir": "assets"
     },
     "scripts": {
         "post-install-cmd": [
@@ -172,7 +172,7 @@ Version wird, sieht so aus:
         }
     },
     "extra": {
-        "contao-component-dir": "public/assets"
+        "contao-component-dir": "assets"
     },
     "scripts": {
         "post-install-cmd": [

--- a/docs/manual/guides/install-test-versions.en.md
+++ b/docs/manual/guides/install-test-versions.en.md
@@ -97,7 +97,7 @@ its latest release candidates (if there are any):
         }
     },
     "extra": {
-        "contao-component-dir": "public/assets"
+        "contao-component-dir": "assets"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
### Description

This PR updates the `contao-component-dir` to it's initial state as it has been reverted in https://github.com/contao/contao/pull/7406.

Everything regarding the issue about the component-dir can be read within https://github.com/contao/contao/pull/7400

### Quick fix

Since this is a release candidate, this does not need to be documented.
If you are already affected by this, you can simply use the two following commands after reverting the change in your `composer.json`
```
mv /public/assets /assets
```
then run
```
@php vendor/bin/contao-console contao:symlinks
```