### PR TITLE
Update the configuration docs

### DIFF
--- a/docs/dev/reference/config.md
+++ b/docs/dev/reference/config.md
@@ -74,6 +74,13 @@ contao:
 
     # Allows to define Symfony Messenger workers (messenger:consume). Workers are started every minute using the Contao cron job framework.
     messenger:
+        # Contao provides a way to work on Messenger transports in the web process (kernel.terminate) if there is no real "messenger:consume" worker. You can configure its behavior here.'
+        web_worker:
+
+          # The transports to apply the web worker logic to.
+          transports:     []
+          grace_period:   PT10M # Must be a valid string for \DateInterval()
+
         workers:
 
             # Prototype
@@ -133,7 +140,12 @@ contao:
 
             # Allows to disable the layer flattening of animated images. Set this option to false to support animations. It has no effect with Gd as Imagine service.
             flatten:              ~
+
+            # One of the Imagine\Image\ImageInterface::INTERLACE_* constants.
             interlace:            plane
+
+            # Filter used when downsampling images. One of the Imagine\Image\ImageInterface::FILTER_* constants. It has no effect with Gd or SVG as Imagine service.
+            resampling-filter:    ~
 
         # Contao automatically uses an Imagine service out of Gmagick, Imagick and Gd (in this order). Set a service ID here to override.
         imagine_service:      null
@@ -313,7 +325,7 @@ contao:
             # Example:
             - files/backend/custom.js
 
-        # Configures the title of the badge in the back end.
+        # Configures the title of the badge in the back end and the Contao Manager.
         badge_title:          '' # Example: develop
 
         # Defines the path of the Contao backend.
@@ -469,7 +481,12 @@ contao:
 
             # Allows to disable the layer flattening of animated images. Set this option to false to support animations. It has no effect with Gd as Imagine service.
             flatten:              ~
+
+            # One of the Imagine\Image\ImageInterface::INTERLACE_* constants.
             interlace:            plane
+
+            # Filter used when downsampling images. One of the Imagine\Image\ImageInterface::FILTER_* constants. It has no effect with Gd or SVG as Imagine service.
+            resampling-filter:    ~
 
         # Contao automatically uses an Imagine service out of Gmagick, Imagick and Gd (in this order). Set a service ID here to override.
         imagine_service:      null
@@ -606,7 +623,7 @@ contao:
             # Example:
             - files/backend/custom.js
 
-        # Configures the title of the badge in the back end.
+        # Configures the title of the badge in the back end and the Contao Manager.
         badge_title:          '' # Example: develop
 
         # Defines the path of the Contao backend.
@@ -673,7 +690,7 @@ container is even built. Settings like trusted proxies or caching are considered
 (if it even needs to be booted thanks to the cache) so they cannot be part of the application itself.
 
 {{% notice info %}}
-Some of the environment variables, like `APP_SECRET`, `DATABASE_URL` and `MAILER_DSN` replace their respective counterparts 
+Some of the environment variables, like `APP_SECRET`, `DATABASE_URL` and `MAILER_DSN` replace their respective counterparts
 of the `config/parameters.yaml` and thus you should not use these parameters, if you are using the environment variable instead.
 {{% /notice %}}
 
@@ -685,15 +702,15 @@ in the `prod` mode, optimizing everything for production. If you want to put you
 mode to have additional logging and debugging output, set `APP_ENV` to `dev`. Never do this for production sites!
 If you set the environment manually, you will no longer be able to toggle the debug mode from the back end as a
 Contao administrator.
-    
+
 
 ### `APP_SECRET`
 
-The `APP_SECRET` environment variable is required e.g. to generate CSRF tokens. This is a string that should be 
-unique to your application and it's commonly used to add more entropy to security related operations. Its value 
-should be a series of characters, numbers and symbols chosen randomly and the recommended length is around 
+The `APP_SECRET` environment variable is required e.g. to generate CSRF tokens. This is a string that should be
+unique to your application and it's commonly used to add more entropy to security related operations. Its value
+should be a series of characters, numbers and symbols chosen randomly and the recommended length is around
 32 characters. As with any other security-related parameter, it is a good practice to change this value from time
