### PR TITLE
[5.5] Document showing the operations in the overview

### DIFF
--- a/docs/dev/reference/dca/list.md
+++ b/docs/dev/reference/dca/list.md
@@ -167,7 +167,8 @@ $GLOBALS['TL_DCA']['tl_example']['list']['operations'] = [
 {{% notice "note" %}}
 {{< version-tag "5.5" >}}
 All operations are now shown within the context-menu. If you want them to appear in the overview, you can enable them by
-prepending your key with `!` as seen in the example.
+prepending your key with `!` as seen in the example. Note that the operations `edit`, `children` and `toggle` will always appear in
+the overview regardless.
 
 ```php
 

--- a/docs/dev/reference/dca/list.md
+++ b/docs/dev/reference/dca/list.md
@@ -164,6 +164,24 @@ $GLOBALS['TL_DCA']['tl_example']['list']['operations'] = [
 ```
 {{% /notice %}}
 
+{{% notice "note" %}}
+{{< version-tag "5.5" >}}
+All operations are now shown within the context-menu. If you want them to appear in the overview, you can enable them by
+prepending your key with `!` as seen in the example.
+
+```php
+
+$GLOBALS['TL_DCA']['tl_example']['list']['operations'] = [
+    '!edit',
+    '!children',
+    'copy',
+    'cut',
+    'delete',
+    'toggle',
+    'show'
+];
+```
+{{% /notice %}}
 
 #### Toggle Operation
 


### PR DESCRIPTION
### Description

With Contao 5.5 around the corner, if you are adding the operations with keys, the default operations will not show within the overview anymore and will be hidden in the context-menu.

This PR documents how to enable those in the short syntax without using `'primary' => true `

![image](https://github.com/user-attachments/assets/a489d110-0261-4b88-9eab-3e4c0a1bfb64)

![image](https://github.com/user-attachments/assets/cc1cf1ff-d9ad-4294-a71e-cb49ac822cdd)
