### PR TITLE
Update DDEV Guide

### DIFF
--- a/docs/manual/guides/local-installation/ddev.de.md
+++ b/docs/manual/guides/local-installation/ddev.de.md
@@ -124,6 +124,8 @@ ddev launch contao-manager.phar.php
 
 ## Zusatz Informationen
 
+Weitere Informationen bez. der Verwaltung von Projekten findest du [hier](https://ddev.readthedocs.io/en/stable/users/usage/managing-projects/#listing-project-information).
+
 - `ddev start` startet das Projekt, `ddev stop` beendet es. Stelle vorher sicher, dass du in den Projektordner gewechselt hast.
 
 - `ddev poweroff` kann aus jedem Verzeichnis heraus alle gestarteten Projekte/Container stoppen.

--- a/docs/manual/guides/local-installation/ddev.de.md
+++ b/docs/manual/guides/local-installation/ddev.de.md
@@ -150,15 +150,22 @@ memory_limit = -1
 ```
 
 
-## DDEV Addons
+## Datenbank Tools
 
-DDEV bietet auch [Services als Addon](https://ddev.readthedocs.io/en/latest/users/extend/additional-services/).
+Wenn du beispielsweise einen Datenbank-Client wie `Adminer` oder `phpMyAdmin` verwenden möchtest, kannst du diese als 
+[Addon](https://ddev.readthedocs.io/en/latest/users/extend/additional-services/) installieren.
 
 
 ### Beispiel: Adminer
 
 ```shell
-ddev get ddev/ddev-adminer && ddev restart
+ddev add-on get ddev/ddev-adminer && ddev restart
 ```
 
-Mit `ddev describe` erfährst du, wie du Adminer erreichst.
+### Beispiel: phpMyAdmin
+
+```shell
+ddev add-on get ddev/ddev-phpmyadmin && ddev restart
+```
+
+Mit `ddev describe` erfährst du, wie du ds jeweilige Datenbank Tool erreichst.

--- a/docs/manual/guides/local-installation/ddev.de.md
+++ b/docs/manual/guides/local-installation/ddev.de.md
@@ -170,4 +170,4 @@ ddev add-on get ddev/ddev-adminer && ddev restart
 ddev add-on get ddev/ddev-phpmyadmin && ddev restart
 ```
 
-Mit `ddev describe` erfährst du, wie du ds jeweilige Datenbank Tool erreichst.
+Mit `ddev describe` erfährst du, wie du das jeweilige Datenbank Tool erreichst.

--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -122,6 +122,8 @@ ddev launch contao-manager.phar.php
 
 ## Additional information
 
+You can find more information about managing projects [here](https://ddev.readthedocs.io/en/stable/users/usage/managing-projects/#listing-project-information).
+
 - `ddev start` starts the project, `ddev stop` ends it. Make sure beforehand that you have changed to the project folder.
 
 - `ddev poweroff` can stop all started projects/containers from any directory.

--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -148,15 +148,22 @@ memory_limit = -1
 ```
 
 
-## DDEV Addons
+## Database Tools
 
-DDEV now offers [Services as Addon](https://ddev.readthedocs.io/en/latest/users/extend/additional-services/).
+If you want to use a database client such as `Adminer` or `phpMyAdmin` for example,, you can install these as a 
+[Addon](https://ddev.readthedocs.io/en/latest/users/extend/additional-services/).
 
 
 ### Example: Adminer
 
 ```shell
-ddev get ddev/ddev-adminer && ddev restart
+ddev add-on get ddev/ddev-adminer && ddev restart
 ```
 
-With `ddev describe` you can find out how to reach Adminer.
+### Example: phpMyAdmin
+
+```shell
+ddev add-on get ddev/ddev-phpmyadmin && ddev restart
+```
+
+With `ddev describe` you can find out how to access the respective database tool.

--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -152,7 +152,7 @@ memory_limit = -1
 
 ## Database Tools
 
-If you want to use a database client such as `Adminer` or `phpMyAdmin` for example,, you can install these as a 
+If you want to use a database client such as `Adminer` or `phpMyAdmin` for example, you can install these as a 
 [Addon](https://ddev.readthedocs.io/en/latest/users/extend/additional-services/).
 
 


### PR DESCRIPTION
Some tools (e.g. database GUI ) are no longer part of DDEV and can optionally be installed as add-ons