### PR TITLE
Simplify BackendMenuListener example

### DIFF
--- a/docs/dev/guides/back-end-routes.md
+++ b/docs/dev/guides/back-end-routes.md
@@ -103,7 +103,6 @@ use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\MenuEvent;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
-use Symfony\Component\Routing\RouterInterface;
 
 #[AsEventListener(ContaoCoreEvents::BACKEND_MENU_BUILD, priority: -255)]
 class BackendMenuListener
@@ -111,9 +110,8 @@ class BackendMenuListener
     protected $router;
     protected $requestStack;
 
-    public function __construct(RouterInterface $router, RequestStack $requestStack)
+    public function __construct(RequestStack $requestStack)
     {
-        $this->router = $router;
         $this->requestStack = $requestStack;
     }
 
@@ -129,8 +127,7 @@ class BackendMenuListener
         $contentNode = $tree->getChild('content');
 
         $node = $factory
-            ->createItem('my-module')
-                ->setUri($this->router->generate(BackendController::class))
+            ->createItem('my-module', ['route' => BackendController::class])
                 ->setLabel('My Modules')
                 ->setLinkAttribute('title', 'Title')
                 ->setLinkAttribute('class', 'my-module')


### PR DESCRIPTION
This one is more of a suggestion than a fix, feel free to reject.

`KnpMenu` can automatically generate URI to routes, if you pass the route name in the options array as a second argument to `createItem` or `addChild` methods. This allows to slightly simplify the backend menu listener by removing `router` dependency.