### PR TITLE
Fix breadcrumbs tablet view

### DIFF
--- a/page/i18n/de.toml
+++ b/page/i18n/de.toml
@@ -1,2 +1,2 @@
 [Edit-this-page]
-other = "Diese Seite bearbeiten"
+other = "Seite bearbeiten"


### PR DESCRIPTION
The "Diese Seite bearbeiten" (only DE) causes the following display in tablet view. 

![image](https://github.com/user-attachments/assets/5b62e521-ffbd-4aa2-b367-ce54aec38588)

If we would shorten the text it fits again.

![image](https://github.com/user-attachments/assets/efe8974e-f630-4ffa-9516-60e5408f911b)

