### PR TITLE
Fix condition example for module listing

### DIFF
--- a/docs/manual/guides/module-listing.de.md
+++ b/docs/manual/guides/module-listing.de.md
@@ -60,7 +60,7 @@ Mitgliedergruppen werden in der Datenbanktabelle `tl_member_group` geführt. Wir
 in der Tabelle `tl_member` über den Datensatz `groups`. 
 
 Möchtest du die Mitgliederliste auf alle »aktiven« Mitglieder beschränken die zur Gruppe »Vorstand« gehören kannst du 
-folgendes als Bedingung eintragen: `disable != 1 AND groups LIKE '%2%'`
+folgendes als Bedingung eintragen: `disable != 1 AND groups LIKE '%"2"%'`
 
 
 ### Template »list_default.html5«

--- a/docs/manual/guides/module-listing.en.md
+++ b/docs/manual/guides/module-listing.en.md
@@ -56,7 +56,7 @@ listed in the database table `tl_member_group`. We assume, that e.g. the group �
 of »2«. The reference of the group membership of a member is made in the table `tl_member` via the data set `groups`.
 
 If you want to limit the member list to all »active« members of the group »board« you can enter the following 
-condition: `disable != 1 AND groups LIKE '%2%'`.
+condition: `disable != 1 AND groups LIKE '%"2"%'`.
 
 
 ### Template »list_default.html5«


### PR DESCRIPTION
I've just tried the example in a project to only list members of a group. It didn't work as expected and instead listed all members. According to a [forum post](https://community.contao.org/de/showthread.php?2438-Modul-Auflistung-f%C3%BCr-Mitglieder-verwenden-Einschr%C3%A4nken-der-Gruppe&p=15073&viewfull=1#post15073), it is just missing some quotes. 

Sorry for 2 commits, the online "edit this page" feature doesn't seem to allow me to change several files at once.