### PR TITLE
Layout fixes for `#contao-network` topbar

### DIFF
--- a/page/layouts/partials/custom-footer.html
+++ b/page/layouts/partials/custom-footer.html
@@ -44,3 +44,4 @@
 })();
 </script>
 {{ partial "json-ld" . }}
+</main>

--- a/page/layouts/partials/custom-footer.html
+++ b/page/layouts/partials/custom-footer.html
@@ -44,4 +44,4 @@
 })();
 </script>
 {{ partial "json-ld" . }}
-</main>
+</div>

--- a/page/layouts/partials/header.html
+++ b/page/layouts/partials/header.html
@@ -41,7 +41,7 @@
     {{ partial "custom-header.html" . }}
   </head>
   <body class="" data-url="{{ .RelPermalink }}">
-    <main id="main">
+    <div id="main">
     {{ partial "menu.html" . }}
         <section id="body">
         <div id="overlay"></div>

--- a/page/layouts/partials/header.html
+++ b/page/layouts/partials/header.html
@@ -41,6 +41,7 @@
     {{ partial "custom-header.html" . }}
   </head>
   <body class="" data-url="{{ .RelPermalink }}">
+    <main id="main">
     {{ partial "menu.html" . }}
         <section id="body">
         <div id="overlay"></div>

--- a/page/static/css/theme-contao.css
+++ b/page/static/css/theme-contao.css
@@ -152,9 +152,13 @@ body {
     z-index: 9999;
 }
 
+#contao-network ~ * {
+    margin-top: var(--BODY-TOP-OFFSET); /* Add an offset to every dynamically added component within body */
+}
+
 #main {
     background: var(--MAIN-BODY-background);
-    margin-top: var(--BODY-TOP-OFFSET); /* Offset for contao-network topbar */
+    margin-top: var(--BODY-TOP-OFFSET); /* Counter CLS when #contao-network gets loaded */
 }
 
 #main > #sidebar {

--- a/page/static/css/theme-contao.css
+++ b/page/static/css/theme-contao.css
@@ -1,5 +1,7 @@
 :root {
 
+    --BODY-TOP-OFFSET: 34px; /* Offset for the body with contao-network bar */
+
     --MAIN-BODY-background: #fff; /* Color of the body */
 
     --MAIN-TEXT-color: #323232; /* Color of text by default */
@@ -137,11 +139,33 @@ html[data-theme=dark] {
 }
 
 body {
-    background: var(--MAIN-BODY-background);
+    background: #222; /* Use top navigation background to counter FOUC */
     color: var(--MAIN-TEXT-color) !important;
     font-family: -apple-system, system-ui, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
     font-weight: 400;
 }
+
+#contao-network {
+    top: 0;
+    position: fixed;
+    width: 100%;
+    z-index: 9999;
+}
+
+#main {
+    background: var(--MAIN-BODY-background);
+    margin-top: var(--BODY-TOP-OFFSET); /* Offset for contao-network topbar */
+}
+
+#main > #sidebar {
+    top: var(--BODY-TOP-OFFSET);
+    transition: unset; /* Unset top transition */
+}
+
+#main #top-bar-sticky-wrapper.is-sticky > #top-bar {
+    top: var(--BODY-TOP-OFFSET) !important;
+}
+
 
 textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[type="password"]:focus, input[type="search"]:focus, input[type="tel"]:focus, input[type="text"]:focus, input[type="url"]:focus, input[type="color"]:focus, input[type="date"]:focus, input[type="datetime"]:focus, input[type="datetime-local"]:focus, input[type="month"]:focus, input[type="time"]:focus, input[type="week"]:focus, select[multiple=multiple]:focus {
     border-color: none;
@@ -966,19 +990,4 @@ html[data-theme=dark] #toc-menu,
     .banner .title {
         padding-right: 3rem;
     }
-}
-
-/* contao.org Top Navigation */
-#body { top: 40px; }
-#sidebar { top: 34px; }
-
-#contao-network {
-  position: fixed;
-  width: 100%;
-  z-index: 9999;
-}
-
-/* Correction sticky #top-bar */
-.sticky-wrapper.is-sticky > #top-bar {
-  top: 34px !important;
 }


### PR DESCRIPTION
### Description

This should handle all the issues that were recently introduced in #1416 and everything mentioned in #1423 and #1424

* Wrapping the docs content into a `<div id="main">`-container to make sure that `#contao-network` is the only other sibling 17fd5eb48bcfd56f0a6ee029a022ef3800902421 4004d96b925c4f0af12d59542b80a72915a6fb60

* consider FOUC (Flash of unstyled content in dark mode) and CLS (Cumulative Layout Shift) on first visit 6cc4118df79f24b7e6998df71e49d90fa1a342c9

* handle dynamically added nodes (replacement for #1425) df768eec90fc76cbcd50f947e4f8efb4b690a51a
