### PR TITLE
Use `@RC` for Release Candidates

### DIFF
--- a/docs/manual/guides/install-test-versions.de.md
+++ b/docs/manual/guides/install-test-versions.de.md
@@ -56,7 +56,7 @@ nicht beachten.
 
 Um die Installation von Release Candidates zu erlauben, muss die `minimum-stability` auf `RC` runter gesetzt werden.
 Alternativ kann man über sogenannte [stability-flags][ComposerStabilityContraints] direkt bei einzelnen Paketen
-niedrigere Stabilitäten erlauben, z.B. mit `"contao/manager-bundle": "5.5.*@RC"` in diesem Fall. In diesem Fall muss man
+niedrigere Stabilitäten erlauben, z. B. mit `"contao/manager-bundle": "5.5.*@RC"` in diesem Fall. In diesem Fall muss man
 allerdings auch zusätzlich das `contao/core-bundle` in die `composer.json` mit aufnehmen, um auch dediziert die
 niedrigere Stabilität bei diesem Paket zu erlauben.
 

--- a/docs/manual/guides/install-test-versions.de.md
+++ b/docs/manual/guides/install-test-versions.de.md
@@ -54,23 +54,11 @@ Der erste Release Candidate von Contao `5.5` heißt z. B. `5.5.0-RC1`. Normalerw
 würde Composer nur _stabile_ Versionen installieren und daher solche Release Candidates
 nicht beachten.
 
-Um die Installation von Release Candidates zu erlauben, muss die `minimum-stability`
-auf `RC` in der `composer.json` runter gesetzt werden. Außerdem sollte man Composer
-anweisen, dass bei jedem Paket _stabile_ Versionen bevorzugt werden, damit auch die
-offiziell veröffentlichten Versionen von Contao automatisch installiert werden, sobald
-diese verfügbar sind. Schließlich muss noch die angeforderte Version von Contao selbst,
-also genau genommen des `contao/manager-bundle` auf `5.5.*` geändert werden, so wie bei
-jedem Update auf eine neuere Contao Version.
-
-```json
-{
-    "require": {
-        "contao/manager-bundle": "5.5.*"
-    },
-    "minimum-stability": "RC",
-    "prefer-stable": true
-}
-```
+Um die Installation von Release Candidates zu erlauben, muss die `minimum-stability` auf `RC` runter gesetzt werden.
+Alternativ kann man über sogenannte [stability-flags][ComposerStabilityContraints] direkt bei einzelnen Paketen
+niedrigere Stabilitäten erlauben, z.B. mit `"contao/manager-bundle": "5.5.*@RC"` in diesem Fall. In diesem Fall muss man
+allerdings auch zusätzlich das `contao/core-bundle` in die `composer.json` mit aufnehmen, um auch dediziert die
+niedrigere Stabilität bei diesem Paket zu erlauben.
 
 Hier ist ein komplettes Beispiel, um die neueste Contao `5.5` Version installieren
 zu lassen, _inklusive_ den neuesten Release Candidates (wenn vorhanden):
@@ -82,18 +70,16 @@ zu lassen, _inklusive_ den neuesten Release Candidates (wenn vorhanden):
     "license": "LGPL-3.0-or-later",
     "type": "project",
     "require": {
-        "contao/calendar-bundle": "^5.5",
-        "contao/comments-bundle": "^5.5",
+        "contao/calendar-bundle": "^5.5@RC",
+        "contao/comments-bundle": "^5.5@RC",
         "contao/conflicts": "@dev",
-        "contao/core-bundle": "^5.5",
-        "contao/faq-bundle": "^5.5",
-        "contao/listing-bundle": "^5.5",
-        "contao/manager-bundle": "5.5.*",
-        "contao/news-bundle": "^5.5",
-        "contao/newsletter-bundle": "^5.5"
+        "contao/core-bundle": "^5.5@RC",
+        "contao/faq-bundle": "^5.5@RC",
+        "contao/listing-bundle": "^5.5@RC",
+        "contao/manager-bundle": "5.5.*@RC",
+        "contao/news-bundle": "^5.5@RC",
+        "contao/newsletter-bundle": "^5.5@RC"
     },
