### PR TITLE
Add warning regarding the use of Symfony Forms

### DIFF
--- a/docs/dev/framework/request-tokens.md
+++ b/docs/dev/framework/request-tokens.md
@@ -152,6 +152,12 @@ class MyCustomService
 }
 ```
 
+{{% notice warning %}}
+If you are using Symfony forms to store records that will be shown in the backend or are rendered in the frontend using
+legacy templates, keep in mind that there won't be any input encoding! Without careful treatment, this will result in XSS
+vulnerabilities!
+{{% /notice %}}
+
 ## Deprecated Constants, Configuration Settings and more
 
 For historical reasons, you may still come across the following constants or configuration settings.


### PR DESCRIPTION
Followup to #1441 

You can easily shoot yourself in the foot using Symfony Forms in an environment with input encoding. Let's add a warning.