### PR TITLE
Change Search Highlight

### DIFF
--- a/page/assets/css/theme-contao.css
+++ b/page/assets/css/theme-contao.css
@@ -756,6 +756,6 @@ nav.TableOfContents li a code {
 mark {
   all: unset;
   color: #fff;
-  background-color: var(--INTERNAL-PRIMARY-color);
+  background-color: var(--PRIMARY-color);
 }
 

--- a/page/assets/css/theme-contao.css
+++ b/page/assets/css/theme-contao.css
@@ -751,3 +751,11 @@ h6 code,
 nav.TableOfContents li a code {
     font-size: 92%;
 }
+
+/* Change Search Highlight Color */
+mark {
+  all: unset;
+  color: #fff;
+  background-color: var(--INTERNAL-PRIMARY-color);
+}
+


### PR DESCRIPTION
When searching, results are marked as follows (s. Screenshot).

![cto-docs-search-highlight-01](https://github.com/user-attachments/assets/41d62970-207a-4c7d-81ab-a5cb04a1d700)
![cto-docs-search-highlight-02](https://github.com/user-attachments/assets/dd216338-5b9b-45c3-b1a6-4758b17d6df7)

An alternative suggestion (color only).