-    "minimum-stability": "RC",
-    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
@@ -184,12 +170,10 @@ Version wird, sieht so aus:
 }
 ```
 
-Zu beachten ist hier, dass diesmal auch das `contao/core-bundle` und das `contao/installation-bundle`
-angefordert wird, welches normalerweise nicht in der `composer.json` des eigenen
-Contao Projekts eingetragen wird. Das ist notwendig, weil Entwicklerversionen der
-Pakete installiert werden sollen, ohne die `minimum-stability` auf `dev` zu senken
-(das würde andernfalls die Berechnungszeit und Speicherauslastung während einer
-Update-Operation drastisch erhöhen).
+Zu beachten ist hier, dass auch diesmal das `contao/core-bundle` Paket angefordert wird, welches normalerweise nicht in
+der `composer.json` des eigenen Contao Projekts eingetragen wird. Das ist notwendig, weil Entwicklerversionen der Pakete
+installiert werden sollen, ohne die `minimum-stability` auf `dev` zu senken (das würde andernfalls die Berechnungszeit
+und Speicherauslastung während einer Update-Operation drastisch erhöhen).
 
 Jedes mal, wenn eine Paketaktualisierung durchgeführt wird, wird der neueste Programmcode
 aus diesem Branch des öffentlichen Git Repositorys von Contao geholt.
@@ -224,3 +208,4 @@ Videoanleitung: [Contao 4 – Testversion | Entwicklerversion | Release Candidat
 
 
 [releasePlan]: https://to.contao.org/release-plan
+[ComposerStabilityContraints]: https://getcomposer.org/doc/articles/versions.md#stability-constraints

--- a/docs/manual/guides/install-test-versions.en.md
+++ b/docs/manual/guides/install-test-versions.en.md
@@ -49,21 +49,11 @@ Release candidates use a specific release version tag. For example the first rel
 candidate of Contao `5.5` will have a release tag called `5.5.0-RC1`. Usually Composer
 will only install _stable_ versions by default and thus skip any such release candidates.
 
-To allow the installation of release candidates, the `minimum-stability` needs to
-be lowered to `RC` in the `composer.json`. Additionally, we instruct Composer to
-always prefer _stable_ versions of each package, so that a stable release of Contao
-`5.5` gets installed, once available. Finally, the requested Contao, i.e. the `contao/manager-bundle` 
-needs to be changed to `5.5.*`, as with any minor version update.
-
-```json
-{
-    "require": {
-        "contao/manager-bundle": "5.5.*"
-    },
-    "minimum-stability": "RC",
-    "prefer-stable": true
-}
-```
+To allow the installation of release candidates, the `minimum-stability` needs to be lowered to `RC` in the
+`composer.json`. Alternatively you can also use [stability-flags][ComposerStabilityContraints] for each package in order
+to allow them to be installed in lower stabilities, e.g. `"contao/manager-bundle": "5.5.*@RC". In this case you will
+also have to add the `contao/core-bundle` package to your project's `composer.json` in order to allow the lower
+stability for this package as well.
 
 Here is a full example for installing the latest Contao `5.5` version, _including_
 its latest release candidates (if there are any):
@@ -75,18 +65,16 @@ its latest release candidates (if there are any):
     "license": "LGPL-3.0-or-later",
     "type": "project",
     "require": {
-        "contao/calendar-bundle": "^5.5",
-        "contao/comments-bundle": "^5.5",
+        "contao/calendar-bundle": "^5.5@RC",
+        "contao/comments-bundle": "^5.5@RC",
         "contao/conflicts": "@dev",
-        "contao/core-bundle": "^5.5",
-        "contao/faq-bundle": "^5.5",
-        "contao/listing-bundle": "^5.5",
-        "contao/manager-bundle": "5.5.*",
-        "contao/news-bundle": "^5.5",
-        "contao/newsletter-bundle": "^5.5"
+        "contao/core-bundle": "^5.5@RC",
+        "contao/faq-bundle": "^5.5@RC",
+        "contao/listing-bundle": "^5.5@RC",
+        "contao/manager-bundle": "5.5.*@RC",
+        "contao/news-bundle": "^5.5@RC",
+        "contao/newsletter-bundle": "^5.5@RC"
     },
-    "minimum-stability": "RC",
-    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
@@ -175,12 +163,10 @@ next version:
 }
 ```
 
-Note that in this case we also need to require the `contao/core-bundle` and the
-`contao/installation-bundle`, which we would usually not include in the project's
-`composer.json`. This is necessary, since we want to tell Composer to specifically
-install a development version, without lowering the `minimum-stability` to `dev`
-(wich would drastically increase computation time and memory consumption during
-a composer update).
+Note that in this case we also need to require the `contao/core-bundle` and the `contao/installation-bundle`, which we
+would usually not include in the project's `composer.json`. This is necessary, since we want to tell Composer to
+specifically install a development version, without lowering the `minimum-stability` to `dev` (wich would drastically
+increase computation time and memory consumption during a composer update).
 
 Each time the packages are updated, the most recent code for this branch will be 
 pulled from Contao's public Git repository.
@@ -212,3 +198,4 @@ package update process to finish.
 
 
 [releasePlan]: https://contao.org/en/release-plan.html
+[ComposerStabilityContraints]: https://getcomposer.org/doc/articles/versions.md#stability-constraints


### PR DESCRIPTION
Instead of lowering the `minimum-stability` I think it's better to always use the `@RC` stability-flag instead.