### PR TITLE
Add double_encode parameter to escape filter

### DIFF
--- a/docs/dev/framework/templates/architecture.md
+++ b/docs/dev/framework/templates/architecture.md
@@ -567,6 +567,14 @@ $contaoExtension = $twig->getExtension(ContaoExtension::class);
 $contaoExtension->addContaoEscaperRule('%^@MyNamespace/%');
 ```
 
+Since Contao 5.3.19 and 5.4.7 you can opt into double encoding by passing `double_encode = true` to the escape filter.
+This is usually required if you have HTML code nested in another language like JSON. For the `|json_encode` Twig filter
+double encoding is enabled automatically.
+
+```twig
+{{ my_json|e('html', double_encode = true) }}
+{{ my_data|json_encode }}
+```
 
 ## Legacy interoperability
 

--- a/docs/dev/framework/templates/architecture.md
+++ b/docs/dev/framework/templates/architecture.md
@@ -568,11 +568,11 @@ $contaoExtension->addContaoEscaperRule('%^@MyNamespace/%');
 ```
 
 Since Contao 5.3.19 and 5.4.7 you can opt into double encoding by passing `double_encode = true` to the escape filter.
-This is usually required if you have HTML code nested in another language like JSON. For the `|json_encode` Twig filter
-double encoding is enabled automatically.
+This is usually required if you have HTML code nested in another language. For JSON double encoding is enabled automatically.
 
 ```twig
-{{ my_json|e('html', double_encode = true) }}
+{{ my_data|e('html', double_encode = true) }}
+{{ attrs().setDoubleEncoding(true).set('data-foo', my_data) }}
 {{ my_data|json_encode }}
 ```
 


### PR DESCRIPTION
After https://github.com/contao/contao/pull/7556 was merged

If you have a json like `["Foo &quot;Bar&quot; Baz"]` and you want to output it in Twig with `data-json="{{ my_json }}"` you currently get `data-json="[&quot;Foo &quot;Bar&quot; Baz&quot;]"` which is invalid because it decodes in the browser to `["Foo "Bar" Baz"]`.

This can now be prevented by using `data-json="{{ my_json|e('html', double_encode = true) }}"`