-to time. However, keep in mind that changing this value will invalidate all signed URIs and Remember Me cookies. 
+to time. However, keep in mind that changing this value will invalidate all signed URIs and Remember Me cookies.
 That is why, after changing this value, you should regenerate the application cache and log out all the application
 users. For more information please visit the [Symfony documentation](https://symfony.com/doc/current/reference/configuration/framework.html#secret).
 
@@ -741,13 +758,13 @@ cookies of extensions you installed:
 ```
 COOKIE_ALLOW_LIST=PHPSESSID,csrf_https-contao_csrf_token,csrf_contao_csrf_token,trusted_device,REMEMBERME
 ```
-    
+
 {{% notice note %}}
 The name of the PHP session cookie is configurable through the `php.ini` so you might want to check if it's `PHPSESSID`
 for you too. Moreover, the CSRF cookie is different for `http` and `https` for security reasons. If you serve your
 website over `http`, note that the cookie name will be `csrf_http-contao_csrf_token`.
 However, protecting your users from CSRF attacks but let them submit the form via unsecured `http` connections is
-not really a valid use case. 
+not really a valid use case.
 {{% /notice %}}
 
 ### `COOKIE_REMOVE_FROM_DENY_LIST`
@@ -794,8 +811,8 @@ present as otherwise you are back to having thousands of cache entries in your c
 
 ### `DATABASE_URL`
 
-The database connection information is stored as an environment variable called `DATABASE_URL`. It defines 
-the database user name, database password, host name, port and database name that will be used by your Contao system. 
+The database connection information is stored as an environment variable called `DATABASE_URL`. It defines
+the database user name, database password, host name, port and database name that will be used by your Contao system.
 The format of this variable is the following: `DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name"`.
 It is used by default for the Doctrine configuration: `doctrine.dbal.url: '%env(DATABASE_URL)%'`.
 
@@ -803,14 +820,14 @@ It is used by default for the Doctrine configuration: `doctrine.dbal.url: '%env(
 ### `MAILER_DSN`
 
 The mailer connection information is stored as an environment variable called `MAILER_DSN`. It defines the transport to
-be used for sending emails, as well as the login credentials, host name and port for an SMTP server for example, if 
+be used for sending emails, as well as the login credentials, host name and port for an SMTP server for example, if
 applicable. The format of this variable is the following: `MAILER_DSN=smtp://username:password@smtp.example.com:465?encryption=ssl`.
 See the [Symfony Swiftmailer Bundle Documentation][SymfonySwiftmailer] for more information.
 
 {{% notice note %}}
 The variable was previously called `MAILER_URL`. Since Contao 5.0 only `MAILER_DSN` will be supported.
 {{% /notice %}}
-    
+
 
 ### `TRUSTED_PROXIES`
 
@@ -821,10 +838,10 @@ For example, instead of reading the `REMOTE_ADDR` header (which will now be the 
 the user's true IP will be stored in a standard `Forwarded: for="…"` header or a `X-Forwarded-For` header.
 If you don't configure the Managed Edition to look for these headers, you'll get incorrect information about the
 client's IP address, whether or not the client is connecting via HTTPS, the client's port and the hostname being
-requested. Let's say your load balancer runs on IP `192.0.2.1`. You can trust that IP by setting `TRUSTED_PROXIES` 
+requested. Let's say your load balancer runs on IP `192.0.2.1`. You can trust that IP by setting `TRUSTED_PROXIES`
 to `192.0.2.1`. You can also trust a whole IP range if you like to: `TRUSTED_PROXIES=192.0.2.0/24`. See the
 [Symfony Documentation on Proxies][SymfonyProxies] for more information.
-    
+
 
 ### `TRUSTED_HOSTS`
 
@@ -832,7 +849,7 @@ The same explanation as for `TRUSTED_PROXIES` and the IP example, also applies t
 originally sent `Host` HTTP header. You would get the host name of your proxy but if you add your proxy host name
 to the list of trusted proxies, you will get the host name that was requested in the original request:
 `TRUSTED_HOSTS=my.proxy.com`
-        
+
 
 ### `DNS_MAPPING`
 
@@ -860,7 +877,7 @@ DNS_MAPPING='{
 }'
 ```
 
-This allows you to - for example - copy the live database to your staging or local environment and then automatically 
+This allows you to - for example - copy the live database to your staging or local environment and then automatically
 change the domains according to the mapping in the respective environment during `contao:migrate`.
 
 You can also migrate the `useSSL` setting to different settings in the respective environment, which might be

--- a/docs/dev/reference/config.md
+++ b/docs/dev/reference/config.md
@@ -690,7 +690,7 @@ container is even built. Settings like trusted proxies or caching are considered
 (if it even needs to be booted thanks to the cache) so they cannot be part of the application itself.
 
 {{% notice info %}}
-Some of the environment variables, like `APP_SECRET`, `DATABASE_URL` and `MAILER_DSN` replace their respective counterparts
+Some of the environment variables, like `APP_SECRET`, `DATABASE_URL` and `MAILER_DSN` replace their respective counterparts 
 of the `config/parameters.yaml` and thus you should not use these parameters, if you are using the environment variable instead.
 {{% /notice %}}
 
@@ -702,15 +702,15 @@ in the `prod` mode, optimizing everything for production. If you want to put you
 mode to have additional logging and debugging output, set `APP_ENV` to `dev`. Never do this for production sites!
 If you set the environment manually, you will no longer be able to toggle the debug mode from the back end as a
 Contao administrator.
-
+    
 
 ### `APP_SECRET`
 
-The `APP_SECRET` environment variable is required e.g. to generate CSRF tokens. This is a string that should be
-unique to your application and it's commonly used to add more entropy to security related operations. Its value
-should be a series of characters, numbers and symbols chosen randomly and the recommended length is around
+The `APP_SECRET` environment variable is required e.g. to generate CSRF tokens. This is a string that should be 
+unique to your application and it's commonly used to add more entropy to security related operations. Its value 
+should be a series of characters, numbers and symbols chosen randomly and the recommended length is around 
 32 characters. As with any other security-related parameter, it is a good practice to change this value from time
-to time. However, keep in mind that changing this value will invalidate all signed URIs and Remember Me cookies.
+to time. However, keep in mind that changing this value will invalidate all signed URIs and Remember Me cookies. 
 That is why, after changing this value, you should regenerate the application cache and log out all the application
 users. For more information please visit the [Symfony documentation](https://symfony.com/doc/current/reference/configuration/framework.html#secret).
 
@@ -758,13 +758,13 @@ cookies of extensions you installed:
 ```
 COOKIE_ALLOW_LIST=PHPSESSID,csrf_https-contao_csrf_token,csrf_contao_csrf_token,trusted_device,REMEMBERME
 ```
-
+    
 {{% notice note %}}
 The name of the PHP session cookie is configurable through the `php.ini` so you might want to check if it's `PHPSESSID`
 for you too. Moreover, the CSRF cookie is different for `http` and `https` for security reasons. If you serve your
 website over `http`, note that the cookie name will be `csrf_http-contao_csrf_token`.
 However, protecting your users from CSRF attacks but let them submit the form via unsecured `http` connections is
-not really a valid use case.
+not really a valid use case. 
 {{% /notice %}}
 
 ### `COOKIE_REMOVE_FROM_DENY_LIST`
@@ -811,8 +811,8 @@ present as otherwise you are back to having thousands of cache entries in your c
 
 ### `DATABASE_URL`
 
-The database connection information is stored as an environment variable called `DATABASE_URL`. It defines
-the database user name, database password, host name, port and database name that will be used by your Contao system.
+The database connection information is stored as an environment variable called `DATABASE_URL`. It defines 
+the database user name, database password, host name, port and database name that will be used by your Contao system. 
 The format of this variable is the following: `DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name"`.
 It is used by default for the Doctrine configuration: `doctrine.dbal.url: '%env(DATABASE_URL)%'`.
 
@@ -820,14 +820,14 @@ It is used by default for the Doctrine configuration: `doctrine.dbal.url: '%env(
 ### `MAILER_DSN`
 
 The mailer connection information is stored as an environment variable called `MAILER_DSN`. It defines the transport to
-be used for sending emails, as well as the login credentials, host name and port for an SMTP server for example, if
+be used for sending emails, as well as the login credentials, host name and port for an SMTP server for example, if 
 applicable. The format of this variable is the following: `MAILER_DSN=smtp://username:password@smtp.example.com:465?encryption=ssl`.
 See the [Symfony Swiftmailer Bundle Documentation][SymfonySwiftmailer] for more information.
 
 {{% notice note %}}
 The variable was previously called `MAILER_URL`. Since Contao 5.0 only `MAILER_DSN` will be supported.
 {{% /notice %}}
-
+    
 
 ### `TRUSTED_PROXIES`
 
@@ -838,10 +838,10 @@ For example, instead of reading the `REMOTE_ADDR` header (which will now be the 
 the user's true IP will be stored in a standard `Forwarded: for="…"` header or a `X-Forwarded-For` header.
 If you don't configure the Managed Edition to look for these headers, you'll get incorrect information about the
 client's IP address, whether or not the client is connecting via HTTPS, the client's port and the hostname being
-requested. Let's say your load balancer runs on IP `192.0.2.1`. You can trust that IP by setting `TRUSTED_PROXIES`
+requested. Let's say your load balancer runs on IP `192.0.2.1`. You can trust that IP by setting `TRUSTED_PROXIES` 
 to `192.0.2.1`. You can also trust a whole IP range if you like to: `TRUSTED_PROXIES=192.0.2.0/24`. See the
 [Symfony Documentation on Proxies][SymfonyProxies] for more information.
-
+    
 
 ### `TRUSTED_HOSTS`
 
@@ -849,7 +849,7 @@ The same explanation as for `TRUSTED_PROXIES` and the IP example, also applies t
 originally sent `Host` HTTP header. You would get the host name of your proxy but if you add your proxy host name
 to the list of trusted proxies, you will get the host name that was requested in the original request:
 `TRUSTED_HOSTS=my.proxy.com`
-
+        
 
 ### `DNS_MAPPING`
 
@@ -877,7 +877,7 @@ DNS_MAPPING='{
 }'
 ```
 
-This allows you to - for example - copy the live database to your staging or local environment and then automatically
+This allows you to - for example - copy the live database to your staging or local environment and then automatically 
 change the domains according to the mapping in the respective environment during `contao:migrate`.
 
 You can also migrate the `useSSL` setting to different settings in the respective environment, which might be

--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -11,15 +11,15 @@ Die Systemeinstellungen verabschieden sich langsam aber sicher aus dem Backend. 
 beeinflussen Contao als Applikation und somit besteht auch die Chance, dass durch eine falsche Einstellung das System
 in einen funktionsuntüchtigen Zustand gebracht wird. Sollte dies geschehen, hast du keine Möglichkeit mehr,
 die Einstellungen rückgängig zu machen und das System wiederherzustellen, da du dich nicht mehr einloggen kannst.
-Aus diesem Grund werden die meisten Einstellungen außerhalb von Contao über die `config.yaml` vorgenommen bzw. können 
+Aus diesem Grund werden die meisten Einstellungen außerhalb von Contao über die `config.yaml` vorgenommen bzw. können
 zukünftig über den Contao Manager vorgenommen werden.
 
 ## Einstellungen
 
 ### Globale Einstellungen
 
-**E-Mail-Adresse des Systemadministrators:** An diese Adresse werden z. B. Benachrichtigungen über gesperrte Konten 
-oder neu registrierte Benutzer geschickt. Du kannst auch folgende Notation verwenden, um einen Namen zur E-Mail-Adresse 
+**E-Mail-Adresse des Systemadministrators:** An diese Adresse werden z. B. Benachrichtigungen über gesperrte Konten
+oder neu registrierte Benutzer geschickt. Du kannst auch folgende Notation verwenden, um einen Namen zur E-Mail-Adresse
 hinzuzufügen:
 
 ```text
@@ -28,8 +28,8 @@ Kevin Jones [kevin.jones@example.com]
 
 ### Datum und Zeit
 
-**Datums- und Zeitformat:** Alle Datums- und Zeitformate müssen wie in der 
-[PHP-Funktion date](https://www.php.net/manual/de/function.date.php) eingegeben werden. Contao verarbeitet im Backend 
+**Datums- und Zeitformat:** Alle Datums- und Zeitformate müssen wie in der
+[PHP-Funktion date](https://www.php.net/manual/de/function.date.php) eingegeben werden. Contao verarbeitet im Backend
 ausschließlich numerische Formate, also die Buchstaben j, d, m, n, y, Y, g, G, h, H, i und s.
 
 Hier sind einige Beispiele gültiger Datums- und Zeitangaben:
@@ -44,23 +44,23 @@ Hier sind einige Beispiele gültiger Datums- und Zeitangaben:
 | H:i:s    | 24 Stunden, Minuten und Sekunden, z. B. `20:36:59`            |
 | g:i      | 12 Stunden ohne führende Nullen sowie Minuten, z. B. `8:36`   |
 
-**Zeitzone:** Die Zeitzone solltest du unbedingt vor dem Erstellen deiner Webseite einstellen, da Contao alle 
-Zeitangaben als [Unix-Zeitstempel](https://www.php.net/time) speichert und Contao diese Zeitstempel bei einer Änderung 
+**Zeitzone:** Die Zeitzone solltest du unbedingt vor dem Erstellen deiner Webseite einstellen, da Contao alle
+Zeitangaben als [Unix-Zeitstempel](https://www.php.net/time) speichert und Contao diese Zeitstempel bei einer Änderung
 der Zeitzone nicht automatisch anpasst.
 
 
 ### Backend-Einstellungen
 
-**Elemente nicht verkürzen:** Im »Parent View« stellt Contao die Elemente aus Gründen der Übersichtlichkeit verkürzt 
-dar, wobei einzelne Elemente über ein Navigationsicon bei Bedarf ausgeklappt werden können. Wähle diese Option, um das 
+**Elemente nicht verkürzen:** Im »Parent View« stellt Contao die Elemente aus Gründen der Übersichtlichkeit verkürzt
+dar, wobei einzelne Elemente über ein Navigationsicon bei Bedarf ausgeklappt werden können. Wähle diese Option, um das
 Feature komplett zu deaktivieren.
 
-**Elemente pro Seite:** Im Abschnitt [Datensätze auflisten](../../administrationsbereich/datensaetze-auflisten/#datensaetze-sortieren-und-filtern) 
-hast du gelernt, dass Contao die Anzahl der Datensätze pro Seite standardmäßig auf 30 begrenzt. Diesen Wert kannst du 
+**Elemente pro Seite:** Im Abschnitt [Datensätze auflisten](../../administrationsbereich/datensaetze-auflisten/#datensaetze-sortieren-und-filtern)
+hast du gelernt, dass Contao die Anzahl der Datensätze pro Seite standardmäßig auf 30 begrenzt. Diesen Wert kannst du
 hier beliebig anpassen. Höhere Werte bedeuten jedoch eine längere Ladezeit.
 
-**Maximum Datensätze pro Seite:** Um zu verhindern, dass ein unbedarfter Benutzer sich 5000 Datensätze auf einmal 
-anzeigen lässt und damit das PHP Memory Limit überschreitet, kannst du festlegen, wie viele Datensätze maximal pro Seite 
+**Maximum Datensätze pro Seite:** Um zu verhindern, dass ein unbedarfter Benutzer sich 5000 Datensätze auf einmal
+anzeigen lässt und damit das PHP Memory Limit überschreitet, kannst du festlegen, wie viele Datensätze maximal pro Seite
 angezeigt werden dürfen.
 
 #### Zusätzliche Backend-Einstellungen:
@@ -101,29 +101,29 @@ Ab Version **4.10** wird die folgende Einstellung im Startpunkt der Webseite vor
 {{% /notice %}}
 
 **Ordner-URLs verwenden:** Hier kannst du Ordnerstrukturen in Seitenaliasen aktivieren. Damit werden die in der
-Seitenhierarchie vorhandenen Aliase in den Alias mit übernommen z. B. die Seite »Download« im Seitenpfad 
+Seitenhierarchie vorhandenen Aliase in den Alias mit übernommen z. B. die Seite »Download« im Seitenpfad
 »Docs > Install« zu `docs/install/download.html` anstatt nur `download.html`.
 
 {{% notice note %}}
 Ab Version **4.10** ist diese Einstellung entfallen:
 {{% /notice %}}
 
-**Leere URLs nicht umleiten:** Ermöglicht die Deaktivierung der Umleitung der "leeren URL" auf die Startseite der sprachlichen Website-Root des Browsers 
+**Leere URLs nicht umleiten:** Ermöglicht die Deaktivierung der Umleitung der "leeren URL" auf die Startseite der sprachlichen Website-Root des Browsers
 bei Verwendung des [Legacy-Routing-Modus][LegacyRouting] ohne `contao.prepend_locale`: true _(nicht empfohlen)_.
 
 
 ### Sicherheitseinstellungen
 
-**Anfrage-Tokens deaktivieren:** Hier kannst du aktivieren, dass die Anfrage-Token beim Absenden eines Formulars nicht 
+**Anfrage-Tokens deaktivieren:** Hier kannst du aktivieren, dass die Anfrage-Token beim Absenden eines Formulars nicht
 geprüft werden _(unsicher!)_.
 
-**Erlaubte HTML-Tags:** Standardmäßig erlaubt Contao keine HTML-Tags in Formularen und entfernt diese beim Speichern 
-automatisch. Für Eingabefelder, bei denen die Nutzung von HTML erwünscht ist, kannst du hier eine Liste erlaubter 
+**Erlaubte HTML-Tags:** Standardmäßig erlaubt Contao keine HTML-Tags in Formularen und entfernt diese beim Speichern
+automatisch. Für Eingabefelder, bei denen die Nutzung von HTML erwünscht ist, kannst du hier eine Liste erlaubter
 HTML-Tags festlegen.
 
-{{< version-tag "4.11.7, 4.9.18 und 4.4.56" >}} **Erlaubte HTML-Attribute:** Die Liste der erlaubten HTML-Attribute für Eingabefelder kannst du hier beliebig erweitern. 
-Wenn ein HTML-Attribute in der Liste nicht vorhanden ist, wird es beim Abspeichern automatisch entfernt. Das Tag bzw. 
-der Attributname * steht für alle Tags bzw. Attribute. Für Attribute mit Bindestrichen können Platzhalter wie z. B. 
+{{< version-tag "4.11.7, 4.9.18 und 4.4.56" >}} **Erlaubte HTML-Attribute:** Die Liste der erlaubten HTML-Attribute für Eingabefelder kannst du hier beliebig erweitern.
+Wenn ein HTML-Attribute in der Liste nicht vorhanden ist, wird es beim Abspeichern automatisch entfernt. Das Tag bzw.
+der Attributname * steht für alle Tags bzw. Attribute. Für Attribute mit Bindestrichen können Platzhalter wie z. B.
 data-* benutzt werden.
 
 **Passwort-Hash:** Standardmäßig verwendet Contao den Default der aktuellen PHP-Version, hier kannst du aber auch einen Wert festlegen. Dieses ist z. B. nötig, wenn du das Passwort in ein weiteres System wie LDAP synchronisieren möchtest.
@@ -137,66 +137,66 @@ security:
       Contao\User: 'auto' # Hash function: bcrypt, sha256, sha512 ...
 ```
 
-**Beispiele:**  
-`<iframe>` ist in den erlaubten HTML-Tags nicht vorhanden, kann aber einfach unter Schlüssel eingefügt werden. 
+**Beispiele:**
+`<iframe>` ist in den erlaubten HTML-Tags nicht vorhanden, kann aber einfach unter Schlüssel eingefügt werden.
 
-{{% notice note %}}  
-Um die selbst hinzugefügten HTML-Tags besser zu erkennen, sollten diese zu Beginn der Liste eingetragen werden.  
-{{% /notice %}}  
+{{% notice note %}}
+Um die selbst hinzugefügten HTML-Tags besser zu erkennen, sollten diese zu Beginn der Liste eingetragen werden.
+{{% /notice %}}
 
-In den erlaubten HTML-Attributen, als Wert muss hierzu dann auch noch das Attribut mit eingefügt werden.  
+In den erlaubten HTML-Attributen, als Wert muss hierzu dann auch noch das Attribut mit eingefügt werden.
 
-`<nav>` und `<input>` sind beispielsweise bereits in den erlaubten HTML-Tags vorhanden und können damit einfach mit erlaubten Attributen erweitert werden.  
+`<nav>` und `<input>` sind beispielsweise bereits in den erlaubten HTML-Tags vorhanden und können damit einfach mit erlaubten Attributen erweitert werden.
 Dazu als Schlüssel `nav` bzw. `input` eintragen und als Wert der gewünschte Wert - in unserem Beispiel `role` bzw. `type`.
 
-Falls du allen Backend-Benutzern zu 100% vertraust, kannst du auch als Schlüssel `*` und als Wert `*` eintragen. Hierdurch sind alle Attribute für alle Elemente erlaubt.  
+Falls du allen Backend-Benutzern zu 100% vertraust, kannst du auch als Schlüssel `*` und als Wert `*` eintragen. Hierdurch sind alle Attribute für alle Elemente erlaubt.
 
 ![Sicherheitseinstellungen]({{% asset "images/manual/system/de/security-settings-de.png" %}}?classes=shadow)
 
 
 ### Dateien und Bilder
 
-**Erlaubte Download-Dateitypen:** Hier kannst du festlegen, welche Dateitypen von deinem Server heruntergeladen werden 
+**Erlaubte Download-Dateitypen:** Hier kannst du festlegen, welche Dateitypen von deinem Server heruntergeladen werden
 dürfen (Download).
 
-**Maximale GD-Bildbreite:** Hier kannst du festlegen, wie breit Bilder sein dürfen, damit sie von der GD 
+**Maximale GD-Bildbreite:** Hier kannst du festlegen, wie breit Bilder sein dürfen, damit sie von der GD
 Bildbearbeitungs-Bibliothek noch verarbeitet werden können. Jegliche Bilder, die diesen Wert übersteigen, werden nicht
 verarbeitet.
 
-**Maximale GD-Bildhöhe:** Hier kannst du festlegen, wie hoch Bilder sein dürften, damit sie von der GD 
+**Maximale GD-Bildhöhe:** Hier kannst du festlegen, wie hoch Bilder sein dürften, damit sie von der GD
 Bildbearbeitungs-Bibliothek noch verarbeitet werden können. Jegliche Bilder, die diesen Wert übersteigen, werden nicht
 verarbeitet.
 
 
 ### Datei-Uploads
 
-**Erlaubte Upload-Dateitypen:** Hier kannst du festlegen, welche Dateitypen auf deinen Server übertragen werden dürfen 
+**Erlaubte Upload-Dateitypen:** Hier kannst du festlegen, welche Dateitypen auf deinen Server übertragen werden dürfen
 (Upload).
 
-**Maximale Upload-Dateigröße:** Hier kannst du festlegen, wie groß eine mit der Dateiverwaltung auf deinen Server 
-übertragene Datei maximal sein darf. Die Eingabe erfolgt in Bytes (1 MiB = 1024 KiB = 1.048.576 Bytes). Größere Dateien 
+**Maximale Upload-Dateigröße:** Hier kannst du festlegen, wie groß eine mit der Dateiverwaltung auf deinen Server
+übertragene Datei maximal sein darf. Die Eingabe erfolgt in Bytes (1 MiB = 1024 KiB = 1.048.576 Bytes). Größere Dateien
 werden abgelehnt.
 
-**Maximale Bildbreite:** Beim Upload von Bildern prüft die Dateiverwaltung automatisch deren Breite und vergleicht diese 
-Werte mit deiner hier festgelegten Vorgabe. Überschreitet ein Bild die maximale Breite, wird es automatisch 
+**Maximale Bildbreite:** Beim Upload von Bildern prüft die Dateiverwaltung automatisch deren Breite und vergleicht diese
+Werte mit deiner hier festgelegten Vorgabe. Überschreitet ein Bild die maximale Breite, wird es automatisch
 verkleinert.
 
-**Maximale Bildhöhe:** Beim Upload von Bildern prüft die Dateiverwaltung automatisch deren Höhe und vergleicht diese Werte 
+**Maximale Bildhöhe:** Beim Upload von Bildern prüft die Dateiverwaltung automatisch deren Höhe und vergleicht diese Werte
 mit deiner hier festgelegten Vorgabe. Überschreitet ein Bild die maximale Höhe, wird es automatisch verkleinert.
 
 
 ### Website-Suche
 
-**Suche aktivieren:** Wenn du diese Option auswählst, indiziert Contao die fertigen Seiten deiner Webseite und erstellt 
-daraus einen Suchindex. Mit dem Frontend-Modul 
-»[Suchmaschine](../../modulverwaltung/website-suche/#konfiguration-des-suchmoduls)« kannst du diesen Index dann 
+**Suche aktivieren:** Wenn du diese Option auswählst, indiziert Contao die fertigen Seiten deiner Webseite und erstellt
+daraus einen Suchindex. Mit dem Frontend-Modul
+»[Suchmaschine](../../modulverwaltung/website-suche/#konfiguration-des-suchmoduls)« kannst du diesen Index dann
 durchsuchen.
 
-**Geschützte Seiten indizieren:** Wähle diese Option, um auch geschützte Seiten für die Suche zu indizieren. Nutze 
+**Geschützte Seiten indizieren:** Wähle diese Option, um auch geschützte Seiten für die Suche zu indizieren. Nutze
 dieses Feature mit Bedacht, und achte darauf, personalisierte Seiten grundsätzlich von der Suche auszuschließen.
 
 {{% notice note %}}
-Ab Version **4.9** kommt ein neuer Such-Indexer zum Einsatz. Die Einstellungen **Suche aktivieren** und 
+Ab Version **4.9** kommt ein neuer Such-Indexer zum Einsatz. Die Einstellungen **Suche aktivieren** und
 **Geschützte Seiten indizieren** werden nun über die `config/config.yaml` konfiguriert:
 
 ```yaml
@@ -211,7 +211,7 @@ contao:
 
 ### Cronjob-Einstellungen
 
-**Den Command-Scheduler deaktivieren:** Hier kannst du den Periodic Command Scheduler deaktivieren und die 
+**Den Command-Scheduler deaktivieren:** Hier kannst du den Periodic Command Scheduler deaktivieren und die
 `_contao/cron`-Route mittels eines echten Cronjobs (den du selbst einrichten musst) ausführen. Seit Contao **4.9** kann
 auch folgendes Kommando benutzt werden:
 
@@ -221,27 +221,27 @@ php vendor/bin/contao-console contao:cron
 
 ### Standard-Zugriffsrechte
 
-**Standardbesitzer:** Hier kannst du vorgeben, welchem Benutzer standardmäßig die Seiten gehören, für die keine 
-Zugriffsrechte definiert wurden. Weitere Informationen dazu findest du im Abschnitt 
+**Standardbesitzer:** Hier kannst du vorgeben, welchem Benutzer standardmäßig die Seiten gehören, für die keine
+Zugriffsrechte definiert wurden. Weitere Informationen dazu findest du im Abschnitt
 [Zugriffsrechte](/de/seitenstruktur/regulaere-seite/#zugriffsrechte).
 
-**Standardgruppe:** Hier kannst du festlegen, welcher Gruppe standardmäßig die Seiten gehören, für die keine 
-Zugriffsrechte definiert wurden. Weitere Informationen dazu findest du im Abschnitt 
+**Standardgruppe:** Hier kannst du festlegen, welcher Gruppe standardmäßig die Seiten gehören, für die keine
+Zugriffsrechte definiert wurden. Weitere Informationen dazu findest du im Abschnitt
 [Zugriffsrechte](/de/seitenstruktur/regulaere-seite/#zugriffsrechte).
 
-**Standardzugriffsrechte:** Hier kannst du festlegen, welche Zugriffsrechte standardmäßig für die Seiten gelten, für 
-die keine speziellen Zugriffsrechte definiert wurden. Weitere Informationen dazu findest du im Abschnitt 
+**Standardzugriffsrechte:** Hier kannst du festlegen, welche Zugriffsrechte standardmäßig für die Seiten gelten, für
+die keine speziellen Zugriffsrechte definiert wurden. Weitere Informationen dazu findest du im Abschnitt
 [Zugriffsrechte](/de/seitenstruktur/regulaere-seite/#zugriffsrechte).
 
 
 
 ## parameters.yaml
 
-In der Contao Managed Edition werden die Parameter (z. B. Datenbankdaten) in der `parameters.yaml` abgelegt. 
-Auf diese Daten greift auch das Contao-Installtool zurück. Diese Datei wird normalerweise von der Versionierung 
+In der Contao Managed Edition werden die Parameter (z. B. Datenbankdaten) in der `parameters.yaml` abgelegt.
+Auf diese Daten greift auch das Contao-Installtool zurück. Diese Datei wird normalerweise von der Versionierung
 ausgenommen und kann auch zusätzliche Einträge wie z. B. die Angaben für den E-Mail-Versand über SMTP enthalten.
 
-Die Datei `parameters.yaml` findest du im Ordner `app/config/` und wird bei der Installation von Contao automatisch 
+Die Datei `parameters.yaml` findest du im Ordner `app/config/` und wird bei der Installation von Contao automatisch
 angelegt.
 
 {{% notice note %}}
@@ -266,12 +266,12 @@ Datenbankpasswörter, die nur aus Ziffern bestehen oder gewisse Sonderzeichen en
 
 ## config.yaml
 
-Die normale Bundle Config gehört in die `config.yaml` und befindet sich im Ordner `config/`. 
-Falls die Datei noch nicht vorhanden ist, muss diese angelegt werden. Contao lädt automatisch die `config_prod.yaml` 
+Die normale Bundle Config gehört in die `config.yaml` und befindet sich im Ordner `config/`.
+Falls die Datei noch nicht vorhanden ist, muss diese angelegt werden. Contao lädt automatisch die `config_prod.yaml`
 bzw. `config_dev.yaml` und falls nicht vorhanden die `config.yaml`.
 
-Damit kannst du unterschiedliche Konfigurationen für deine Test- bzw. Produktionsumgebung (dev/prod) realisieren (z. B. 
-mehr Logging im Debug Modus). Außerdem committest du die `config.yaml` im Gegensatz zur `parameters.yaml` in dein 
+Damit kannst du unterschiedliche Konfigurationen für deine Test- bzw. Produktionsumgebung (dev/prod) realisieren (z. B.
+mehr Logging im Debug Modus). Außerdem committest du die `config.yaml` im Gegensatz zur `parameters.yaml` in dein
 [Repository](https://de.wikipedia.org/wiki/Repository). Ein Repository kannst du verwenden, um deine Projekt-Versionen abzulegen, z. B. mit Git.
 
 {{% notice note %}}
@@ -295,282 +295,6 @@ php vendor/bin/contao-console debug:config contao
 ```
 
 {{< tabs groupId="bundle-config" >}}
-{{% tab name="Contao 4" %}}
-```yaml
-# Default configuration for extension with alias: "contao"
-contao:
-    csrf_cookie_prefix:   csrf_
-    csrf_token_name:      contao_csrf_token
-    encryption_key:       '%kernel.secret%'
-
-    # The error reporting level set when the framework is initialized. Defaults to E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED.
-    error_level:          8183
-    intl:
-
-        # Adds, removes or overwrites the list of ICU locale IDs. Defaults to all locale IDs known to the system.
-        locales:
-
-            # Examples:
-            - +de
-            - '-de_AT'
-            - gsw_CH
-
-        # Adds, removes or overwrites the list of enabled locale IDs that can be used in the Backend for example. Defaults to all languages for which a translation exists.
-        enabled_locales:
-
-            # Examples:
-            - +de
-            - '-de_AT'
-            - gsw_CH
-
-        # Adds, removes or overwrites the list of ISO 3166-1 alpha-2 country codes.
-        countries:
-
-            # Examples:
-            - +DE
-            - '-AT'
-            - CH
-
-    # Disabling legacy routing allows to configure the URL prefix and suffix per root page. However, it might not be compatible with third-party extensions.
-    legacy_routing:       true
-
-    # Allows to set TL_CONFIG variables, overriding settings stored in localconfig.php. Changes in the Contao back end will not have any effect.
-    localconfig:          ~
-
-    # Allows to configure which languages can be used in the Contao back end. Defaults to all languages for which a translation exists.
-    locales:              [] # Deprecated (Since contao/core-bundle 4.12: Using contao.locales is deprecated. Please use contao.intl.enabled_locales instead.)
-
-    # Whether or not to add the page language to the URL.
-    prepend_locale:       false # Deprecated (Since contao/core-bundle 4.10: The URL prefix is configured per root page since Contao 4.10. Using this option requires legacy routing.)
-
-    # Show customizable, pretty error screens instead of the default PHP error messages.
-    pretty_error_screens: false
-
-    # An optional entry point script that bypasses the front end cache for previewing changes (e.g. "/preview.php").
-    preview_script:       ''
-
-    # The folder used by the file manager.
-    upload_path:          files
-    editable_files:       'css,csv,html,ini,js,json,less,md,scss,svg,svgz,ts,txt,xliff,xml,yml,yaml'
-    url_suffix:           .html # Deprecated (Since contao/core-bundle 4.10: The URL suffix is configured per root page since Contao 4.10. Using this option requires legacy routing.)
-
-    # Absolute path to the web directory. Defaults to %kernel.project_dir%/public.
-    web_dir:              '%kernel.project_dir%/public' # Deprecated (Since contao/core-bundle 4.13: Setting the web directory in a config file is deprecated. Use the "extra.public-dir" config key in your root composer.json instead.)
-    image:
-
-        # Bypass the image cache and always regenerate images when requested. This also disables deferred image resizing.
-        bypass_cache:         false
-        imagine_options:
-            jpeg_quality:         80
-            jpeg_sampling_factors:
-
-                # Defaults:
-                - 2
-                - 1
-                - 1
-            png_compression_level: ~
-            png_compression_filter: ~
-            webp_quality:         ~
-            webp_lossless:        ~
-            avif_quality:         ~
-            avif_lossless:        ~
-            heic_quality:         ~
-            heic_lossless:        ~
-            jxl_quality:          ~
-            jxl_lossless:         ~
-
-            # Allows to disable the layer flattening of animated images. Set this option to false to support animations. It has no effect with Gd as Imagine service.
-            flatten:              ~
-            interlace:            plane
-
-        # Contao automatically uses an Imagine service out of Gmagick, Imagick and Gd (in this order). Set a service ID here to override.
-        imagine_service:      null
-
-        # Reject uploaded images exceeding the localconfig.gdMaxImgWidth and localconfig.gdMaxImgHeight dimensions.
-        reject_large_uploads: false
-
-        # Allows to define image sizes in the configuration file in addition to in the Contao back end. Use the special name "_defaults" to preset values for all sizes of the configuration file.
-        sizes:
-
-            # Prototype
-            name:
-                width:                ~
-                height:               ~
-                resize_mode:          ~ # One of "crop"; "box"; "proportional"
-                zoom:                 ~
-                css_class:            ~
-                lazy_loading:         ~
-                densities:            ~
-                sizes:                ~
-
-                # If the output dimensions match the source dimensions, the image will not be processed. Instead, the original file will be used.
-                skip_if_dimensions_match: ~
-
-                # Allows to convert one image format to another or to provide additional image formats for an image (e.g. WebP).
-                formats:
-
-                    # Examples:
-                    jpg:                 [jxl, webp, jpg]
-                    gif:                 [avif, png]
-
-                    # Prototype
-                    source:               []
-                items:
-
-                    # Prototype
-                    -
-                        width:                ~
-                        height:               ~
-                        resize_mode:          ~ # One of "crop"; "box"; "proportional"
-                        zoom:                 ~
-                        media:                ~
-                        densities:            ~
-                        sizes:                ~
-                        resizeMode:           ~ # One of "crop"; "box"; "proportional", Deprecated (Since contao/core-bundle 4.9: Using contao.image.sizes.*.items.resizeMode is deprecated. Please use contao.image.sizes.*.items.resize_mode instead.)
-                resizeMode:           ~ # One of "crop"; "box"; "proportional", Deprecated (Since contao/core-bundle 4.9: Using contao.image.sizes.*.resizeMode is deprecated. Please use contao.image.sizes.*.resize_mode instead.)
-                cssClass:             ~ # Deprecated (Since contao/core-bundle 4.9: Using contao.image.sizes.*.cssClass is deprecated. Please use contao.image.sizes.*.css_class instead.)
-                lazyLoading:          ~ # Deprecated (Since contao/core-bundle 4.9: Using contao.image.sizes.*.lazyLoading is deprecated. Please use contao.image.sizes.*.lazy_loading instead.)
-                skipIfDimensionsMatch: ~ # Deprecated (Since contao/core-bundle 4.9: Using contao.image.sizes.*.skipIfDimensionsMatch is deprecated. Please use contao.image.sizes.*.skip_if_dimensions_match instead.)
-
-        # The target directory for the cached images processed by Contao.
-        target_dir:           '%kernel.project_dir%/assets/images' # Example: '%kernel.project_dir%/assets/images'
-        target_path:          null # Deprecated (Since contao/core-bundle 4.9: Use the "contao.image.target_dir" parameter instead.)
-        valid_extensions:
-
-            # Defaults:
-            - jpg
-            - jpeg
-            - gif
-            - png
-            - tif
-            - tiff
-            - bmp
-            - svg
-            - svgz
-            - webp
-        preview:
-
-            # The target directory for the cached previews.
-            target_dir:           '%kernel.project_dir%/assets/previews' # Example: '%kernel.project_dir%/assets/previews'
-            default_size:         512
-            max_size:             1024
-
-            # Whether or not to generate previews for unsupported file types that show a file icon containing the file type.
-            enable_fallback_images: true
-    security:
-        two_factor:
-            enforce_backend:      false
-    search:
-
-        # The default search indexer, which indexes pages in the database.
-        default_indexer:
-            enable:               true
-
-        # Enables indexing of protected pages.
-        index_protected:      false
-
-        # The search index listener can index valid and delete invalid responses upon every request. You may limit it to one of the features or disable it completely.
-        listener:
-
-            # Enables indexing successful responses.
-            index:                true
-
-            # Enables deleting unsuccessful responses from the index.
-            delete:               true
-    crawl:
-
-        # Additional URIs to crawl. By default, only the ones defined in the root pages are crawled.
-        additional_uris:      []
-
-        # Allows to configure the default HttpClient options (useful for proxy settings, SSL certificate validation and more).
-        default_http_client_options: []
-    mailer:
-
-        # Specifies the mailer transports available for selection within Contao.
-        transports:
-
-            # Prototype
-            name:
-
-                # Overrides the "From" address for any e-mails sent with this mailer transport.
-                from:                 null
-    backend:
-
-        # Adds HTML attributes to the <body> tag in the back end.
-        attributes:
-
-            # Examples:
-            app-name:            'My App'
-            app-version:         1.2.3
-
-            # Prototype
-            name:                 ~
-
-        # Adds custom style sheets to the back end.
-        custom_css:
-
-            # Example:
-            - files/backend/custom.css
-
-        # Adds custom JavaScript files to the back end.
-        custom_js:
-
-            # Example:
-            - files/backend/custom.js
-
-        # Configures the title of the badge in the back end.
-        badge_title:          '' # Example: develop
-
-        # Defines the path of the Contao backend.
-        route_prefix:         /contao # Example: /admin
-    insert_tags:
-
-        # A list of allowed insert tags.
-        allowed_tags:
-
-            # Default:
-            - *
-
-            # Examples:
-            - '*_url'
-            - request_token
-    backup:
-
-        # These tables are ignored by default when creating and restoring backups.
-        ignore_tables:
-
-            # Defaults:
-            - tl_crawl_queue
-            - tl_log
-            - tl_search
-            - tl_search_index
-            - tl_search_term
-
-        # The maximum number of backups to keep. Use 0 to keep all the backups forever.
-        keep_max:             5
-
-        # The latest backup plus the oldest of every configured interval will be kept. Intervals have to be specified as documented in https://www.php.net/manual/en/dateinterval.construct.php without the P prefix.
-        keep_intervals:
-
-            # Defaults:
-            - 1D
-            - 7D
-            - 14D
-            - 1M
-    sanitizer:
-        allowed_url_protocols:
-
-            # Defaults:
-            - http
-            - https
-            - ftp
-            - mailto
-            - tel
-            - data
-            - skype
-            - whatsapp
-```
-{{% /tab %}}
 {{% tab name="Contao 5" %}}
 ```yaml
 # Default configuration for extension with alias: "contao"
@@ -630,6 +354,13 @@ contao:
 
     # Allows to define Symfony Messenger workers (messenger:consume). Workers are started every minute using the Contao cron job framework.
     messenger:
+        # Contao provides a way to work on Messenger transports in the web process (kernel.terminate) if there is no real "messenger:consume" worker. You can configure its behavior here.'
+        web_worker:
+
+          # The transports to apply the web worker logic to.
+          transports:     []
+          grace_period:   PT10M # Must be a valid string for \DateInterval()
+
         workers:
 
             # Prototype
@@ -689,7 +420,12 @@ contao:
 
             # Allows to disable the layer flattening of animated images. Set this option to false to support animations. It has no effect with Gd as Imagine service.
             flatten:              ~
+
+            # One of the Imagine\Image\ImageInterface::INTERLACE_* constants.
             interlace:            plane
+
+            # Filter used when downsampling images. One of the Imagine\Image\ImageInterface::FILTER_* constants. It has no effect with Gd or SVG as Imagine service.
+            resampling-filter:    ~
 
         # Contao automatically uses an Imagine service out of Gmagick, Imagick and Gd (in this order). Set a service ID here to override.
         imagine_service:      null
@@ -869,7 +605,7 @@ contao:
             # Example:
             - files/backend/custom.js
 
-        # Configures the title of the badge in the back end.
+        # Configures the title of the badge in the back end and the Contao Manager.
         badge_title:          '' # Example: develop
 
         # Defines the path of the Contao backend.
@@ -939,6 +675,287 @@ contao:
         max_header_size:      3072
 ```
 {{% /tab %}}
+{{% tab name="Contao 4" %}}
+```yaml
+# Default configuration for extension with alias: "contao"
+contao:
+    csrf_cookie_prefix:   csrf_
+    csrf_token_name:      contao_csrf_token
+    encryption_key:       '%kernel.secret%'
+
+    # The error reporting level set when the framework is initialized. Defaults to E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED.
+    error_level:          8183
+    intl:
+
+        # Adds, removes or overwrites the list of ICU locale IDs. Defaults to all locale IDs known to the system.
+        locales:
+
+            # Examples:
+            - +de
+            - '-de_AT'
+            - gsw_CH
+
+        # Adds, removes or overwrites the list of enabled locale IDs that can be used in the Backend for example. Defaults to all languages for which a translation exists.
+        enabled_locales:
+
+            # Examples:
+            - +de
+            - '-de_AT'
+            - gsw_CH
+
+        # Adds, removes or overwrites the list of ISO 3166-1 alpha-2 country codes.
+        countries:
+
+            # Examples:
+            - +DE
+            - '-AT'
+            - CH
+
+    # Disabling legacy routing allows to configure the URL prefix and suffix per root page. However, it might not be compatible with third-party extensions.
+    legacy_routing:       true
+
+    # Allows to set TL_CONFIG variables, overriding settings stored in localconfig.php. Changes in the Contao back end will not have any effect.
+    localconfig:          ~
+
+    # Allows to configure which languages can be used in the Contao back end. Defaults to all languages for which a translation exists.
+    locales:              [] # Deprecated (Since contao/core-bundle 4.12: Using contao.locales is deprecated. Please use contao.intl.enabled_locales instead.)
+
+    # Whether or not to add the page language to the URL.
+    prepend_locale:       false # Deprecated (Since contao/core-bundle 4.10: The URL prefix is configured per root page since Contao 4.10. Using this option requires legacy routing.)
+
+    # Show customizable, pretty error screens instead of the default PHP error messages.
+    pretty_error_screens: false
+
+    # An optional entry point script that bypasses the front end cache for previewing changes (e.g. "/preview.php").
+    preview_script:       ''
+
+    # The folder used by the file manager.
+    upload_path:          files
+    editable_files:       'css,csv,html,ini,js,json,less,md,scss,svg,svgz,ts,txt,xliff,xml,yml,yaml'
+    url_suffix:           .html # Deprecated (Since contao/core-bundle 4.10: The URL suffix is configured per root page since Contao 4.10. Using this option requires legacy routing.)
+
+    # Absolute path to the web directory. Defaults to %kernel.project_dir%/public.
+    web_dir:              '%kernel.project_dir%/public' # Deprecated (Since contao/core-bundle 4.13: Setting the web directory in a config file is deprecated. Use the "extra.public-dir" config key in your root composer.json instead.)
+    image:
+
+        # Bypass the image cache and always regenerate images when requested. This also disables deferred image resizing.
+        bypass_cache:         false
+        imagine_options:
+            jpeg_quality:         80
+            jpeg_sampling_factors:
+
+                # Defaults:
+                - 2
+                - 1
+                - 1
+            png_compression_level: ~
+            png_compression_filter: ~
+            webp_quality:         ~
+            webp_lossless:        ~
+            avif_quality:         ~
+            avif_lossless:        ~
+            heic_quality:         ~
+            heic_lossless:        ~
+            jxl_quality:          ~
+            jxl_lossless:         ~
+
+            # Allows to disable the layer flattening of animated images. Set this option to false to support animations. It has no effect with Gd as Imagine service.
+            flatten:              ~
+
+            # One of the Imagine\Image\ImageInterface::INTERLACE_* constants.
+            interlace:            plane
+
+            # Filter used when downsampling images. One of the Imagine\Image\ImageInterface::FILTER_* constants. It has no effect with Gd or SVG as Imagine service.
+            resampling-filter:    ~
+
+        # Contao automatically uses an Imagine service out of Gmagick, Imagick and Gd (in this order). Set a service ID here to override.
+        imagine_service:      null
+
+        # Reject uploaded images exceeding the localconfig.gdMaxImgWidth and localconfig.gdMaxImgHeight dimensions.
+        reject_large_uploads: false
+
+        # Allows to define image sizes in the configuration file in addition to in the Contao back end. Use the special name "_defaults" to preset values for all sizes of the configuration file.
+        sizes:
+
+            # Prototype
+            name:
+                width:                ~
+                height:               ~
+                resize_mode:          ~ # One of "crop"; "box"; "proportional"
+                zoom:                 ~
+                css_class:            ~
+                lazy_loading:         ~
+                densities:            ~
+                sizes:                ~
+
+                # If the output dimensions match the source dimensions, the image will not be processed. Instead, the original file will be used.
+                skip_if_dimensions_match: ~
+
+                # Allows to convert one image format to another or to provide additional image formats for an image (e.g. WebP).
+                formats:
+
+                    # Examples:
+                    jpg:                 [jxl, webp, jpg]
+                    gif:                 [avif, png]
+
+                    # Prototype
+                    source:               []
+                items:
+
+                    # Prototype
+                    -
+                        width:                ~
+                        height:               ~
+                        resize_mode:          ~ # One of "crop"; "box"; "proportional"
+                        zoom:                 ~
+                        media:                ~
+                        densities:            ~
+                        sizes:                ~
+                        resizeMode:           ~ # One of "crop"; "box"; "proportional", Deprecated (Since contao/core-bundle 4.9: Using contao.image.sizes.*.items.resizeMode is deprecated. Please use contao.image.sizes.*.items.resize_mode instead.)
+                resizeMode:           ~ # One of "crop"; "box"; "proportional", Deprecated (Since contao/core-bundle 4.9: Using contao.image.sizes.*.resizeMode is deprecated. Please use contao.image.sizes.*.resize_mode instead.)
+                cssClass:             ~ # Deprecated (Since contao/core-bundle 4.9: Using contao.image.sizes.*.cssClass is deprecated. Please use contao.image.sizes.*.css_class instead.)
+                lazyLoading:          ~ # Deprecated (Since contao/core-bundle 4.9: Using contao.image.sizes.*.lazyLoading is deprecated. Please use contao.image.sizes.*.lazy_loading instead.)
+                skipIfDimensionsMatch: ~ # Deprecated (Since contao/core-bundle 4.9: Using contao.image.sizes.*.skipIfDimensionsMatch is deprecated. Please use contao.image.sizes.*.skip_if_dimensions_match instead.)
+
+        # The target directory for the cached images processed by Contao.
+        target_dir:           '%kernel.project_dir%/assets/images' # Example: '%kernel.project_dir%/assets/images'
+        target_path:          null # Deprecated (Since contao/core-bundle 4.9: Use the "contao.image.target_dir" parameter instead.)
+        valid_extensions:
+
+            # Defaults:
+            - jpg
+            - jpeg
+            - gif
+            - png
+            - tif
+            - tiff
+            - bmp
+            - svg
+            - svgz
+            - webp
+        preview:
+
+            # The target directory for the cached previews.
+            target_dir:           '%kernel.project_dir%/assets/previews' # Example: '%kernel.project_dir%/assets/previews'
+            default_size:         512
+            max_size:             1024
+
+            # Whether or not to generate previews for unsupported file types that show a file icon containing the file type.
+            enable_fallback_images: true
+    security:
+        two_factor:
+            enforce_backend:      false
+    search:
+
+        # The default search indexer, which indexes pages in the database.
+        default_indexer:
+            enable:               true
+
+        # Enables indexing of protected pages.
+        index_protected:      false
+
+        # The search index listener can index valid and delete invalid responses upon every request. You may limit it to one of the features or disable it completely.
+        listener:
+
+            # Enables indexing successful responses.
+            index:                true
+
+            # Enables deleting unsuccessful responses from the index.
+            delete:               true
+    crawl:
+
+        # Additional URIs to crawl. By default, only the ones defined in the root pages are crawled.
+        additional_uris:      []
+
+        # Allows to configure the default HttpClient options (useful for proxy settings, SSL certificate validation and more).
+        default_http_client_options: []
+    mailer:
+
+        # Specifies the mailer transports available for selection within Contao.
+        transports:
+
+            # Prototype
+            name:
+
+                # Overrides the "From" address for any e-mails sent with this mailer transport.
+                from:                 null
+    backend:
+
+        # Adds HTML attributes to the <body> tag in the back end.
+        attributes:
+
+            # Examples:
+            app-name:            'My App'
+            app-version:         1.2.3
+
+            # Prototype
+            name:                 ~
+
+        # Adds custom style sheets to the back end.
+        custom_css:
+
+            # Example:
+            - files/backend/custom.css
+
+        # Adds custom JavaScript files to the back end.
+        custom_js:
+
+            # Example:
+            - files/backend/custom.js
+
+        # Configures the title of the badge in the back end and the Contao Manager.
+        badge_title:          '' # Example: develop
+
+        # Defines the path of the Contao backend.
+        route_prefix:         /contao # Example: /admin
+    insert_tags:
+
+        # A list of allowed insert tags.
+        allowed_tags:
+
+            # Default:
+            - *
+
+            # Examples:
+            - '*_url'
+            - request_token
+    backup:
+
+        # These tables are ignored by default when creating and restoring backups.
+        ignore_tables:
+
+            # Defaults:
+            - tl_crawl_queue
+            - tl_log
+            - tl_search
+            - tl_search_index
+            - tl_search_term
+
+        # The maximum number of backups to keep. Use 0 to keep all the backups forever.
+        keep_max:             5
+
+        # The latest backup plus the oldest of every configured interval will be kept. Intervals have to be specified as documented in https://www.php.net/manual/en/dateinterval.construct.php without the P prefix.
+        keep_intervals:
+
+            # Defaults:
+            - 1D
+            - 7D
+            - 14D
+            - 1M
+    sanitizer:
+        allowed_url_protocols:
+
+            # Defaults:
+            - http
+            - https
+            - ftp
+            - mailto
+            - tel
+            - data
+            - skype
+            - whatsapp
+```
+{{% /tab %}}
 {{< /tabs >}}
 
 
@@ -952,7 +969,7 @@ während andere Einstellungen nun bspw. in den Benutzereinstellungen oder im Sta
 können.
 
 Je nach Contao-Version werden aber immer noch Einstellungen aus der `localconfig` benutzt. Daher kann es nützlich sein zu
-wissen, wie man diese Einstellungen über die Applikationskonfiguration (also die `config.yaml`) überschreiben könnte, 
+wissen, wie man diese Einstellungen über die Applikationskonfiguration (also die `config.yaml`) überschreiben könnte,
 anstatt die veraltete `localconfig.php` dafür zu benutzen. Dies kann für den eigenen Deployment-Flow wichtig sein, aber
 auch weil es gewisse Einstellungen gibt, die _nur_ manuell gesetzt werden können, weil diese weder eine Bundle Einstellung
 noch eine andere Einstellungsmöglichkeit im Backend haben.
@@ -1154,7 +1171,7 @@ In Contao **4.9** heißt diese Umgebungsvariable `COOKIE_WHITELIST`.
 {{% /notice %}}
 
 Dies ist eine spezielle Umgebungsvariable, die sich auf den Standard-Caching-Proxy bezieht, der mit der Contao Managed Edition standardmäßig ausgeliefert wird.
-Contao deaktiviert jegliches HTTP-Caching, sobald entweder ein `Cookie`- oder ein `Authorization`-Header in der Anfrage vorhanden ist. Der Grund dafür ist, dass diese Header möglicherweise einen Benutzer authentifizieren und somit personalisierte Inhalte erzeugen können. In diesem Fall wollen wir niemals Inhalte aus dem Cache bereitstellen.Leider besteht das Web jedoch aus einer Vielzahl verschiedener Cookies. Die meisten davon sind völlig irrelevant für die Anwendung selbst und werden nur in JavaScript verwendet (obwohl es bessere Alternativen wie LocalStorage, SessionStorage oder IndexedDB gibt). 
+Contao deaktiviert jegliches HTTP-Caching, sobald entweder ein `Cookie`- oder ein `Authorization`-Header in der Anfrage vorhanden ist. Der Grund dafür ist, dass diese Header möglicherweise einen Benutzer authentifizieren und somit personalisierte Inhalte erzeugen können. In diesem Fall wollen wir niemals Inhalte aus dem Cache bereitstellen.Leider besteht das Web jedoch aus einer Vielzahl verschiedener Cookies. Die meisten davon sind völlig irrelevant für die Anwendung selbst und werden nur in JavaScript verwendet (obwohl es bessere Alternativen wie LocalStorage, SessionStorage oder IndexedDB gibt).
 
 Du wirst feststellen, dass z. B. Google Analytics, Matomo, Facebook usw. alle Cookies setzen, die die Anwendung (in diesem Fall Contao) überhaupt nicht interessiert. Da der HTTP-Cache jedoch entscheiden muss, ob er eine Antwort aus dem Cache ausliefert oder nicht, bevor die Anwendung überhaupt gestartet ist, kann er nicht wissen, welche Cookies relevant sind und welche nicht. Also müssen wir es ihm sagen. Die Contao Managed Edition wird mit einer Liste von irrelevanten Cookies ausgeliefert, die standardmäßig ignoriert werden, um die Trefferquote zu erhöhen. Zur Optimierung kannst du die Standardliste deaktivieren, indem du eine explizite Liste von benötigten Cookies bereit stellst. Dies sind die Cookies, von denen du weisst, dass sie **relevant** für die Anwendung sind, und in diesem Fall muss der Cache **ausgeschaltet** werden.
 
@@ -1164,10 +1181,10 @@ Cookies von installierten Erweiterungen zulassen:
 ```
 COOKIE_ALLOW_LIST=PHPSESSID,csrf_https-contao_csrf_token,csrf_contao_csrf_token,trusted_device,REMEMBERME
 ```
-    
+
 {{% notice note %}}
 Der Name des PHP-Session-Cookies ist über die `php.ini` konfigurierbar, daher solltest du überprüfen, ob er auch `PHPSESSID` lautet. Außerdem ist der CSRF-Cookie aus Sicherheitsgründen für `http` und `https` unterschiedlich. Wenn die Website über `http` ausgeliefert wird, ist zu beachten, dass der Cookie-Name `csrf_http-contao_csrf_token` lautet. Wenn du Benutzer vor CSRF-Angriffen schützen möchtest, aber das Formular über ungesicherte `http`-Verbindungen übermittelst, ist das
-nicht wirklich ein gültiger Anwendungsfall. 
+nicht wirklich ein gültiger Anwendungsfall.
 {{% /notice %}}
 
 
@@ -1243,7 +1260,7 @@ DNS_MAPPING='{
 }'
 ```
 
-Dadurch kann bspw. die Live-Datenbank zur Staging- oder Entwicklungs-Umgebung kopiert und durch die Datenbankmigration 
+Dadurch kann bspw. die Live-Datenbank zur Staging- oder Entwicklungs-Umgebung kopiert und durch die Datenbankmigration
 (`contao:migrate`) die Domain-Einstellungen automatisch angepasst werden.
 
 Auch die Protokoll-Einstellung kann automatisch geändert werden. Dies kann hilfreich sein, wenn bspw. für die lokale
@@ -1289,7 +1306,7 @@ parameters:
 
 ## E-Mail Versand Konfiguration
 
-Um den E-Mail Versand über einen SMTP-Server einzurichten, brauchst du folgende Angaben von deinem Hoster (manche davon können optional 
+Um den E-Mail Versand über einen SMTP-Server einzurichten, brauchst du folgende Angaben von deinem Hoster (manche davon können optional
 sein, je nach Server):
 
 - Den **Hostnamen** des SMTP-Servers.
@@ -1337,8 +1354,8 @@ parameters:
 {{< /tabs >}}
 
 {{% notice warning %}}
-**Cache leeren:** Damit die Änderungen aktiv werden, muss am Ende der Anwendungs-Cache über den Contao Manager (»Systemwartung« > 
-»Prod.-Cache erneuern«) oder alternativ über die Kommandozeile geleert werden. Dazu muss man sich im Contao 
+**Cache leeren:** Damit die Änderungen aktiv werden, muss am Ende der Anwendungs-Cache über den Contao Manager (»Systemwartung« >
+»Prod.-Cache erneuern«) oder alternativ über die Kommandozeile geleert werden. Dazu muss man sich im Contao
 Installationsverzeichnis befinden.
 
 ```bash
@@ -1385,20 +1402,20 @@ In vielen Fällen erlauben SMTP-Server nicht den Versand von beliebigen Absender
 zu den verwendeten SMTP-Server Zugangsdaten passen. Vor allem in Multidomain-Installationen von Contao kann es jedoch
 wichtig sein, dass die Absenderadresse der E-Mails, die Contao verschickt, zur jeweiligen Domain passt.
 
-Ab Contao **4.10** besteht daher die Möglichkeit, mehrere E-Mail Konfigurationen in Contao zu benutzen. Diese 
-Konfigurationen können dann pro Webseiten-Startpunkt, pro Formular und pro Newsletter-Kanal ausgewählt werden. Pro E-Mail 
+Ab Contao **4.10** besteht daher die Möglichkeit, mehrere E-Mail Konfigurationen in Contao zu benutzen. Diese
+Konfigurationen können dann pro Webseiten-Startpunkt, pro Formular und pro Newsletter-Kanal ausgewählt werden. Pro E-Mail
 Konfiguration kann dann außerdem auch der Absender gesetzt werden, welcher dann für jede E-Mail benutzt wird, die über
 die ausgewählte E-Mail Konfiguration gesendet wird.
 
 Die Konfiguration benötigt zwei Schritte. Zuerst müssen die verfügbaren E-Mail Versandmethoden über die Symfony Framework
-Konfiguration in der `config.yaml` als sogenannte »Transports« eingestellt werden. Dabei können bspw. ein oder mehrere 
+Konfiguration in der `config.yaml` als sogenannte »Transports« eingestellt werden. Dabei können bspw. ein oder mehrere
 SMTP-Server über die sogenannte »DSN«-Syntax definiert werden. Diese Syntax ist grundsätzlich sehr einfach aufgebaut:
 
 ```
 smtp://<BENUTZERNAME>:<PASSWORT>@<HOSTNAME>:<PORT>
 ```
 
-Man ersetzt die `<PLATZHALTER>` mit den Angaben des verwendeten SMTP-Servers, oder entfernt sie dementsprechend. Siehe 
+Man ersetzt die `<PLATZHALTER>` mit den Angaben des verwendeten SMTP-Servers, oder entfernt sie dementsprechend. Siehe
 dazu auch die Informationen in der offiziellen [Symfony Dokumentation][SymfonyMailer].
 
 Für diese Encodierung kann dieses [Tool](#konvertieren-deiner-mail-parameter) genutzt werden.
@@ -1412,7 +1429,7 @@ mit dem Doppelpunkt. Bei Verwendung der `config.yaml` muß die jeweilige Kodieru
 
 {{% notice tip %}}
 Anstatt `smtp://` kann auch `smtps://` verwendet werden, um automatisch SSL Verschlüsselung über Port `465` zu verwenden.
-{{% /notice %}} 
+{{% /notice %}}
 
 ```yaml
 # config/config.yaml
@@ -1441,7 +1458,7 @@ Backend zur Verfügung.
 
 {{% notice note %}}
 Wird kein Transport konfiguriert, gelten nach wie vor die Informationen aus der `parameters.yaml`. Werden Transports
-konfiguriert, aber es wird kein Transport im Contao Backend ausgewählt, wird automatisch der erste definierte Transport 
+konfiguriert, aber es wird kein Transport im Contao Backend ausgewählt, wird automatisch der erste definierte Transport
 verwendet.
 {{% /notice %}}
 
@@ -1474,9 +1491,9 @@ website2: 'SMTP für Webseite 2'
 ```
 
 {{% notice warning %}}
-**Cache leeren**  
-Damit die Änderungen im Backend sichtbar werden, muss am Ende der Anwendungs-Cache über den Contao Manager (»Systemwartung« > 
-»Prod.-Cache erneuern«) oder alternativ über die Kommandozeile geleert werden. Dazu muss man sich im Contao 
+**Cache leeren**
+Damit die Änderungen im Backend sichtbar werden, muss am Ende der Anwendungs-Cache über den Contao Manager (»Systemwartung« >
+»Prod.-Cache erneuern«) oder alternativ über die Kommandozeile geleert werden. Dazu muss man sich im Contao
 Installationsverzeichnis befinden.
 
 ```bash
@@ -1508,7 +1525,7 @@ swiftmailer:
     spool:
         type: file
         path: '%kernel.project_dir%/var/spool'
-``` 
+```
 
 In diesem Fall bedienen wir uns dem _File_ Spool, das heißt wenn Contao eine E-Mail sendet wird diese zuerst als Datei in das angegebene
 Verzeichnis abgelegt. In der beschriebenen Konfiguration wird der Ordner `var/spool/` der Contao Installation benutzt (beachte, dass dieser
@@ -1534,7 +1551,7 @@ Bei einem minütlichen Aufruf würde das also den E-Mail Versand auf 600 E-Mails
 
 {{< version "4.10" >}}
 
-Ab Contao **4.10** steht das Swiftmailer Bundle nicht mehr von Haus aus zur Verfügung, statt dessen nutzt Contao 
+Ab Contao **4.10** steht das Swiftmailer Bundle nicht mehr von Haus aus zur Verfügung, statt dessen nutzt Contao
 [Symfony Mailer][SymfonyMailer]. Um E-Mail asnychron senden zu können wird in diesem Fall die [Symfony Messenger][SymfonyMessenger]
 Komponente benötigt. Diese muss zuerst via Composer installiert werden:
 
@@ -1561,7 +1578,7 @@ framework:
 
 {{% notice "note" %}}
 Anstatt den Messenger Transport direkt zu definieren können wie immer auch Umgebungsvariablen benutzt werden, falls man in verschiedenen
-Umgebungen verschiedene Transports haben möchte (bspw. lokal zum testen den 
+Umgebungen verschiedene Transports haben möchte (bspw. lokal zum testen den
 [In Memory Transport](https://symfony.com/doc/current/messenger.html#in-memory-transport)).
 
 ```yaml
@@ -1593,15 +1610,15 @@ Bei einem minütlichen Aufruf würde das also den E-Mail Versand auf 600 E-Mails
 
 {{% notice "info" %}}
 In den Kommandos wird die Option `--time-limit=1` benutzt. Von Haus aus läuft der `messenger:consume` Prozess unendlich lang und verarbeitet
-alle E-Mails in dieser Zeit automatisch - und es müsste daher auch kein Cronjob eingerichtet werden. Um sicherzustellen, dass dieser 
+alle E-Mails in dieser Zeit automatisch - und es müsste daher auch kein Cronjob eingerichtet werden. Um sicherzustellen, dass dieser
 Prozess läuft und ggf. neu gestartet wird könnten entsprechende Tools am Server verwendet werden. In Shared Hosting Umgebungen hat man diese
 Möglichkeit meist jedoch nicht, daher muss in der Cronjob Variante sichergestellt werden, dass der Prozess nur einmalig läuft. Mit der
-bereits erwähnten `--time-limit=1` Option wird der Prozess nach spätestens einer Sekunde beendet. Nähere Details dazu findet man in der 
+bereits erwähnten `--time-limit=1` Option wird der Prozess nach spätestens einer Sekunde beendet. Nähere Details dazu findet man in der
 [Symfony Dokumentation](https://symfony.com/doc/current/messenger.html#consuming-messages-running-the-worker).
 {{% /notice %}}
 
 {{% notice "note" %}}
-Es kann sein, dass Mails zeitversetzt verarbeitet werden, 
+Es kann sein, dass Mails zeitversetzt verarbeitet werden,
 wenn der Cronjob keine Angabe für die Zeitzone hat und dann den Standard `UTC` verwendet.
 Deshalb sollte die lokale Zeitzone entweder global auf dem Server festgelegt werden oder explizit im Cronjob.
 {{% /notice %}}

--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -11,15 +11,15 @@ Die Systemeinstellungen verabschieden sich langsam aber sicher aus dem Backend. 
 beeinflussen Contao als Applikation und somit besteht auch die Chance, dass durch eine falsche Einstellung das System
 in einen funktionsuntüchtigen Zustand gebracht wird. Sollte dies geschehen, hast du keine Möglichkeit mehr,
 die Einstellungen rückgängig zu machen und das System wiederherzustellen, da du dich nicht mehr einloggen kannst.
-Aus diesem Grund werden die meisten Einstellungen außerhalb von Contao über die `config.yaml` vorgenommen bzw. können
+Aus diesem Grund werden die meisten Einstellungen außerhalb von Contao über die `config.yaml` vorgenommen bzw. können 
 zukünftig über den Contao Manager vorgenommen werden.
 
 ## Einstellungen
 
 ### Globale Einstellungen
 
-**E-Mail-Adresse des Systemadministrators:** An diese Adresse werden z. B. Benachrichtigungen über gesperrte Konten
-oder neu registrierte Benutzer geschickt. Du kannst auch folgende Notation verwenden, um einen Namen zur E-Mail-Adresse
+**E-Mail-Adresse des Systemadministrators:** An diese Adresse werden z. B. Benachrichtigungen über gesperrte Konten 
+oder neu registrierte Benutzer geschickt. Du kannst auch folgende Notation verwenden, um einen Namen zur E-Mail-Adresse 
 hinzuzufügen:
 
 ```text
@@ -28,8 +28,8 @@ Kevin Jones [kevin.jones@example.com]
 
 ### Datum und Zeit
 
-**Datums- und Zeitformat:** Alle Datums- und Zeitformate müssen wie in der
-[PHP-Funktion date](https://www.php.net/manual/de/function.date.php) eingegeben werden. Contao verarbeitet im Backend
+**Datums- und Zeitformat:** Alle Datums- und Zeitformate müssen wie in der 
+[PHP-Funktion date](https://www.php.net/manual/de/function.date.php) eingegeben werden. Contao verarbeitet im Backend 
 ausschließlich numerische Formate, also die Buchstaben j, d, m, n, y, Y, g, G, h, H, i und s.
 
 Hier sind einige Beispiele gültiger Datums- und Zeitangaben:
@@ -44,23 +44,23 @@ Hier sind einige Beispiele gültiger Datums- und Zeitangaben:
 | H:i:s    | 24 Stunden, Minuten und Sekunden, z. B. `20:36:59`            |
 | g:i      | 12 Stunden ohne führende Nullen sowie Minuten, z. B. `8:36`   |
 
-**Zeitzone:** Die Zeitzone solltest du unbedingt vor dem Erstellen deiner Webseite einstellen, da Contao alle
-Zeitangaben als [Unix-Zeitstempel](https://www.php.net/time) speichert und Contao diese Zeitstempel bei einer Änderung
+**Zeitzone:** Die Zeitzone solltest du unbedingt vor dem Erstellen deiner Webseite einstellen, da Contao alle 
+Zeitangaben als [Unix-Zeitstempel](https://www.php.net/time) speichert und Contao diese Zeitstempel bei einer Änderung 
 der Zeitzone nicht automatisch anpasst.
 
 
 ### Backend-Einstellungen
 
-**Elemente nicht verkürzen:** Im »Parent View« stellt Contao die Elemente aus Gründen der Übersichtlichkeit verkürzt
-dar, wobei einzelne Elemente über ein Navigationsicon bei Bedarf ausgeklappt werden können. Wähle diese Option, um das
+**Elemente nicht verkürzen:** Im »Parent View« stellt Contao die Elemente aus Gründen der Übersichtlichkeit verkürzt 
+dar, wobei einzelne Elemente über ein Navigationsicon bei Bedarf ausgeklappt werden können. Wähle diese Option, um das 
 Feature komplett zu deaktivieren.
 
-**Elemente pro Seite:** Im Abschnitt [Datensätze auflisten](../../administrationsbereich/datensaetze-auflisten/#datensaetze-sortieren-und-filtern)
-hast du gelernt, dass Contao die Anzahl der Datensätze pro Seite standardmäßig auf 30 begrenzt. Diesen Wert kannst du
+**Elemente pro Seite:** Im Abschnitt [Datensätze auflisten](../../administrationsbereich/datensaetze-auflisten/#datensaetze-sortieren-und-filtern) 
+hast du gelernt, dass Contao die Anzahl der Datensätze pro Seite standardmäßig auf 30 begrenzt. Diesen Wert kannst du 
 hier beliebig anpassen. Höhere Werte bedeuten jedoch eine längere Ladezeit.
 
-**Maximum Datensätze pro Seite:** Um zu verhindern, dass ein unbedarfter Benutzer sich 5000 Datensätze auf einmal
-anzeigen lässt und damit das PHP Memory Limit überschreitet, kannst du festlegen, wie viele Datensätze maximal pro Seite
+**Maximum Datensätze pro Seite:** Um zu verhindern, dass ein unbedarfter Benutzer sich 5000 Datensätze auf einmal 
+anzeigen lässt und damit das PHP Memory Limit überschreitet, kannst du festlegen, wie viele Datensätze maximal pro Seite 
 angezeigt werden dürfen.
 
 #### Zusätzliche Backend-Einstellungen:
@@ -101,29 +101,29 @@ Ab Version **4.10** wird die folgende Einstellung im Startpunkt der Webseite vor
 {{% /notice %}}
 
 **Ordner-URLs verwenden:** Hier kannst du Ordnerstrukturen in Seitenaliasen aktivieren. Damit werden die in der
-Seitenhierarchie vorhandenen Aliase in den Alias mit übernommen z. B. die Seite »Download« im Seitenpfad
+Seitenhierarchie vorhandenen Aliase in den Alias mit übernommen z. B. die Seite »Download« im Seitenpfad 
 »Docs > Install« zu `docs/install/download.html` anstatt nur `download.html`.
 
 {{% notice note %}}
 Ab Version **4.10** ist diese Einstellung entfallen:
 {{% /notice %}}
 
-**Leere URLs nicht umleiten:** Ermöglicht die Deaktivierung der Umleitung der "leeren URL" auf die Startseite der sprachlichen Website-Root des Browsers
+**Leere URLs nicht umleiten:** Ermöglicht die Deaktivierung der Umleitung der "leeren URL" auf die Startseite der sprachlichen Website-Root des Browsers 
 bei Verwendung des [Legacy-Routing-Modus][LegacyRouting] ohne `contao.prepend_locale`: true _(nicht empfohlen)_.
 
 
 ### Sicherheitseinstellungen
 
-**Anfrage-Tokens deaktivieren:** Hier kannst du aktivieren, dass die Anfrage-Token beim Absenden eines Formulars nicht
+**Anfrage-Tokens deaktivieren:** Hier kannst du aktivieren, dass die Anfrage-Token beim Absenden eines Formulars nicht 
 geprüft werden _(unsicher!)_.
 
-**Erlaubte HTML-Tags:** Standardmäßig erlaubt Contao keine HTML-Tags in Formularen und entfernt diese beim Speichern
-automatisch. Für Eingabefelder, bei denen die Nutzung von HTML erwünscht ist, kannst du hier eine Liste erlaubter
+**Erlaubte HTML-Tags:** Standardmäßig erlaubt Contao keine HTML-Tags in Formularen und entfernt diese beim Speichern 
+automatisch. Für Eingabefelder, bei denen die Nutzung von HTML erwünscht ist, kannst du hier eine Liste erlaubter 
 HTML-Tags festlegen.
 
-{{< version-tag "4.11.7, 4.9.18 und 4.4.56" >}} **Erlaubte HTML-Attribute:** Die Liste der erlaubten HTML-Attribute für Eingabefelder kannst du hier beliebig erweitern.
-Wenn ein HTML-Attribute in der Liste nicht vorhanden ist, wird es beim Abspeichern automatisch entfernt. Das Tag bzw.
-der Attributname * steht für alle Tags bzw. Attribute. Für Attribute mit Bindestrichen können Platzhalter wie z. B.
+{{< version-tag "4.11.7, 4.9.18 und 4.4.56" >}} **Erlaubte HTML-Attribute:** Die Liste der erlaubten HTML-Attribute für Eingabefelder kannst du hier beliebig erweitern. 
+Wenn ein HTML-Attribute in der Liste nicht vorhanden ist, wird es beim Abspeichern automatisch entfernt. Das Tag bzw. 
+der Attributname * steht für alle Tags bzw. Attribute. Für Attribute mit Bindestrichen können Platzhalter wie z. B. 
 data-* benutzt werden.
 
 **Passwort-Hash:** Standardmäßig verwendet Contao den Default der aktuellen PHP-Version, hier kannst du aber auch einen Wert festlegen. Dieses ist z. B. nötig, wenn du das Passwort in ein weiteres System wie LDAP synchronisieren möchtest.
@@ -137,66 +137,66 @@ security:
       Contao\User: 'auto' # Hash function: bcrypt, sha256, sha512 ...
 ```
 
-**Beispiele:**
+**Beispiele:**  
 `<iframe>` ist in den erlaubten HTML-Tags nicht vorhanden, kann aber einfach unter Schlüssel eingefügt werden.
 
-{{% notice note %}}
-Um die selbst hinzugefügten HTML-Tags besser zu erkennen, sollten diese zu Beginn der Liste eingetragen werden.
-{{% /notice %}}
+{{% notice note %}}  
+Um die selbst hinzugefügten HTML-Tags besser zu erkennen, sollten diese zu Beginn der Liste eingetragen werden. 
+{{% /notice %}}  
 
-In den erlaubten HTML-Attributen, als Wert muss hierzu dann auch noch das Attribut mit eingefügt werden.
+In den erlaubten HTML-Attributen, als Wert muss hierzu dann auch noch das Attribut mit eingefügt werden.  
 
-`<nav>` und `<input>` sind beispielsweise bereits in den erlaubten HTML-Tags vorhanden und können damit einfach mit erlaubten Attributen erweitert werden.
+`<nav>` und `<input>` sind beispielsweise bereits in den erlaubten HTML-Tags vorhanden und können damit einfach mit erlaubten Attributen erweitert werden.  
 Dazu als Schlüssel `nav` bzw. `input` eintragen und als Wert der gewünschte Wert - in unserem Beispiel `role` bzw. `type`.
 
-Falls du allen Backend-Benutzern zu 100% vertraust, kannst du auch als Schlüssel `*` und als Wert `*` eintragen. Hierdurch sind alle Attribute für alle Elemente erlaubt.
+Falls du allen Backend-Benutzern zu 100% vertraust, kannst du auch als Schlüssel `*` und als Wert `*` eintragen. Hierdurch sind alle Attribute für alle Elemente erlaubt.  
 
 ![Sicherheitseinstellungen]({{% asset "images/manual/system/de/security-settings-de.png" %}}?classes=shadow)
 
 
 ### Dateien und Bilder
 
-**Erlaubte Download-Dateitypen:** Hier kannst du festlegen, welche Dateitypen von deinem Server heruntergeladen werden
+**Erlaubte Download-Dateitypen:** Hier kannst du festlegen, welche Dateitypen von deinem Server heruntergeladen werden 
 dürfen (Download).
 
-**Maximale GD-Bildbreite:** Hier kannst du festlegen, wie breit Bilder sein dürfen, damit sie von der GD
+**Maximale GD-Bildbreite:** Hier kannst du festlegen, wie breit Bilder sein dürfen, damit sie von der GD 
 Bildbearbeitungs-Bibliothek noch verarbeitet werden können. Jegliche Bilder, die diesen Wert übersteigen, werden nicht
 verarbeitet.
 
-**Maximale GD-Bildhöhe:** Hier kannst du festlegen, wie hoch Bilder sein dürften, damit sie von der GD
+**Maximale GD-Bildhöhe:** Hier kannst du festlegen, wie hoch Bilder sein dürften, damit sie von der GD 
 Bildbearbeitungs-Bibliothek noch verarbeitet werden können. Jegliche Bilder, die diesen Wert übersteigen, werden nicht
 verarbeitet.
 
 
 ### Datei-Uploads
 
-**Erlaubte Upload-Dateitypen:** Hier kannst du festlegen, welche Dateitypen auf deinen Server übertragen werden dürfen
+**Erlaubte Upload-Dateitypen:** Hier kannst du festlegen, welche Dateitypen auf deinen Server übertragen werden dürfen 
 (Upload).
 
-**Maximale Upload-Dateigröße:** Hier kannst du festlegen, wie groß eine mit der Dateiverwaltung auf deinen Server
-übertragene Datei maximal sein darf. Die Eingabe erfolgt in Bytes (1 MiB = 1024 KiB = 1.048.576 Bytes). Größere Dateien
+**Maximale Upload-Dateigröße:** Hier kannst du festlegen, wie groß eine mit der Dateiverwaltung auf deinen Server 
+übertragene Datei maximal sein darf. Die Eingabe erfolgt in Bytes (1 MiB = 1024 KiB = 1.048.576 Bytes). Größere Dateien 
 werden abgelehnt.
 
-**Maximale Bildbreite:** Beim Upload von Bildern prüft die Dateiverwaltung automatisch deren Breite und vergleicht diese
-Werte mit deiner hier festgelegten Vorgabe. Überschreitet ein Bild die maximale Breite, wird es automatisch
+**Maximale Bildbreite:** Beim Upload von Bildern prüft die Dateiverwaltung automatisch deren Breite und vergleicht diese 
+Werte mit deiner hier festgelegten Vorgabe. Überschreitet ein Bild die maximale Breite, wird es automatisch 
 verkleinert.
 
-**Maximale Bildhöhe:** Beim Upload von Bildern prüft die Dateiverwaltung automatisch deren Höhe und vergleicht diese Werte
+**Maximale Bildhöhe:** Beim Upload von Bildern prüft die Dateiverwaltung automatisch deren Höhe und vergleicht diese Werte 
 mit deiner hier festgelegten Vorgabe. Überschreitet ein Bild die maximale Höhe, wird es automatisch verkleinert.
 
 
 ### Website-Suche
 
-**Suche aktivieren:** Wenn du diese Option auswählst, indiziert Contao die fertigen Seiten deiner Webseite und erstellt
-daraus einen Suchindex. Mit dem Frontend-Modul
-»[Suchmaschine](../../modulverwaltung/website-suche/#konfiguration-des-suchmoduls)« kannst du diesen Index dann
+**Suche aktivieren:** Wenn du diese Option auswählst, indiziert Contao die fertigen Seiten deiner Webseite und erstellt 
+daraus einen Suchindex. Mit dem Frontend-Modul 
+»[Suchmaschine](../../modulverwaltung/website-suche/#konfiguration-des-suchmoduls)« kannst du diesen Index dann 
 durchsuchen.
 
-**Geschützte Seiten indizieren:** Wähle diese Option, um auch geschützte Seiten für die Suche zu indizieren. Nutze
+**Geschützte Seiten indizieren:** Wähle diese Option, um auch geschützte Seiten für die Suche zu indizieren. Nutze 
 dieses Feature mit Bedacht, und achte darauf, personalisierte Seiten grundsätzlich von der Suche auszuschließen.
 
 {{% notice note %}}
-Ab Version **4.9** kommt ein neuer Such-Indexer zum Einsatz. Die Einstellungen **Suche aktivieren** und
+Ab Version **4.9** kommt ein neuer Such-Indexer zum Einsatz. Die Einstellungen **Suche aktivieren** und 
 **Geschützte Seiten indizieren** werden nun über die `config/config.yaml` konfiguriert:
 
 ```yaml
@@ -211,7 +211,7 @@ contao:
 
 ### Cronjob-Einstellungen
 
-**Den Command-Scheduler deaktivieren:** Hier kannst du den Periodic Command Scheduler deaktivieren und die
+**Den Command-Scheduler deaktivieren:** Hier kannst du den Periodic Command Scheduler deaktivieren und die 
 `_contao/cron`-Route mittels eines echten Cronjobs (den du selbst einrichten musst) ausführen. Seit Contao **4.9** kann
 auch folgendes Kommando benutzt werden:
 
@@ -221,27 +221,27 @@ php vendor/bin/contao-console contao:cron
 
 ### Standard-Zugriffsrechte
 
-**Standardbesitzer:** Hier kannst du vorgeben, welchem Benutzer standardmäßig die Seiten gehören, für die keine
-Zugriffsrechte definiert wurden. Weitere Informationen dazu findest du im Abschnitt
+**Standardbesitzer:** Hier kannst du vorgeben, welchem Benutzer standardmäßig die Seiten gehören, für die keine 
+Zugriffsrechte definiert wurden. Weitere Informationen dazu findest du im Abschnitt 
 [Zugriffsrechte](/de/seitenstruktur/regulaere-seite/#zugriffsrechte).
 
-**Standardgruppe:** Hier kannst du festlegen, welcher Gruppe standardmäßig die Seiten gehören, für die keine
-Zugriffsrechte definiert wurden. Weitere Informationen dazu findest du im Abschnitt
+**Standardgruppe:** Hier kannst du festlegen, welcher Gruppe standardmäßig die Seiten gehören, für die keine 
+Zugriffsrechte definiert wurden. Weitere Informationen dazu findest du im Abschnitt 
 [Zugriffsrechte](/de/seitenstruktur/regulaere-seite/#zugriffsrechte).
 
-**Standardzugriffsrechte:** Hier kannst du festlegen, welche Zugriffsrechte standardmäßig für die Seiten gelten, für
-die keine speziellen Zugriffsrechte definiert wurden. Weitere Informationen dazu findest du im Abschnitt
+**Standardzugriffsrechte:** Hier kannst du festlegen, welche Zugriffsrechte standardmäßig für die Seiten gelten, für 
+die keine speziellen Zugriffsrechte definiert wurden. Weitere Informationen dazu findest du im Abschnitt 
 [Zugriffsrechte](/de/seitenstruktur/regulaere-seite/#zugriffsrechte).
 
 
 
 ## parameters.yaml
 
-In der Contao Managed Edition werden die Parameter (z. B. Datenbankdaten) in der `parameters.yaml` abgelegt.
-Auf diese Daten greift auch das Contao-Installtool zurück. Diese Datei wird normalerweise von der Versionierung
+In der Contao Managed Edition werden die Parameter (z. B. Datenbankdaten) in der `parameters.yaml` abgelegt. 
+Auf diese Daten greift auch das Contao-Installtool zurück. Diese Datei wird normalerweise von der Versionierung 
 ausgenommen und kann auch zusätzliche Einträge wie z. B. die Angaben für den E-Mail-Versand über SMTP enthalten.
 
-Die Datei `parameters.yaml` findest du im Ordner `app/config/` und wird bei der Installation von Contao automatisch
+Die Datei `parameters.yaml` findest du im Ordner `app/config/` und wird bei der Installation von Contao automatisch 
 angelegt.
 
 {{% notice note %}}
@@ -266,12 +266,12 @@ Datenbankpasswörter, die nur aus Ziffern bestehen oder gewisse Sonderzeichen en
 
 ## config.yaml
 
-Die normale Bundle Config gehört in die `config.yaml` und befindet sich im Ordner `config/`.
-Falls die Datei noch nicht vorhanden ist, muss diese angelegt werden. Contao lädt automatisch die `config_prod.yaml`
+Die normale Bundle Config gehört in die `config.yaml` und befindet sich im Ordner `config/`. 
+Falls die Datei noch nicht vorhanden ist, muss diese angelegt werden. Contao lädt automatisch die `config_prod.yaml` 
 bzw. `config_dev.yaml` und falls nicht vorhanden die `config.yaml`.
 
-Damit kannst du unterschiedliche Konfigurationen für deine Test- bzw. Produktionsumgebung (dev/prod) realisieren (z. B.
-mehr Logging im Debug Modus). Außerdem committest du die `config.yaml` im Gegensatz zur `parameters.yaml` in dein
+Damit kannst du unterschiedliche Konfigurationen für deine Test- bzw. Produktionsumgebung (dev/prod) realisieren (z. B. 
+mehr Logging im Debug Modus). Außerdem committest du die `config.yaml` im Gegensatz zur `parameters.yaml` in dein 
 [Repository](https://de.wikipedia.org/wiki/Repository). Ein Repository kannst du verwenden, um deine Projekt-Versionen abzulegen, z. B. mit Git.
 
 {{% notice note %}}
@@ -969,7 +969,7 @@ während andere Einstellungen nun bspw. in den Benutzereinstellungen oder im Sta
 können.
 
 Je nach Contao-Version werden aber immer noch Einstellungen aus der `localconfig` benutzt. Daher kann es nützlich sein zu
-wissen, wie man diese Einstellungen über die Applikationskonfiguration (also die `config.yaml`) überschreiben könnte,
+wissen, wie man diese Einstellungen über die Applikationskonfiguration (also die `config.yaml`) überschreiben könnte, 
 anstatt die veraltete `localconfig.php` dafür zu benutzen. Dies kann für den eigenen Deployment-Flow wichtig sein, aber
 auch weil es gewisse Einstellungen gibt, die _nur_ manuell gesetzt werden können, weil diese weder eine Bundle Einstellung
 noch eine andere Einstellungsmöglichkeit im Backend haben.
@@ -1171,7 +1171,7 @@ In Contao **4.9** heißt diese Umgebungsvariable `COOKIE_WHITELIST`.
 {{% /notice %}}
 
 Dies ist eine spezielle Umgebungsvariable, die sich auf den Standard-Caching-Proxy bezieht, der mit der Contao Managed Edition standardmäßig ausgeliefert wird.
-Contao deaktiviert jegliches HTTP-Caching, sobald entweder ein `Cookie`- oder ein `Authorization`-Header in der Anfrage vorhanden ist. Der Grund dafür ist, dass diese Header möglicherweise einen Benutzer authentifizieren und somit personalisierte Inhalte erzeugen können. In diesem Fall wollen wir niemals Inhalte aus dem Cache bereitstellen.Leider besteht das Web jedoch aus einer Vielzahl verschiedener Cookies. Die meisten davon sind völlig irrelevant für die Anwendung selbst und werden nur in JavaScript verwendet (obwohl es bessere Alternativen wie LocalStorage, SessionStorage oder IndexedDB gibt).
+Contao deaktiviert jegliches HTTP-Caching, sobald entweder ein `Cookie`- oder ein `Authorization`-Header in der Anfrage vorhanden ist. Der Grund dafür ist, dass diese Header möglicherweise einen Benutzer authentifizieren und somit personalisierte Inhalte erzeugen können. In diesem Fall wollen wir niemals Inhalte aus dem Cache bereitstellen.Leider besteht das Web jedoch aus einer Vielzahl verschiedener Cookies. Die meisten davon sind völlig irrelevant für die Anwendung selbst und werden nur in JavaScript verwendet (obwohl es bessere Alternativen wie LocalStorage, SessionStorage oder IndexedDB gibt). 
 
 Du wirst feststellen, dass z. B. Google Analytics, Matomo, Facebook usw. alle Cookies setzen, die die Anwendung (in diesem Fall Contao) überhaupt nicht interessiert. Da der HTTP-Cache jedoch entscheiden muss, ob er eine Antwort aus dem Cache ausliefert oder nicht, bevor die Anwendung überhaupt gestartet ist, kann er nicht wissen, welche Cookies relevant sind und welche nicht. Also müssen wir es ihm sagen. Die Contao Managed Edition wird mit einer Liste von irrelevanten Cookies ausgeliefert, die standardmäßig ignoriert werden, um die Trefferquote zu erhöhen. Zur Optimierung kannst du die Standardliste deaktivieren, indem du eine explizite Liste von benötigten Cookies bereit stellst. Dies sind die Cookies, von denen du weisst, dass sie **relevant** für die Anwendung sind, und in diesem Fall muss der Cache **ausgeschaltet** werden.
 
@@ -1181,10 +1181,10 @@ Cookies von installierten Erweiterungen zulassen:
 ```
 COOKIE_ALLOW_LIST=PHPSESSID,csrf_https-contao_csrf_token,csrf_contao_csrf_token,trusted_device,REMEMBERME
 ```
-
+    
 {{% notice note %}}
 Der Name des PHP-Session-Cookies ist über die `php.ini` konfigurierbar, daher solltest du überprüfen, ob er auch `PHPSESSID` lautet. Außerdem ist der CSRF-Cookie aus Sicherheitsgründen für `http` und `https` unterschiedlich. Wenn die Website über `http` ausgeliefert wird, ist zu beachten, dass der Cookie-Name `csrf_http-contao_csrf_token` lautet. Wenn du Benutzer vor CSRF-Angriffen schützen möchtest, aber das Formular über ungesicherte `http`-Verbindungen übermittelst, ist das
-nicht wirklich ein gültiger Anwendungsfall.
+nicht wirklich ein gültiger Anwendungsfall. 
 {{% /notice %}}
 
 
@@ -1260,7 +1260,7 @@ DNS_MAPPING='{
 }'
 ```
 
-Dadurch kann bspw. die Live-Datenbank zur Staging- oder Entwicklungs-Umgebung kopiert und durch die Datenbankmigration
+Dadurch kann bspw. die Live-Datenbank zur Staging- oder Entwicklungs-Umgebung kopiert und durch die Datenbankmigration 
 (`contao:migrate`) die Domain-Einstellungen automatisch angepasst werden.
 
 Auch die Protokoll-Einstellung kann automatisch geändert werden. Dies kann hilfreich sein, wenn bspw. für die lokale
@@ -1306,7 +1306,7 @@ parameters:
 
 ## E-Mail Versand Konfiguration
 
-Um den E-Mail Versand über einen SMTP-Server einzurichten, brauchst du folgende Angaben von deinem Hoster (manche davon können optional
+Um den E-Mail Versand über einen SMTP-Server einzurichten, brauchst du folgende Angaben von deinem Hoster (manche davon können optional 
 sein, je nach Server):
 
 - Den **Hostnamen** des SMTP-Servers.
@@ -1354,7 +1354,7 @@ parameters:
 {{< /tabs >}}
 
 {{% notice warning %}}
-**Cache leeren:** Damit die Änderungen aktiv werden, muss am Ende der Anwendungs-Cache über den Contao Manager (»Systemwartung« >
+**Cache leeren:** Damit die Änderungen aktiv werden, muss am Ende der Anwendungs-Cache über den Contao Manager (»Systemwartung« > 
 »Prod.-Cache erneuern«) oder alternativ über die Kommandozeile geleert werden. Dazu muss man sich im Contao
 Installationsverzeichnis befinden.
 
@@ -1402,20 +1402,20 @@ In vielen Fällen erlauben SMTP-Server nicht den Versand von beliebigen Absender
 zu den verwendeten SMTP-Server Zugangsdaten passen. Vor allem in Multidomain-Installationen von Contao kann es jedoch
 wichtig sein, dass die Absenderadresse der E-Mails, die Contao verschickt, zur jeweiligen Domain passt.
 
-Ab Contao **4.10** besteht daher die Möglichkeit, mehrere E-Mail Konfigurationen in Contao zu benutzen. Diese
-Konfigurationen können dann pro Webseiten-Startpunkt, pro Formular und pro Newsletter-Kanal ausgewählt werden. Pro E-Mail
+Ab Contao **4.10** besteht daher die Möglichkeit, mehrere E-Mail Konfigurationen in Contao zu benutzen. Diese 
+Konfigurationen können dann pro Webseiten-Startpunkt, pro Formular und pro Newsletter-Kanal ausgewählt werden. Pro E-Mail 
 Konfiguration kann dann außerdem auch der Absender gesetzt werden, welcher dann für jede E-Mail benutzt wird, die über
 die ausgewählte E-Mail Konfiguration gesendet wird.
 
 Die Konfiguration benötigt zwei Schritte. Zuerst müssen die verfügbaren E-Mail Versandmethoden über die Symfony Framework
-Konfiguration in der `config.yaml` als sogenannte »Transports« eingestellt werden. Dabei können bspw. ein oder mehrere
+Konfiguration in der `config.yaml` als sogenannte »Transports« eingestellt werden. Dabei können bspw. ein oder mehrere 
 SMTP-Server über die sogenannte »DSN«-Syntax definiert werden. Diese Syntax ist grundsätzlich sehr einfach aufgebaut:
 
 ```
 smtp://<BENUTZERNAME>:<PASSWORT>@<HOSTNAME>:<PORT>
 ```
 
-Man ersetzt die `<PLATZHALTER>` mit den Angaben des verwendeten SMTP-Servers, oder entfernt sie dementsprechend. Siehe
+Man ersetzt die `<PLATZHALTER>` mit den Angaben des verwendeten SMTP-Servers, oder entfernt sie dementsprechend. Siehe 
 dazu auch die Informationen in der offiziellen [Symfony Dokumentation][SymfonyMailer].
 
 Für diese Encodierung kann dieses [Tool](#konvertieren-deiner-mail-parameter) genutzt werden.
@@ -1429,7 +1429,7 @@ mit dem Doppelpunkt. Bei Verwendung der `config.yaml` muß die jeweilige Kodieru
 
 {{% notice tip %}}
 Anstatt `smtp://` kann auch `smtps://` verwendet werden, um automatisch SSL Verschlüsselung über Port `465` zu verwenden.
-{{% /notice %}}
+{{% /notice %}} 
 
 ```yaml
 # config/config.yaml
@@ -1458,7 +1458,7 @@ Backend zur Verfügung.
 
 {{% notice note %}}
 Wird kein Transport konfiguriert, gelten nach wie vor die Informationen aus der `parameters.yaml`. Werden Transports
-konfiguriert, aber es wird kein Transport im Contao Backend ausgewählt, wird automatisch der erste definierte Transport
+konfiguriert, aber es wird kein Transport im Contao Backend ausgewählt, wird automatisch der erste definierte Transport 
 verwendet.
 {{% /notice %}}
 
@@ -1491,7 +1491,7 @@ website2: 'SMTP für Webseite 2'
 ```
 
 {{% notice warning %}}
-**Cache leeren**
+**Cache leeren**  
 Damit die Änderungen im Backend sichtbar werden, muss am Ende der Anwendungs-Cache über den Contao Manager (»Systemwartung« >
 »Prod.-Cache erneuern«) oder alternativ über die Kommandozeile geleert werden. Dazu muss man sich im Contao
 Installationsverzeichnis befinden.
@@ -1525,7 +1525,7 @@ swiftmailer:
     spool:
         type: file
         path: '%kernel.project_dir%/var/spool'
-```
+``` 
 
 In diesem Fall bedienen wir uns dem _File_ Spool, das heißt wenn Contao eine E-Mail sendet wird diese zuerst als Datei in das angegebene
 Verzeichnis abgelegt. In der beschriebenen Konfiguration wird der Ordner `var/spool/` der Contao Installation benutzt (beachte, dass dieser
@@ -1551,7 +1551,7 @@ Bei einem minütlichen Aufruf würde das also den E-Mail Versand auf 600 E-Mails
 
 {{< version "4.10" >}}
 
-Ab Contao **4.10** steht das Swiftmailer Bundle nicht mehr von Haus aus zur Verfügung, statt dessen nutzt Contao
+Ab Contao **4.10** steht das Swiftmailer Bundle nicht mehr von Haus aus zur Verfügung, statt dessen nutzt Contao 
 [Symfony Mailer][SymfonyMailer]. Um E-Mail asnychron senden zu können wird in diesem Fall die [Symfony Messenger][SymfonyMessenger]
 Komponente benötigt. Diese muss zuerst via Composer installiert werden:
 
@@ -1578,7 +1578,7 @@ framework:
 
 {{% notice "note" %}}
 Anstatt den Messenger Transport direkt zu definieren können wie immer auch Umgebungsvariablen benutzt werden, falls man in verschiedenen
-Umgebungen verschiedene Transports haben möchte (bspw. lokal zum testen den
+Umgebungen verschiedene Transports haben möchte (bspw. lokal zum testen den 
 [In Memory Transport](https://symfony.com/doc/current/messenger.html#in-memory-transport)).
 
 ```yaml
@@ -1610,15 +1610,15 @@ Bei einem minütlichen Aufruf würde das also den E-Mail Versand auf 600 E-Mails
 
 {{% notice "info" %}}
 In den Kommandos wird die Option `--time-limit=1` benutzt. Von Haus aus läuft der `messenger:consume` Prozess unendlich lang und verarbeitet
-alle E-Mails in dieser Zeit automatisch - und es müsste daher auch kein Cronjob eingerichtet werden. Um sicherzustellen, dass dieser
+alle E-Mails in dieser Zeit automatisch - und es müsste daher auch kein Cronjob eingerichtet werden. Um sicherzustellen, dass dieser 
 Prozess läuft und ggf. neu gestartet wird könnten entsprechende Tools am Server verwendet werden. In Shared Hosting Umgebungen hat man diese
 Möglichkeit meist jedoch nicht, daher muss in der Cronjob Variante sichergestellt werden, dass der Prozess nur einmalig läuft. Mit der
-bereits erwähnten `--time-limit=1` Option wird der Prozess nach spätestens einer Sekunde beendet. Nähere Details dazu findet man in der
+bereits erwähnten `--time-limit=1` Option wird der Prozess nach spätestens einer Sekunde beendet. Nähere Details dazu findet man in der 
 [Symfony Dokumentation](https://symfony.com/doc/current/messenger.html#consuming-messages-running-the-worker).
 {{% /notice %}}
 
 {{% notice "note" %}}
-Es kann sein, dass Mails zeitversetzt verarbeitet werden,
+Es kann sein, dass Mails zeitversetzt verarbeitet werden, 
 wenn der Cronjob keine Angabe für die Zeitzone hat und dann den Standard `UTC` verwendet.
 Deshalb sollte die lokale Zeitzone entweder global auf dem Server festgelegt werden oder explizit im Cronjob.
 {{% /notice %}}

--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -138,10 +138,10 @@ security:
 ```
 
 **Beispiele:**  
-`<iframe>` ist in den erlaubten HTML-Tags nicht vorhanden, kann aber einfach unter Schlüssel eingefügt werden.
+`<iframe>` ist in den erlaubten HTML-Tags nicht vorhanden, kann aber einfach unter Schlüssel eingefügt werden. 
 
 {{% notice note %}}  
-Um die selbst hinzugefügten HTML-Tags besser zu erkennen, sollten diese zu Beginn der Liste eingetragen werden. 
+Um die selbst hinzugefügten HTML-Tags besser zu erkennen, sollten diese zu Beginn der Liste eingetragen werden.  
 {{% /notice %}}  
 
 In den erlaubten HTML-Attributen, als Wert muss hierzu dann auch noch das Attribut mit eingefügt werden.  
@@ -1355,7 +1355,7 @@ parameters:
 
 {{% notice warning %}}
 **Cache leeren:** Damit die Änderungen aktiv werden, muss am Ende der Anwendungs-Cache über den Contao Manager (»Systemwartung« > 
-»Prod.-Cache erneuern«) oder alternativ über die Kommandozeile geleert werden. Dazu muss man sich im Contao
+»Prod.-Cache erneuern«) oder alternativ über die Kommandozeile geleert werden. Dazu muss man sich im Contao 
 Installationsverzeichnis befinden.
 
 ```bash
@@ -1492,8 +1492,8 @@ website2: 'SMTP für Webseite 2'
 
 {{% notice warning %}}
 **Cache leeren**  
-Damit die Änderungen im Backend sichtbar werden, muss am Ende der Anwendungs-Cache über den Contao Manager (»Systemwartung« >
-»Prod.-Cache erneuern«) oder alternativ über die Kommandozeile geleert werden. Dazu muss man sich im Contao
+Damit die Änderungen im Backend sichtbar werden, muss am Ende der Anwendungs-Cache über den Contao Manager (»Systemwartung« > 
+»Prod.-Cache erneuern«) oder alternativ über die Kommandozeile geleert werden. Dazu muss man sich im Contao 
 Installationsverzeichnis befinden.
 
 ```bash

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -118,7 +118,7 @@ language respective website root when using the [legacy routing mode][LegacyRout
 For input fields where the use of HTML is desired, you can specify a list of allowed HTML tags here.
 
 {{< version-tag "4.11.7, 4.9.18 and 4.4.56" >}} **Allowed HTML attributes:** You can extend the list of allowed HTML attributes for input fields here. If an HTML 
-attribute is not present in the list, it will be automatically removed when saving. The tag or attribute name * stands for
+attribute is not present in the list, it will be automatically removed when saving. The tag or attribute name * stands for 
 all tags or attributes. For attributes with hyphens, placeholders such as data-* can be used.
 
 **Password hash:** By default, Contao uses the defaut of the current PHP version, but you can also set a value. This 

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -5,9 +5,9 @@ aliases:
 weight: 10
 ---
 
-The system settings slowly but surely leave the backend. Basic system settings influence Contao as an application and 
-therefore there is a chance that a wrong setting will render the system non-functional. If this happens, you will not 
-be able to undo the settings and restore the system because you will not be able to log in anymore. For this reason, 
+The system settings slowly but surely leave the backend. Basic system settings influence Contao as an application and
+therefore there is a chance that a wrong setting will render the system non-functional. If this happens, you will not
+be able to undo the settings and restore the system because you will not be able to log in anymore. For this reason,
 most settings are configured outside of Contao via the `config.yaml`, or can be configured via the Contao Manager in the future.
 
 
@@ -16,7 +16,7 @@ most settings are configured outside of Contao via the `config.yaml`, or can be 
 
 ### Global configuration
 
-**E-mail address of the system administrator:** This is the address to which notifications about e.g. locked accounts or 
+**E-mail address of the system administrator:** This is the address to which notifications about e.g. locked accounts or
 newly registered users are sent. You can also use the following notation to add a name to the email address:
 
 ```text
@@ -26,8 +26,8 @@ Kevin Jones [kevin.jones@example.com]
 
 ### Date and time
 
-**Date and time format:** All date and time formats must be entered as used with the PHP 
-[date](https://www.php.net/manual/de/function.date.php) function. Contao processes only numeric formats in the backend, 
+**Date and time format:** All date and time formats must be entered as used with the PHP
+[date](https://www.php.net/manual/de/function.date.php) function. Contao processes only numeric formats in the backend,
 i.e. the letters j, d, m, n, y, Y, g, G, h, H, i and s.
 
 Here are some examples of valid date and time specifications:
@@ -42,21 +42,21 @@ Here are some examples of valid date and time specifications:
 | H:i:s | 24 hours, minutes and seconds, e.g. `20:36:59` |
 | g:i | 12 hours without leading zeros and minutes, e.g. `8:36` |
 
-**Time zone:** You should set the timezone before you create your website because Contao stores all dates as 
+**Time zone:** You should set the timezone before you create your website because Contao stores all dates as
 [Unix timestamps](https://www.php.net/time) and Contao will not adjust these, if the timezone is changed.
 
 
 ### Back end configuration
 
-**Do not collapse elements:** In the "Parent View", Contao displays the elements in a shortened form for clarity 
-reasons. Individual elements can be unfolded using a navigation icon if needed. Select this option to disable the 
+**Do not collapse elements:** In the "Parent View", Contao displays the elements in a shortened form for clarity
+reasons. Individual elements can be unfolded using a navigation icon if needed. Select this option to disable the
 feature completely.
 
-**Items per page:** In the [Listing Records](/en/administration-area/list-data-records/#sort-and-filter-records) 
-section, you learned that Contao limits the number of records per page to 30 by default. You can change this value here. 
+**Items per page:** In the [Listing Records](/en/administration-area/list-data-records/#sort-and-filter-records)
+section, you learned that Contao limits the number of records per page to 30 by default. You can change this value here.
 Higher values mean a longer loading time.
 
-**Maximum items per page:** To prevent an inexperienced user from displaying 5000 records at once and thus 
+**Maximum items per page:** To prevent an inexperienced user from displaying 5000 records at once and thus
 exceeding the PHP memory limit, you can specify the maximum number of records that can be displayed per page.
 
 #### Additional back end settings:
@@ -73,7 +73,7 @@ Some additional parameters can be configured via the `config/config.yaml`.
 | `badge_title` | Configures the title of the badge in the back end. |
 | `route_prefix` | {{< version-tag "4.13" >}} Configures the path to the Contao back end, e.g., `/admin` instead of `/contao`. |
 
-The following config defines some example values: 
+The following config defines some example values:
 
 ```yaml
 # config/config.yaml
@@ -96,32 +96,32 @@ contao:
 Starting with version **4.10** this setting can be changed in the settings of the website root instead:
 {{% /notice %}}
 
-**Enable folder URLs:** Here you can activate folder structures in page aliases. This will add the aliases that exist in 
-the page hierarchy to the alias, e.g. the page "Download" in the page path "Docs &gt; Install" will use the alias 
+**Enable folder URLs:** Here you can activate folder structures in page aliases. This will add the aliases that exist in
+the page hierarchy to the alias, e.g. the page "Download" in the page path "Docs &gt; Install" will use the alias
 `docs/install/download.html` instead of just `download.html`.
 
 {{% notice note %}}
 This setting does not exist anymore in Contao **4.10** and higher:
 {{% /notice %}}
 
-**Do not redirect empty URLs:** Allows you to disable the redirect of the "empty URL" to the start page of the browser's 
-language respective website root when using the [legacy routing mode][LegacyRouting] without `contao.prepend_locale: true` 
+**Do not redirect empty URLs:** Allows you to disable the redirect of the "empty URL" to the start page of the browser's
+language respective website root when using the [legacy routing mode][LegacyRouting] without `contao.prepend_locale: true`
 *(not recommended)*.
 
 
 ### Security settings
 
-**Disable request tokens:** Here you can activate that the request tokens are not checked when submitting a form 
+**Disable request tokens:** Here you can activate that the request tokens are not checked when submitting a form
 *(insecure!)*.
 
-**Allowed HTML tags:** By default, Contao does not allow HTML tags in forms and removes them automatically when saving. 
+**Allowed HTML tags:** By default, Contao does not allow HTML tags in forms and removes them automatically when saving.
 For input fields where the use of HTML is desired, you can specify a list of allowed HTML tags here.
 
-{{< version-tag "4.11.7, 4.9.18 and 4.4.56" >}} **Allowed HTML attributes:** You can extend the list of allowed HTML attributes for input fields here. If an HTML 
-attribute is not present in the list, it will be automatically removed when saving. The tag or attribute name * stands for 
+{{< version-tag "4.11.7, 4.9.18 and 4.4.56" >}} **Allowed HTML attributes:** You can extend the list of allowed HTML attributes for input fields here. If an HTML
+attribute is not present in the list, it will be automatically removed when saving. The tag or attribute name * stands for
 all tags or attributes. For attributes with hyphens, placeholders such as data-* can be used.
 
-**Password hash:** By default, Contao uses the defaut of the current PHP version, but you can also set a value. This 
+**Password hash:** By default, Contao uses the defaut of the current PHP version, but you can also set a value. This
 is necessary if you want to sync the password to another system like LDAP.
 
 The following configuration defines some example values:
@@ -134,16 +134,16 @@ security:
 ```
 
 
-**Examples:**  
+**Examples:**
 `<iframe>` is not present in the allowed HTML tags, but can easily be inserted under key.
 
-{{% notice note %}}  
+{{% notice note %}}
 In order to better recognise the HTML tags added by the user, these should be entered at the beginning of the list.
-{{% /notice %}}  
+{{% /notice %}}
 
-In the permitted HTML attributes, the attribute must then also be inserted as a value for this.    
+In the permitted HTML attributes, the attribute must then also be inserted as a value for this.
 
-`<nav>` and `<input>` are, for example, already present in the permitted HTML tags and can thus be easily extended with permitted attributes. 
+`<nav>` and `<input>` are, for example, already present in the permitted HTML tags and can thus be easily extended with permitted attributes.
 Enter `nav` or `input` as the key and the desired value as the value - in our example `role` or `type`.
 
 If you trust all backend users 100%, you can also enter `*` as the key and `*` as the value. This will allow all attributes for all elements.
@@ -166,28 +166,28 @@ process library. Any image exceeding this value will not be processed.
 
 **Upload file types:** Here you can define which file types can be uploaded to your server.
 
-**Maximum upload file size:** Here you can define the maximum size of a file that can be uploaded to your server using 
+**Maximum upload file size:** Here you can define the maximum size of a file that can be uploaded to your server using
 the file manager. The entry is in bytes (1 MiB = 1024 KiB = 1,048,576 bytes). Larger files will be rejected.
 
-**Maximum image width:** When uploading images, the file manager automatically checks the width of the image and 
+**Maximum image width:** When uploading images, the file manager automatically checks the width of the image and
 compares it with the width you set here. If an image exceeds the maximum width, it will be reduced automatically.
 
-**Maximum image height:** When uploading images, the file manager automatically checks their height and compares it with 
+**Maximum image height:** When uploading images, the file manager automatically checks their height and compares it with
 your default value. If an image exceeds the maximum height, it will be resized automatically.
 
 
 ### Search engine settings
 
-**Enable searching:** If you select this option, Contao indexes the finished pages of your website and creates a search 
-index from them. With the frontend module 
-"[search engine](/en/layout/module-management/website-search/#configuration-of-the-search-module)", you can search this 
+**Enable searching:** If you select this option, Contao indexes the finished pages of your website and creates a search
+index from them. With the frontend module
+"[search engine](/en/layout/module-management/website-search/#configuration-of-the-search-module)", you can search this
 index.
 
-**Index protected pages:** Select this option to index protected pages for your search. Use this feature with care and 
+**Index protected pages:** Select this option to index protected pages for your search. Use this feature with care and
 make sure to exclude personalized pages from the search.
 
 {{% notice note %}}
-Starting with version **4.9** a new search indexer is used. The settings **Enable searching** and 
+Starting with version **4.9** a new search indexer is used. The settings **Enable searching** and
 **Index protected pages** are now configured via the `config/config.yaml`.
 
 ```yaml
@@ -202,7 +202,7 @@ contao:
 
 ### Cron job settings
 
-**Deactivate the command scheduler:** Here you can disable the Periodic Command Scheduler and run the route 
+**Deactivate the command scheduler:** Here you can disable the Periodic Command Scheduler and run the route
 `_contao/cron` using a real cron job (which you have to set up yourself). Starting with Contao **4.9** you can also
 use the following command:
 
@@ -213,20 +213,20 @@ php vendor/bin/contao-console contao:cron
 
 ### Default access rights
 
-**Default page owner:** Here you can specify the default owner of the pages for which no access rights have been 
+**Default page owner:** Here you can specify the default owner of the pages for which no access rights have been
 defined. For more information, see the Access Rights section.
 
-**Default page group**: Here you can define to which group the pages for which no access rights are defined belong by 
+**Default page group**: Here you can define to which group the pages for which no access rights are defined belong by
 default. For more information, see the Access Rights section.
 
-**Default access rights:** Here you can set the default access rights for the pages for which no special access rights 
+**Default access rights:** Here you can set the default access rights for the pages for which no special access rights
 are defined. For more information, see the Access Rights section.
 
 
 ## parameters.yaml
 
-In the Contao Managed Edition, the parameters (e.g. database credentials) are stored in the `parameters.yaml` file that 
-is generated by the Contao installation tool. This file is usually excluded from the versioning process and can also 
+In the Contao Managed Edition, the parameters (e.g. database credentials) are stored in the `parameters.yaml` file that
+is generated by the Contao installation tool. This file is usually excluded from the versioning process and can also
 contain additional entries such as the credentials for sending e-mails via SMTP.
 
 The file `parameters.yaml` is located in the folder `config/` and is created automatically when you install Contao.
@@ -252,11 +252,11 @@ parameters:
 
 ## config.yaml
 
-The bundle configuration belongs in the `config.yaml` and is located in the folder `config/`. If the file does not 
-exist yet, it must be created. Contao automatically loads the `config_prod.yaml` or `config_dev.yaml` and if not available 
+The bundle configuration belongs in the `config.yaml` and is located in the folder `config/`. If the file does not
+exist yet, it must be created. Contao automatically loads the `config_prod.yaml` or `config_dev.yaml` and if not available
 the `config.yaml`.
 
-This allows you to realize different configurations for your test or production environment (dev/prod) (e.g. more 
+This allows you to realize different configurations for your test or production environment (dev/prod) (e.g. more
 logging in debug mode). In addition, you can commit the `config.yaml` configuration files to your repository, if your
 project is versioned via Git for example.
 
@@ -340,6 +340,13 @@ contao:
 
     # Allows to define Symfony Messenger workers (messenger:consume). Workers are started every minute using the Contao cron job framework.
     messenger:
+        # Contao provides a way to work on Messenger transports in the web process (kernel.terminate) if there is no real "messenger:consume" worker. You can configure its behavior here.'
+        web_worker:
+
+          # The transports to apply the web worker logic to.
+          transports:     []
+          grace_period:   PT10M # Must be a valid string for \DateInterval()
+
         workers:
 
             # Prototype
@@ -399,7 +406,12 @@ contao:
 
             # Allows to disable the layer flattening of animated images. Set this option to false to support animations. It has no effect with Gd as Imagine service.
             flatten:              ~
+
+            # One of the Imagine\Image\ImageInterface::INTERLACE_* constants.
             interlace:            plane
+
+            # Filter used when downsampling images. One of the Imagine\Image\ImageInterface::FILTER_* constants. It has no effect with Gd or SVG as Imagine service.
+            resampling-filter:    ~
 
         # Contao automatically uses an Imagine service out of Gmagick, Imagick and Gd (in this order). Set a service ID here to override.
         imagine_service:      null
@@ -579,7 +591,7 @@ contao:
             # Example:
             - files/backend/custom.js
 
-        # Configures the title of the badge in the back end.
+        # Configures the title of the badge in the back end and the Contao Manager.
         badge_title:          '' # Example: develop
 
         # Defines the path of the Contao backend.
@@ -735,7 +747,12 @@ contao:
 
             # Allows to disable the layer flattening of animated images. Set this option to false to support animations. It has no effect with Gd as Imagine service.
             flatten:              ~
+
+            # One of the Imagine\Image\ImageInterface::INTERLACE_* constants.
             interlace:            plane
+
+            # Filter used when downsampling images. One of the Imagine\Image\ImageInterface::FILTER_* constants. It has no effect with Gd or SVG as Imagine service.
+            resampling-filter:    ~
 
         # Contao automatically uses an Imagine service out of Gmagick, Imagick and Gd (in this order). Set a service ID here to override.
         imagine_service:      null
@@ -872,7 +889,7 @@ contao:
             # Example:
             - files/backend/custom.js
 
-        # Configures the title of the badge in the back end.
+        # Configures the title of the badge in the back end and the Contao Manager.
         badge_title:          '' # Example: develop
 
         # Defines the path of the Contao backend.
@@ -931,16 +948,16 @@ contao:
 ### localconfig
 
 As mentioned in the config reference above the configuration key `contao.localconfig` allows you to set any configuration
-that is defined via `$GLOBALS['TL_CONFIG']`, the default values of which can be overwritten via the 
+that is defined via `$GLOBALS['TL_CONFIG']`, the default values of which can be overwritten via the
 `system/config/localconfig.php`. This is where Contao stores any settings that have been customised in the back end, i.e.
 under _System_ » _Settings_. This form of storing settings is being phased out step by step. Some of the settings now
 have a counterpart in the bundle configuration, others are e.g. set in the website root or within the back end user's
-settings. 
+settings.
 
-However depending on the Contao version you are using there are still settings being used from the localconfig. Thus it 
-can be useful to define them directly in your applications configuration (i.e. the `config.yaml`) rather than the legacy 
-`localconfig.php`. Not only because you might need it for your deployment flow, but also because some settings can _only_ 
-be set manually - because they neither have a bundle configuration counterpart, nor is there another mean of setting them 
+However depending on the Contao version you are using there are still settings being used from the localconfig. Thus it
+can be useful to define them directly in your applications configuration (i.e. the `config.yaml`) rather than the legacy
+`localconfig.php`. Not only because you might need it for your deployment flow, but also because some settings can _only_
+be set manually - because they neither have a bundle configuration counterpart, nor is there another mean of setting them
 via the back end.
 
 The following example defines the administrator's e-mail address via an environment variable and increases the undo period
@@ -1006,7 +1023,7 @@ Environment variables are variables that can be defined at the operating system 
 The variables are defined in the file `.env` and this file must be located in the root directory of the Contao installation. The usage and name of the following variables are predefined. However, you can also define arbitrary variables and then reference them e.g. in the `config.yaml`. If an additional `.env.local` file exists in the same directory, it will be used automatically.
 
 {{% notice info %}}
-Some of the environment variables, like `APP_SECRET`, `DATABASE_URL` and `MAILER_DSN` replace their respective counterparts 
+Some of the environment variables, like `APP_SECRET`, `DATABASE_URL` and `MAILER_DSN` replace their respective counterparts
 of the `config/parameters.yaml` and thus you should not use these parameters, if you are using the environment variable instead.
 {{% /notice %}}
 
@@ -1035,23 +1052,23 @@ in the `prod` mode, optimizing everything for production. If you want to put you
 mode to have additional logging and debugging output, set `APP_ENV` to `dev`. Never do this for production sites!
 If you set the environment manually, you will no longer be able to toggle the debug mode from the back end as a
 Contao administrator.
-    
+
 
 ### `APP_SECRET`
 
-The `APP_SECRET` environment variable is required e.g. to generate CSRF tokens. This is a string that should be 
-unique to your application and it's commonly used to add more entropy to security related operations. Its value 
-should be a series of characters, numbers and symbols chosen randomly and the recommended length is around 
+The `APP_SECRET` environment variable is required e.g. to generate CSRF tokens. This is a string that should be
+unique to your application and it's commonly used to add more entropy to security related operations. Its value
+should be a series of characters, numbers and symbols chosen randomly and the recommended length is around
 32 characters. As with any other security-related parameter, it is a good practice to change this value from time
-to time. However, keep in mind that changing this value will invalidate all signed URIs and Remember Me cookies. 
+to time. However, keep in mind that changing this value will invalidate all signed URIs and Remember Me cookies.
 That is why, after changing this value, you should regenerate the application cache and log out all the application
 users. For more information please visit the [Symfony documentation](https://symfony.com/doc/current/reference/configuration/framework.html#secret).
 
 
 ### `DATABASE_URL`
 
-The database connection information is stored as an environment variable called `DATABASE_URL`. It defines 
-the database user name, database password, host name, port and database name that will be used by your Contao system. 
+The database connection information is stored as an environment variable called `DATABASE_URL`. It defines
+the database user name, database password, host name, port and database name that will be used by your Contao system.
 The format of this variable is the following: `DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name"`.
 
 It is used by default for the [Doctrine configuration][DoctrineConfig]: `doctrine.dbal.url: '%env(DATABASE_URL)%'`.
@@ -1105,7 +1122,7 @@ The following tool runs in your browser and helps you to convert the variables o
 ### `MAILER_DSN`
 
 The mailer connection information is stored as an environment variable called `MAILER_DSN`. It defines the transport to
-be used for sending emails, as well as the login credentials, host name and port for an SMTP server for example, if 
+be used for sending emails, as well as the login credentials, host name and port for an SMTP server for example, if
 applicable. The format of this variable is the following: `MAILER_DSN=smtp://username:password@smtp.example.com:465?encryption=ssl`.
 See the [Symfony Mailer Documentation][SymfonyMailer] for more information.
 
@@ -1177,13 +1194,13 @@ cookies of extensions you installed:
 ```
 COOKIE_ALLOW_LIST=PHPSESSID,csrf_https-contao_csrf_token,csrf_contao_csrf_token,trusted_device,REMEMBERME
 ```
-    
+
 {{% notice note %}}
 The name of the PHP session cookie is configurable through the `php.ini` so you might want to check if it's `PHPSESSID`
 for you too. Moreover, the CSRF cookie is different for `http` and `https` for security reasons. If you serve your
 website over `http`, note that the cookie name will be `csrf_http-contao_csrf_token`.
 However, protecting your users from CSRF attacks but let them submit the form via unsecured `http` connections is
-not really a valid use case. 
+not really a valid use case.
 {{% /notice %}}
 
 ### `COOKIE_REMOVE_FROM_DENY_LIST`
@@ -1227,7 +1244,7 @@ QUERY_PARAMS_REMOVE_FROM_DENY_LIST=fbclid
 If you do so, make sure to disable caching by e.g. setting `Cache-Control: no-store` on this response if `fbclid` is
 present as otherwise you are back to having thousands of cache entries in your cache proxy.
 {{% /notice %}}
-    
+
 
 ### `TRUSTED_PROXIES`
 
@@ -1238,10 +1255,10 @@ For example, instead of reading the `REMOTE_ADDR` header (which will now be the 
 the user's true IP will be stored in a standard `Forwarded: for="…"` header or a `X-Forwarded-For` header.
 If you don't configure the Managed Edition to look for these headers, you'll get incorrect information about the
 client's IP address, whether or not the client is connecting via HTTPS, the client's port and the hostname being
-requested. Let's say your load balancer runs on IP `192.0.2.1`. You can trust that IP by setting `TRUSTED_PROXIES` 
+requested. Let's say your load balancer runs on IP `192.0.2.1`. You can trust that IP by setting `TRUSTED_PROXIES`
 to `192.0.2.1`. You can also trust a whole IP range if you like to: `TRUSTED_PROXIES=192.0.2.0/24`. See the
 [Symfony Documentation on Proxies][SymfonyProxies] for more information.
-    
+
 
 ### `TRUSTED_HOSTS`
 
@@ -1277,7 +1294,7 @@ DNS_MAPPING='{
 }'
 ```
 
-This allows you to - for example - copy the live database to your staging or local environment and then automatically 
+This allows you to - for example - copy the live database to your staging or local environment and then automatically
 change the domains according to the mapping in the respective environment during `contao:migrate`.
 
 You can also migrate the protocol setting to different settings in the respective environment, which might be
@@ -1309,7 +1326,7 @@ DNS_MAPPING='{
 }'
 ```
 
-Instead of the environment variable, you can also directly set the `contao.dns_mapping` parameter in your 
+Instead of the environment variable, you can also directly set the `contao.dns_mapping` parameter in your
 `parameters.yaml`, if you prefer:
 
 ```yaml
@@ -1340,7 +1357,7 @@ e.g. via the `.env.local` of your Contao instance.
 {{% tab name=".env.local" %}}
 {{< version-tag "4.9" >}} You can define the SMTP server via the [`.env.local`](https://symfony.com/doc/current/configuration.html#overriding-environment-values-via-env-local)
 of your Contao instance (note that the `.env` file must also exist in order for the `.env.local` to take effect). In Contao **4.9** you need
-to use the `MAILER_URL` environment variable, while in Contao **4.10** and up the [`MAILER_DSN`](#mailer-dsn) variable can be used. In 
+to use the `MAILER_URL` environment variable, while in Contao **4.10** and up the [`MAILER_DSN`](#mailer-dsn) variable can be used. In
 Contao **5.0** and up only the `MAILER_DSN` environment variable will work.
 
 ```ini
@@ -1412,26 +1429,26 @@ You can also omit the parameters. The command will then ask you for each paramet
 
 {{< version "4.10" >}}
 
-In many cases, SMTP servers do not allow sending from any sender address. Oftentimes the sender address must match 
-the SMTP server credentials. Especially in multi-domain installations of Contao it might be important that the 
+In many cases, SMTP servers do not allow sending from any sender address. Oftentimes the sender address must match
+the SMTP server credentials. Especially in multi-domain installations of Contao it might be important that the
 sender address of the emails that Contao sends matches the domain. Or you might want to have different sender
 addresses for different front end forms created via the Contao form generator.
 
-Since Contao **4.10**, it is possible to use multiple email configurations in Contao. These configurations can be 
-selected per website root, per form and per newsletter channel. For each e-mail configuration, you can also set the 
+Since Contao **4.10**, it is possible to use multiple email configurations in Contao. These configurations can be
+selected per website root, per form and per newsletter channel. For each e-mail configuration, you can also set the
 sender that will be used for each e-mail sent by the selected e-mail configuration.
 
-The configuration requires two steps. First, the available e-mail sending methods have to be set in the Symfony 
+The configuration requires two steps. First, the available e-mail sending methods have to be set in the Symfony
 framework configuration in the `config.yaml` so-called. One or more SMTP servers can be defined using the so-called "DSN" syntax:
 
 ```
 smtp://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>
 ```
 
-Replace the `<PLACEHOLDER>` with the information of the SMTP server used, or remove them accordingly. See also the 
+Replace the `<PLACEHOLDER>` with the information of the SMTP server used, or remove them accordingly. See also the
 information in the official [Symfony documentation][SymfonyMailer].
 
-You can use this [Tool](#convert-your-mail-parameters) to encode your parameters. 
+You can use this [Tool](#convert-your-mail-parameters) to encode your parameters.
 
 {{% notice warning %}}
 If your username or password contains special characters, they need to be "url encoded". There are several online
@@ -1453,7 +1470,7 @@ framework:
             website2: smtps://email%%40example.de:foobar@example.de
 ```
 
-In the second step, the configured transports can be made available in the back end via the Contao framework 
+In the second step, the configured transports can be made available in the back end via the Contao framework
 configuration. In the following example, the transports `website1` and `website2` are made available:
 
 ```yaml
@@ -1465,11 +1482,11 @@ contao:
             website2: ~
 ```
 
-If the symfony application cache has been refreshed afterwards, these email configurations will be available for 
+If the symfony application cache has been refreshed afterwards, these email configurations will be available for
 selection in the Contao back end.
 
 {{% notice note %}}
-If no transport is configured, the information from the `parameters.yaml` is used. If a transport is configured but no transport 
+If no transport is configured, the information from the `parameters.yaml` is used. If a transport is configured but no transport
 is selected in the Contao back end, the first defined transport is used automatically.
 {{% /notice %}}
 
@@ -1501,9 +1518,9 @@ website2: 'SMTP für Webseite 2'
 ```
 
 {{% notice warning %}}
-**Clear cache** 
-In order to enable these changes, the application cache must be rebuilt using the Contao Manager ("Maintenance" &gt; 
-"Rebuild Production Cache") or alternatively via the command line. To do the latter you have to execute the following in 
+**Clear cache**
+In order to enable these changes, the application cache must be rebuilt using the Contao Manager ("Maintenance" &gt;
+"Rebuild Production Cache") or alternatively via the command line. To do the latter you have to execute the following in
 the Contao installation directory:
 
 ```bash
@@ -1515,7 +1532,7 @@ php vendor/bin/contao-console cache:warmup --env=prod
 
 ### Send Emails Asynchronously
 
-Instead of letting Contao send emails immediately when a request is processed (e.g. when a form was submitted) the email can be sent 
+Instead of letting Contao send emails immediately when a request is processed (e.g. when a form was submitted) the email can be sent
 asynchronously by the server later. There are several reasons why this can be important:
 
 * It reduces the server response time of such requests (in some cases sending via a defined SMTP server can take several seconds).
@@ -1570,7 +1587,7 @@ composer require symfony/messenger
 ```
 
 Now we can define a Messenger transport and routing for email messages. First we need to decide on the type of Messenger transport though.
-The component already provides different [transport types][SymfonyMessengerTransports]. In this case the 
+The component already provides different [transport types][SymfonyMessengerTransports]. In this case the
 [Doctrine transport][SymfonyMessengerDoctrine] is a good fit since it will save our emails in the database first for later consumption.
 In order to enable asynchronous emails via Symfony Mailer [the following needs to be configured][SymfonyMailerMessenger]:
 
@@ -1587,7 +1604,7 @@ framework:
 
 {{% notice "note" %}}
 Instead of defining the Messenger transport directly we can also use environment variables as usual, in case you want to use different
-transports in different environments (e.g. using the 
+transports in different environments (e.g. using the
 [In Memory transport](https://symfony.com/doc/current/messenger.html#in-memory-transport) locally for testing).
 
 ```yaml
@@ -1622,7 +1639,7 @@ The commands described above use the `--time-limit=1` option. By default the `me
 any new messages continuously. Therefore you would not need to run a separate cronjob. In order to make sure that this process is always
 running and is restarted on demand, different tools can be used on the server. However, in shared hosting environments such tools are
 usually not available. Thus, when using a cronjob you need to make sure that the process will only run a limited time when executed. The
-aforementioned `--time-limit=1` option will cause the process to exit after one second. You can find more details in the 
+aforementioned `--time-limit=1` option will cause the process to exit after one second. You can find more details in the
 [Symfony documentation](https://symfony.com/doc/current/messenger.html#consuming-messages-running-the-worker).
 {{% /notice %}}
 

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -5,9 +5,9 @@ aliases:
 weight: 10
 ---
 
-The system settings slowly but surely leave the backend. Basic system settings influence Contao as an application and
-therefore there is a chance that a wrong setting will render the system non-functional. If this happens, you will not
-be able to undo the settings and restore the system because you will not be able to log in anymore. For this reason,
+The system settings slowly but surely leave the backend. Basic system settings influence Contao as an application and 
+therefore there is a chance that a wrong setting will render the system non-functional. If this happens, you will not 
+be able to undo the settings and restore the system because you will not be able to log in anymore. For this reason, 
 most settings are configured outside of Contao via the `config.yaml`, or can be configured via the Contao Manager in the future.
 
 
@@ -16,7 +16,7 @@ most settings are configured outside of Contao via the `config.yaml`, or can be 
 
 ### Global configuration
 
-**E-mail address of the system administrator:** This is the address to which notifications about e.g. locked accounts or
+**E-mail address of the system administrator:** This is the address to which notifications about e.g. locked accounts or 
 newly registered users are sent. You can also use the following notation to add a name to the email address:
 
 ```text
@@ -26,8 +26,8 @@ Kevin Jones [kevin.jones@example.com]
 
 ### Date and time
 
-**Date and time format:** All date and time formats must be entered as used with the PHP
-[date](https://www.php.net/manual/de/function.date.php) function. Contao processes only numeric formats in the backend,
+**Date and time format:** All date and time formats must be entered as used with the PHP 
+[date](https://www.php.net/manual/de/function.date.php) function. Contao processes only numeric formats in the backend, 
 i.e. the letters j, d, m, n, y, Y, g, G, h, H, i and s.
 
 Here are some examples of valid date and time specifications:
@@ -42,21 +42,21 @@ Here are some examples of valid date and time specifications:
 | H:i:s | 24 hours, minutes and seconds, e.g. `20:36:59` |
 | g:i | 12 hours without leading zeros and minutes, e.g. `8:36` |
 
-**Time zone:** You should set the timezone before you create your website because Contao stores all dates as
+**Time zone:** You should set the timezone before you create your website because Contao stores all dates as 
 [Unix timestamps](https://www.php.net/time) and Contao will not adjust these, if the timezone is changed.
 
 
 ### Back end configuration
 
-**Do not collapse elements:** In the "Parent View", Contao displays the elements in a shortened form for clarity
-reasons. Individual elements can be unfolded using a navigation icon if needed. Select this option to disable the
+**Do not collapse elements:** In the "Parent View", Contao displays the elements in a shortened form for clarity 
+reasons. Individual elements can be unfolded using a navigation icon if needed. Select this option to disable the 
 feature completely.
 
-**Items per page:** In the [Listing Records](/en/administration-area/list-data-records/#sort-and-filter-records)
-section, you learned that Contao limits the number of records per page to 30 by default. You can change this value here.
+**Items per page:** In the [Listing Records](/en/administration-area/list-data-records/#sort-and-filter-records) 
+section, you learned that Contao limits the number of records per page to 30 by default. You can change this value here. 
 Higher values mean a longer loading time.
 
-**Maximum items per page:** To prevent an inexperienced user from displaying 5000 records at once and thus
+**Maximum items per page:** To prevent an inexperienced user from displaying 5000 records at once and thus 
 exceeding the PHP memory limit, you can specify the maximum number of records that can be displayed per page.
 
 #### Additional back end settings:
@@ -73,7 +73,7 @@ Some additional parameters can be configured via the `config/config.yaml`.
 | `badge_title` | Configures the title of the badge in the back end. |
 | `route_prefix` | {{< version-tag "4.13" >}} Configures the path to the Contao back end, e.g., `/admin` instead of `/contao`. |
 
-The following config defines some example values:
+The following config defines some example values: 
 
 ```yaml
 # config/config.yaml
@@ -96,32 +96,32 @@ contao:
 Starting with version **4.10** this setting can be changed in the settings of the website root instead:
 {{% /notice %}}
 
-**Enable folder URLs:** Here you can activate folder structures in page aliases. This will add the aliases that exist in
-the page hierarchy to the alias, e.g. the page "Download" in the page path "Docs &gt; Install" will use the alias
+**Enable folder URLs:** Here you can activate folder structures in page aliases. This will add the aliases that exist in 
+the page hierarchy to the alias, e.g. the page "Download" in the page path "Docs &gt; Install" will use the alias 
 `docs/install/download.html` instead of just `download.html`.
 
 {{% notice note %}}
 This setting does not exist anymore in Contao **4.10** and higher:
 {{% /notice %}}
 
-**Do not redirect empty URLs:** Allows you to disable the redirect of the "empty URL" to the start page of the browser's
-language respective website root when using the [legacy routing mode][LegacyRouting] without `contao.prepend_locale: true`
+**Do not redirect empty URLs:** Allows you to disable the redirect of the "empty URL" to the start page of the browser's 
+language respective website root when using the [legacy routing mode][LegacyRouting] without `contao.prepend_locale: true` 
 *(not recommended)*.
 
 
 ### Security settings
 
-**Disable request tokens:** Here you can activate that the request tokens are not checked when submitting a form
+**Disable request tokens:** Here you can activate that the request tokens are not checked when submitting a form 
 *(insecure!)*.
 
-**Allowed HTML tags:** By default, Contao does not allow HTML tags in forms and removes them automatically when saving.
+**Allowed HTML tags:** By default, Contao does not allow HTML tags in forms and removes them automatically when saving. 
 For input fields where the use of HTML is desired, you can specify a list of allowed HTML tags here.
 
-{{< version-tag "4.11.7, 4.9.18 and 4.4.56" >}} **Allowed HTML attributes:** You can extend the list of allowed HTML attributes for input fields here. If an HTML
+{{< version-tag "4.11.7, 4.9.18 and 4.4.56" >}} **Allowed HTML attributes:** You can extend the list of allowed HTML attributes for input fields here. If an HTML 
 attribute is not present in the list, it will be automatically removed when saving. The tag or attribute name * stands for
 all tags or attributes. For attributes with hyphens, placeholders such as data-* can be used.
 
-**Password hash:** By default, Contao uses the defaut of the current PHP version, but you can also set a value. This
+**Password hash:** By default, Contao uses the defaut of the current PHP version, but you can also set a value. This 
 is necessary if you want to sync the password to another system like LDAP.
 
 The following configuration defines some example values:
@@ -134,16 +134,16 @@ security:
 ```
 
 
-**Examples:**
+**Examples:**  
 `<iframe>` is not present in the allowed HTML tags, but can easily be inserted under key.
 
-{{% notice note %}}
+{{% notice note %}}  
 In order to better recognise the HTML tags added by the user, these should be entered at the beginning of the list.
-{{% /notice %}}
+{{% /notice %}}  
 
-In the permitted HTML attributes, the attribute must then also be inserted as a value for this.
+In the permitted HTML attributes, the attribute must then also be inserted as a value for this.    
 
-`<nav>` and `<input>` are, for example, already present in the permitted HTML tags and can thus be easily extended with permitted attributes.
+`<nav>` and `<input>` are, for example, already present in the permitted HTML tags and can thus be easily extended with permitted attributes. 
 Enter `nav` or `input` as the key and the desired value as the value - in our example `role` or `type`.
 
 If you trust all backend users 100%, you can also enter `*` as the key and `*` as the value. This will allow all attributes for all elements.
@@ -166,28 +166,28 @@ process library. Any image exceeding this value will not be processed.
 
 **Upload file types:** Here you can define which file types can be uploaded to your server.
 
-**Maximum upload file size:** Here you can define the maximum size of a file that can be uploaded to your server using
+**Maximum upload file size:** Here you can define the maximum size of a file that can be uploaded to your server using 
 the file manager. The entry is in bytes (1 MiB = 1024 KiB = 1,048,576 bytes). Larger files will be rejected.
 
-**Maximum image width:** When uploading images, the file manager automatically checks the width of the image and
+**Maximum image width:** When uploading images, the file manager automatically checks the width of the image and 
 compares it with the width you set here. If an image exceeds the maximum width, it will be reduced automatically.
 
-**Maximum image height:** When uploading images, the file manager automatically checks their height and compares it with
+**Maximum image height:** When uploading images, the file manager automatically checks their height and compares it with 
 your default value. If an image exceeds the maximum height, it will be resized automatically.
 
 
 ### Search engine settings
 
-**Enable searching:** If you select this option, Contao indexes the finished pages of your website and creates a search
-index from them. With the frontend module
-"[search engine](/en/layout/module-management/website-search/#configuration-of-the-search-module)", you can search this
+**Enable searching:** If you select this option, Contao indexes the finished pages of your website and creates a search 
+index from them. With the frontend module 
+"[search engine](/en/layout/module-management/website-search/#configuration-of-the-search-module)", you can search this 
 index.
 
-**Index protected pages:** Select this option to index protected pages for your search. Use this feature with care and
+**Index protected pages:** Select this option to index protected pages for your search. Use this feature with care and 
 make sure to exclude personalized pages from the search.
 
 {{% notice note %}}
-Starting with version **4.9** a new search indexer is used. The settings **Enable searching** and
+Starting with version **4.9** a new search indexer is used. The settings **Enable searching** and 
 **Index protected pages** are now configured via the `config/config.yaml`.
 
 ```yaml
@@ -202,7 +202,7 @@ contao:
 
 ### Cron job settings
 
-**Deactivate the command scheduler:** Here you can disable the Periodic Command Scheduler and run the route
+**Deactivate the command scheduler:** Here you can disable the Periodic Command Scheduler and run the route 
 `_contao/cron` using a real cron job (which you have to set up yourself). Starting with Contao **4.9** you can also
 use the following command:
 
@@ -213,20 +213,20 @@ php vendor/bin/contao-console contao:cron
 
 ### Default access rights
 
-**Default page owner:** Here you can specify the default owner of the pages for which no access rights have been
+**Default page owner:** Here you can specify the default owner of the pages for which no access rights have been 
 defined. For more information, see the Access Rights section.
 
-**Default page group**: Here you can define to which group the pages for which no access rights are defined belong by
+**Default page group**: Here you can define to which group the pages for which no access rights are defined belong by 
 default. For more information, see the Access Rights section.
 
-**Default access rights:** Here you can set the default access rights for the pages for which no special access rights
+**Default access rights:** Here you can set the default access rights for the pages for which no special access rights 
 are defined. For more information, see the Access Rights section.
 
 
 ## parameters.yaml
 
-In the Contao Managed Edition, the parameters (e.g. database credentials) are stored in the `parameters.yaml` file that
-is generated by the Contao installation tool. This file is usually excluded from the versioning process and can also
+In the Contao Managed Edition, the parameters (e.g. database credentials) are stored in the `parameters.yaml` file that 
+is generated by the Contao installation tool. This file is usually excluded from the versioning process and can also 
 contain additional entries such as the credentials for sending e-mails via SMTP.
 
 The file `parameters.yaml` is located in the folder `config/` and is created automatically when you install Contao.
@@ -252,11 +252,11 @@ parameters:
 
 ## config.yaml
 
-The bundle configuration belongs in the `config.yaml` and is located in the folder `config/`. If the file does not
-exist yet, it must be created. Contao automatically loads the `config_prod.yaml` or `config_dev.yaml` and if not available
+The bundle configuration belongs in the `config.yaml` and is located in the folder `config/`. If the file does not 
+exist yet, it must be created. Contao automatically loads the `config_prod.yaml` or `config_dev.yaml` and if not available 
 the `config.yaml`.
 
-This allows you to realize different configurations for your test or production environment (dev/prod) (e.g. more
+This allows you to realize different configurations for your test or production environment (dev/prod) (e.g. more 
 logging in debug mode). In addition, you can commit the `config.yaml` configuration files to your repository, if your
 project is versioned via Git for example.
 
@@ -948,16 +948,16 @@ contao:
 ### localconfig
 
 As mentioned in the config reference above the configuration key `contao.localconfig` allows you to set any configuration
-that is defined via `$GLOBALS['TL_CONFIG']`, the default values of which can be overwritten via the
+that is defined via `$GLOBALS['TL_CONFIG']`, the default values of which can be overwritten via the 
 `system/config/localconfig.php`. This is where Contao stores any settings that have been customised in the back end, i.e.
 under _System_ » _Settings_. This form of storing settings is being phased out step by step. Some of the settings now
 have a counterpart in the bundle configuration, others are e.g. set in the website root or within the back end user's
-settings.
+settings. 
 
-However depending on the Contao version you are using there are still settings being used from the localconfig. Thus it
-can be useful to define them directly in your applications configuration (i.e. the `config.yaml`) rather than the legacy
-`localconfig.php`. Not only because you might need it for your deployment flow, but also because some settings can _only_
-be set manually - because they neither have a bundle configuration counterpart, nor is there another mean of setting them
+However depending on the Contao version you are using there are still settings being used from the localconfig. Thus it 
+can be useful to define them directly in your applications configuration (i.e. the `config.yaml`) rather than the legacy 
+`localconfig.php`. Not only because you might need it for your deployment flow, but also because some settings can _only_ 
+be set manually - because they neither have a bundle configuration counterpart, nor is there another mean of setting them 
 via the back end.
 
 The following example defines the administrator's e-mail address via an environment variable and increases the undo period
@@ -1023,7 +1023,7 @@ Environment variables are variables that can be defined at the operating system 
 The variables are defined in the file `.env` and this file must be located in the root directory of the Contao installation. The usage and name of the following variables are predefined. However, you can also define arbitrary variables and then reference them e.g. in the `config.yaml`. If an additional `.env.local` file exists in the same directory, it will be used automatically.
 
 {{% notice info %}}
-Some of the environment variables, like `APP_SECRET`, `DATABASE_URL` and `MAILER_DSN` replace their respective counterparts
+Some of the environment variables, like `APP_SECRET`, `DATABASE_URL` and `MAILER_DSN` replace their respective counterparts 
 of the `config/parameters.yaml` and thus you should not use these parameters, if you are using the environment variable instead.
 {{% /notice %}}
 
@@ -1052,23 +1052,23 @@ in the `prod` mode, optimizing everything for production. If you want to put you
 mode to have additional logging and debugging output, set `APP_ENV` to `dev`. Never do this for production sites!
 If you set the environment manually, you will no longer be able to toggle the debug mode from the back end as a
 Contao administrator.
-
+    
 
 ### `APP_SECRET`
 
-The `APP_SECRET` environment variable is required e.g. to generate CSRF tokens. This is a string that should be
-unique to your application and it's commonly used to add more entropy to security related operations. Its value
-should be a series of characters, numbers and symbols chosen randomly and the recommended length is around
+The `APP_SECRET` environment variable is required e.g. to generate CSRF tokens. This is a string that should be 
+unique to your application and it's commonly used to add more entropy to security related operations. Its value 
+should be a series of characters, numbers and symbols chosen randomly and the recommended length is around 
 32 characters. As with any other security-related parameter, it is a good practice to change this value from time
-to time. However, keep in mind that changing this value will invalidate all signed URIs and Remember Me cookies.
+to time. However, keep in mind that changing this value will invalidate all signed URIs and Remember Me cookies. 
 That is why, after changing this value, you should regenerate the application cache and log out all the application
 users. For more information please visit the [Symfony documentation](https://symfony.com/doc/current/reference/configuration/framework.html#secret).
 
 
 ### `DATABASE_URL`
 
-The database connection information is stored as an environment variable called `DATABASE_URL`. It defines
-the database user name, database password, host name, port and database name that will be used by your Contao system.
+The database connection information is stored as an environment variable called `DATABASE_URL`. It defines 
+the database user name, database password, host name, port and database name that will be used by your Contao system. 
 The format of this variable is the following: `DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name"`.
 
 It is used by default for the [Doctrine configuration][DoctrineConfig]: `doctrine.dbal.url: '%env(DATABASE_URL)%'`.
@@ -1122,7 +1122,7 @@ The following tool runs in your browser and helps you to convert the variables o
 ### `MAILER_DSN`
 
 The mailer connection information is stored as an environment variable called `MAILER_DSN`. It defines the transport to
-be used for sending emails, as well as the login credentials, host name and port for an SMTP server for example, if
+be used for sending emails, as well as the login credentials, host name and port for an SMTP server for example, if 
 applicable. The format of this variable is the following: `MAILER_DSN=smtp://username:password@smtp.example.com:465?encryption=ssl`.
 See the [Symfony Mailer Documentation][SymfonyMailer] for more information.
 
@@ -1194,13 +1194,13 @@ cookies of extensions you installed:
 ```
 COOKIE_ALLOW_LIST=PHPSESSID,csrf_https-contao_csrf_token,csrf_contao_csrf_token,trusted_device,REMEMBERME
 ```
-
+    
 {{% notice note %}}
 The name of the PHP session cookie is configurable through the `php.ini` so you might want to check if it's `PHPSESSID`
 for you too. Moreover, the CSRF cookie is different for `http` and `https` for security reasons. If you serve your
 website over `http`, note that the cookie name will be `csrf_http-contao_csrf_token`.
 However, protecting your users from CSRF attacks but let them submit the form via unsecured `http` connections is
-not really a valid use case.
+not really a valid use case. 
 {{% /notice %}}
 
 ### `COOKIE_REMOVE_FROM_DENY_LIST`
@@ -1244,7 +1244,7 @@ QUERY_PARAMS_REMOVE_FROM_DENY_LIST=fbclid
 If you do so, make sure to disable caching by e.g. setting `Cache-Control: no-store` on this response if `fbclid` is
 present as otherwise you are back to having thousands of cache entries in your cache proxy.
 {{% /notice %}}
-
+    
 
 ### `TRUSTED_PROXIES`
 
@@ -1255,10 +1255,10 @@ For example, instead of reading the `REMOTE_ADDR` header (which will now be the 
 the user's true IP will be stored in a standard `Forwarded: for="…"` header or a `X-Forwarded-For` header.
 If you don't configure the Managed Edition to look for these headers, you'll get incorrect information about the
 client's IP address, whether or not the client is connecting via HTTPS, the client's port and the hostname being
-requested. Let's say your load balancer runs on IP `192.0.2.1`. You can trust that IP by setting `TRUSTED_PROXIES`
+requested. Let's say your load balancer runs on IP `192.0.2.1`. You can trust that IP by setting `TRUSTED_PROXIES` 
 to `192.0.2.1`. You can also trust a whole IP range if you like to: `TRUSTED_PROXIES=192.0.2.0/24`. See the
 [Symfony Documentation on Proxies][SymfonyProxies] for more information.
-
+    
 
 ### `TRUSTED_HOSTS`
 
@@ -1294,7 +1294,7 @@ DNS_MAPPING='{
 }'
 ```
 
-This allows you to - for example - copy the live database to your staging or local environment and then automatically
+This allows you to - for example - copy the live database to your staging or local environment and then automatically 
 change the domains according to the mapping in the respective environment during `contao:migrate`.
 
 You can also migrate the protocol setting to different settings in the respective environment, which might be
@@ -1326,7 +1326,7 @@ DNS_MAPPING='{
 }'
 ```
 
-Instead of the environment variable, you can also directly set the `contao.dns_mapping` parameter in your
+Instead of the environment variable, you can also directly set the `contao.dns_mapping` parameter in your 
 `parameters.yaml`, if you prefer:
 
 ```yaml
@@ -1357,7 +1357,7 @@ e.g. via the `.env.local` of your Contao instance.
 {{% tab name=".env.local" %}}
 {{< version-tag "4.9" >}} You can define the SMTP server via the [`.env.local`](https://symfony.com/doc/current/configuration.html#overriding-environment-values-via-env-local)
 of your Contao instance (note that the `.env` file must also exist in order for the `.env.local` to take effect). In Contao **4.9** you need
-to use the `MAILER_URL` environment variable, while in Contao **4.10** and up the [`MAILER_DSN`](#mailer-dsn) variable can be used. In
+to use the `MAILER_URL` environment variable, while in Contao **4.10** and up the [`MAILER_DSN`](#mailer-dsn) variable can be used. In 
 Contao **5.0** and up only the `MAILER_DSN` environment variable will work.
 
 ```ini
@@ -1429,26 +1429,26 @@ You can also omit the parameters. The command will then ask you for each paramet
 
 {{< version "4.10" >}}
 
-In many cases, SMTP servers do not allow sending from any sender address. Oftentimes the sender address must match
-the SMTP server credentials. Especially in multi-domain installations of Contao it might be important that the
+In many cases, SMTP servers do not allow sending from any sender address. Oftentimes the sender address must match 
+the SMTP server credentials. Especially in multi-domain installations of Contao it might be important that the 
 sender address of the emails that Contao sends matches the domain. Or you might want to have different sender
 addresses for different front end forms created via the Contao form generator.
 
-Since Contao **4.10**, it is possible to use multiple email configurations in Contao. These configurations can be
-selected per website root, per form and per newsletter channel. For each e-mail configuration, you can also set the
+Since Contao **4.10**, it is possible to use multiple email configurations in Contao. These configurations can be 
+selected per website root, per form and per newsletter channel. For each e-mail configuration, you can also set the 
 sender that will be used for each e-mail sent by the selected e-mail configuration.
 
-The configuration requires two steps. First, the available e-mail sending methods have to be set in the Symfony
+The configuration requires two steps. First, the available e-mail sending methods have to be set in the Symfony 
 framework configuration in the `config.yaml` so-called. One or more SMTP servers can be defined using the so-called "DSN" syntax:
 
 ```
 smtp://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>
 ```
 
-Replace the `<PLACEHOLDER>` with the information of the SMTP server used, or remove them accordingly. See also the
+Replace the `<PLACEHOLDER>` with the information of the SMTP server used, or remove them accordingly. See also the 
 information in the official [Symfony documentation][SymfonyMailer].
 
-You can use this [Tool](#convert-your-mail-parameters) to encode your parameters.
+You can use this [Tool](#convert-your-mail-parameters) to encode your parameters. 
 
 {{% notice warning %}}
 If your username or password contains special characters, they need to be "url encoded". There are several online
@@ -1470,7 +1470,7 @@ framework:
             website2: smtps://email%%40example.de:foobar@example.de
 ```
 
-In the second step, the configured transports can be made available in the back end via the Contao framework
+In the second step, the configured transports can be made available in the back end via the Contao framework 
 configuration. In the following example, the transports `website1` and `website2` are made available:
 
 ```yaml
@@ -1482,11 +1482,11 @@ contao:
             website2: ~
 ```
 
-If the symfony application cache has been refreshed afterwards, these email configurations will be available for
+If the symfony application cache has been refreshed afterwards, these email configurations will be available for 
 selection in the Contao back end.
 
 {{% notice note %}}
-If no transport is configured, the information from the `parameters.yaml` is used. If a transport is configured but no transport
+If no transport is configured, the information from the `parameters.yaml` is used. If a transport is configured but no transport 
 is selected in the Contao back end, the first defined transport is used automatically.
 {{% /notice %}}
 
@@ -1518,9 +1518,9 @@ website2: 'SMTP für Webseite 2'
 ```
 
 {{% notice warning %}}
-**Clear cache**
-In order to enable these changes, the application cache must be rebuilt using the Contao Manager ("Maintenance" &gt;
-"Rebuild Production Cache") or alternatively via the command line. To do the latter you have to execute the following in
+**Clear cache** 
+In order to enable these changes, the application cache must be rebuilt using the Contao Manager ("Maintenance" &gt; 
+"Rebuild Production Cache") or alternatively via the command line. To do the latter you have to execute the following in 
 the Contao installation directory:
 
 ```bash
@@ -1532,7 +1532,7 @@ php vendor/bin/contao-console cache:warmup --env=prod
 
 ### Send Emails Asynchronously
 
-Instead of letting Contao send emails immediately when a request is processed (e.g. when a form was submitted) the email can be sent
+Instead of letting Contao send emails immediately when a request is processed (e.g. when a form was submitted) the email can be sent 
 asynchronously by the server later. There are several reasons why this can be important:
 
 * It reduces the server response time of such requests (in some cases sending via a defined SMTP server can take several seconds).
@@ -1587,7 +1587,7 @@ composer require symfony/messenger
 ```
 
 Now we can define a Messenger transport and routing for email messages. First we need to decide on the type of Messenger transport though.
-The component already provides different [transport types][SymfonyMessengerTransports]. In this case the
+The component already provides different [transport types][SymfonyMessengerTransports]. In this case the 
 [Doctrine transport][SymfonyMessengerDoctrine] is a good fit since it will save our emails in the database first for later consumption.
 In order to enable asynchronous emails via Symfony Mailer [the following needs to be configured][SymfonyMailerMessenger]:
 
@@ -1604,7 +1604,7 @@ framework:
 
 {{% notice "note" %}}
 Instead of defining the Messenger transport directly we can also use environment variables as usual, in case you want to use different
-transports in different environments (e.g. using the
+transports in different environments (e.g. using the 
 [In Memory transport](https://symfony.com/doc/current/messenger.html#in-memory-transport) locally for testing).
 
 ```yaml
@@ -1639,7 +1639,7 @@ The commands described above use the `--time-limit=1` option. By default the `me
 any new messages continuously. Therefore you would not need to run a separate cronjob. In order to make sure that this process is always
 running and is restarted on demand, different tools can be used on the server. However, in shared hosting environments such tools are
 usually not available. Thus, when using a cronjob you need to make sure that the process will only run a limited time when executed. The
-aforementioned `--time-limit=1` option will cause the process to exit after one second. You can find more details in the
+aforementioned `--time-limit=1` option will cause the process to exit after one second. You can find more details in the 
 [Symfony documentation](https://symfony.com/doc/current/messenger.html#consuming-messages-running-the-worker).
 {{% /notice %}}
 


### PR DESCRIPTION
### Description

This PR updates the configuration examples for both the dev and manual (en/de) according to
> https://github.com/contao/docs/issues/1474#issuecomment-2475781300

#### Dev @fritzmg 
c4a368d997870e5469d4c311bdf98bab6ddf4643
* added missing `contao.messenger.web_worker`
* added missing `contao.imagine_options.resampling-filter`
* updated description for the badge title

#### Manual @netzarbeiter 
02eee3df630b377a6411a5c8d656809d74991041 0168b9303fb6b9147cddf8e5b62b25527ebeb636
* all of the above
* Updated tab position of `Contao 4 | Contao 5` to `Contao 5 | Contao 4` in `/de` to match `/en` and `/dev`