### PR TITLE
Replace ScriptHandler with contao-setup script

### DIFF
--- a/docs/dev/getting-started/initial-setup/managed-edition.md
+++ b/docs/dev/getting-started/initial-setup/managed-edition.md
@@ -60,10 +60,10 @@ run `composer create-project contao/managed-edition`:
 {
     "scripts": {
         "post-install-cmd": [
-            "@php vendor/bin/contao-setup --ansi"
+            "@php vendor/bin/contao-setup"
         ],
         "post-update-cmd": [
-            "@php vendor/bin/contao-setup --ansi"
+            "@php vendor/bin/contao-setup"
         ]
     }
 }

--- a/docs/dev/getting-started/initial-setup/managed-edition.md
+++ b/docs/dev/getting-started/initial-setup/managed-edition.md
@@ -60,18 +60,18 @@ run `composer create-project contao/managed-edition`:
 {
     "scripts": {
         "post-install-cmd": [
-            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
+            "@php vendor/bin/contao-setup --ansi"
         ],
         "post-update-cmd": [
-            "Contao\\ManagerBundle\\Composer\\ScriptHandler::initializeApplication"
+            "@php vendor/bin/contao-setup --ansi"
         ]
     }
 }
 ```
 
-So after every `composer update` or `composer install`, the `ScriptHandler` of the `Managed Edition` is called so it is
+So after every `composer update` or `composer install`, the `contao-setup` script of the `Managed Edition` is called so it is
 able to initialize the application.
-Here are examples of what the `ScriptHandler` does to give you an idea about its responsibilities:
+Here are examples of what the `contao-setup` script does to give you an idea about its responsibilities:
 
 * Creating the whole application structure. Folders such as the `app` and the `web` folders with the entry points.
 * It purges and rebuilds the cache


### PR DESCRIPTION
ScriptHandler is deprecated since Contao 4.11

Following deprecation notice is issued:
```
Deprecation Notice: Since contao/manager-bundle 4.11: Using ScriptHandler::initializeApplication() has been deprecated and will no longer work in Contao 5.0. Use the "contao-setup" binary instead. in phar://.../bin/composer/vendor/symfony/deprecation-contracts/function.php:25
Please edit your root composer.json and set "post-install-cmd" to "@php vendor/bin/contao-setup --ansi" instead of using "ScriptHandler::initializeApplication()".
```