### PR TITLE
Update deprecated Security service in parseTemplate.md

### DIFF
--- a/docs/dev/reference/hooks/parseTemplate.md
+++ b/docs/dev/reference/hooks/parseTemplate.md
@@ -53,16 +53,14 @@ use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\FrontendTemplate;
 use Contao\Template;
-use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 #[AsHook('parseTemplate')]
 class ParseTemplateListener
 {
-    private $security;
-
-    public function __construct(Security $security)
-    {
-        $this->security = $security;
+    public function __construct(
+        private readonly AuthorizationCheckerInterface $authorizationChecker
+    ) {
     }
 
     public function __invoke(Template $template): void
@@ -72,7 +70,7 @@ class ParseTemplateListener
         }
 
         $template->isMemberOf = function ($groupId): bool {
-            return $this->security->isGranted(ContaoCorePermissions::MEMBER_IN_GROUPS, $groupId);
+            return $this->authorizationChecker->isGranted(ContaoCorePermissions::MEMBER_IN_GROUPS, $groupId);
         };
     }
 }

--- a/docs/dev/reference/hooks/parseTemplate.md
+++ b/docs/dev/reference/hooks/parseTemplate.md
@@ -53,7 +53,7 @@ use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\FrontendTemplate;
 use Contao\Template;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 
 #[AsHook('parseTemplate')]
 class ParseTemplateListener


### PR DESCRIPTION
New bundle in Symfony 7:
use Symfony\Bundle\SecurityBundle\Security;
Instead of the previous version:
use Symfony\Component\Security\Core\Security;

Old service was deprecated with Symfony 6.2:
https://github.com/symfony/security-bundle/blob/7.1/CHANGELOG.md#62