### PR TITLE
Add a Twig reference

### DIFF
--- a/docs/dev/framework/templates/_index.md
+++ b/docs/dev/framework/templates/_index.md
@@ -2,9 +2,8 @@
 title: "Templates"
 description: Contao's template engine.
 aliases:
-
-- /framework/templates/
-
+    - /framework/templates/
+tags: [Twig]
 ---
 
 {{% notice info %}}

--- a/docs/dev/framework/templates/architecture.md
+++ b/docs/dev/framework/templates/architecture.md
@@ -4,6 +4,7 @@ description: How the Contao Twig integration works.
 weight: 200
 aliases:
     - /framework/templates/architecture/
+tags: [Twig]
 ---
 
 Rendering a Twig template requires several things: First, the template needs to be found by a loader, that knows where

--- a/docs/dev/framework/templates/creating-templates.md
+++ b/docs/dev/framework/templates/creating-templates.md
@@ -4,6 +4,7 @@ description: Writing good templates and making use of components
 weight: 300
 aliases:
     - /framework/templates/creating-templates/
+tags: [Twig]
 ---
 
 We talked about the general [architecture]({{% ref "architecture" %}}) in the last part. Now we are focusing on what is or should

--- a/docs/dev/framework/templates/debugging.md
+++ b/docs/dev/framework/templates/debugging.md
@@ -3,9 +3,8 @@ title: "Debugging"
 description: How to resolve issues with Twig or the Contao-Twig integration and to improve your workflow.
 weight: 400
 aliases:
-
-- /framework/templates/debugging/
-
+    - /framework/templates/debugging/
+tags: [Twig]
 ---
 
 In this article, we discuss how to analyze and resolve Twig-related issues. Twig is a compiled language, that means,

--- a/docs/dev/framework/templates/getting-started.md
+++ b/docs/dev/framework/templates/getting-started.md
@@ -3,9 +3,8 @@ title: "Getting started"
 description: How to quickly get going with the most typical Twig use cases.
 weight: 100
 aliases:
-
-- /framework/templates/quick-reference/
-
+    - /framework/templates/quick-reference/
+tags: [Twig]
 ---
 
 If you are already familiar with writing Twig templates, you might want to skip this part and directly head over to the

--- a/docs/dev/framework/templates/quick-reference.md
+++ b/docs/dev/framework/templates/quick-reference.md
@@ -3,8 +3,8 @@ title: "Quick reference handbook"
 description: How to quickly get going with the most typical Twig scenarios.
 weight: 500
 aliases:
-
-- /framework/templates/quick-reference/
+    - /framework/templates/quick-reference/
+tags: [Twig]
 
 ---
 

--- a/docs/dev/reference/twig/_index.md
+++ b/docs/dev/reference/twig/_index.md
@@ -1,0 +1,31 @@
+---
+title: Twig
+description: Developer Reference for Twig functions, filters and globals.
+tags: [Twig]
+---
+
+This documents the Twig functions, filters and globals provided by Contao.
+
+## The Contao Global
+
+Contao provides its own `contao` Twig global.
+
+```twig
+{# Provides the `PageModel` of the current page #}
+{% set page = contao.page %}
+{{ contao.page.title }}
+
+{# Check in the front end whether a back end user is present in the current session #}
+{% if contao.has_backend_user %}…{% endif %}
+
+{# Check whether the "preview mode" (i.e. show hidden elements) is active #}
+{% if contao.is_preview_mode %}…{% endif %}
+
+{# Outputs a request token for forms #}
+{{ contao.request_token }}
+
+{# Gives access to the back end user in the front end, if available #}
+{% set backendUser = contao.backend_user %}
+```
+
+{{% children depth="2" %}}

--- a/docs/dev/reference/twig/filter/_index.md
+++ b/docs/dev/reference/twig/filter/_index.md
@@ -1,0 +1,8 @@
+---
+title: Twig Filters
+linkTitle: Filters
+description: Developer Reference for Twig Filters provided by Contao.
+tags: [Twig]
+---
+
+{{% children depth="1" %}}

--- a/docs/dev/reference/twig/filter/csp_inline_styles.md
+++ b/docs/dev/reference/twig/filter/csp_inline_styles.md
@@ -1,0 +1,10 @@
+---
+title: csp_inline_styles - Twig Filter
+linkTitle: csp_inline_styles
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/filter/csp_unsafe_inline_style.md
+++ b/docs/dev/reference/twig/filter/csp_unsafe_inline_style.md
@@ -1,0 +1,10 @@
+---
+title: csp_unsafe_inline_style - Twig Filter
+linkTitle: csp_unsafe_inline_style
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/filter/deserialize.md
+++ b/docs/dev/reference/twig/filter/deserialize.md
@@ -1,0 +1,22 @@
+---
+title: deserialize - Twig Filter
+linkTitle: deserialize
+description: Unserializes data from a serialized string.
+tags: [Twig]
+---
+
+{{< version "5.3.8" >}}
+
+The `deserialize` filter unserializes a string that contains serialized data into an array.
+
+{{% notice "info" %}}
+Internally, this filter uses the `Contao\StringUtil::deserialize()` method.
+{{% /notice %}}
+
+```twig
+{# data will be a ["Foo", "Bar"] array #}
+{% set data = 'a:2:{i:0;s:3:"Foo";i:1;s:3:"Bar";}'|deserialize %}
+
+{# outputs the content of "foo" from the serialized array in "bar" #}
+{{ (bar|deserialize).foo }}
+```

--- a/docs/dev/reference/twig/filter/e.md
+++ b/docs/dev/reference/twig/filter/e.md
@@ -1,0 +1,10 @@
+---
+title: e - Twig Filter
+linkTitle: e
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/filter/encode_email.md
+++ b/docs/dev/reference/twig/filter/encode_email.md
@@ -1,0 +1,10 @@
+---
+title: encode_email - Twig Filter
+linkTitle: encode_email
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/filter/escape.md
+++ b/docs/dev/reference/twig/filter/escape.md
@@ -1,0 +1,10 @@
+---
+title: escape - Twig Filter
+linkTitle: escape
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/filter/format_bytes.md
+++ b/docs/dev/reference/twig/filter/format_bytes.md
@@ -1,0 +1,10 @@
+---
+title: format_bytes - Twig Filter
+linkTitle: format_bytes
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/filter/highlight.md
+++ b/docs/dev/reference/twig/filter/highlight.md
@@ -1,0 +1,10 @@
+---
+title: highlight - Twig Filter
+linkTitle: highlight
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/filter/highlight_auto.md
+++ b/docs/dev/reference/twig/filter/highlight_auto.md
@@ -1,0 +1,10 @@
+---
+title: highlight_auto - Twig Filter
+linkTitle: highlight_auto
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/filter/insert_tag.md
+++ b/docs/dev/reference/twig/filter/insert_tag.md
@@ -1,0 +1,10 @@
+---
+title: insert_tag - Twig Filter
+linkTitle: insert_tag
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/filter/insert_tag_raw.md
+++ b/docs/dev/reference/twig/filter/insert_tag_raw.md
@@ -1,0 +1,10 @@
+---
+title: insert_tag_raw - Twig Filter
+linkTitle: insert_tag_raw
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/filter/sanitize_html.md
+++ b/docs/dev/reference/twig/filter/sanitize_html.md
@@ -1,0 +1,10 @@
+---
+title: sanitize_html - Twig Filter
+linkTitle: sanitize_html
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/_index.md
+++ b/docs/dev/reference/twig/function/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Twig Functions"
+linkTitle: "Functions"
+description: Developer Reference for Twig Functions provided by Contao.
+tags: [Twig]
+---
+
+{{% children depth="1" %}}

--- a/docs/dev/reference/twig/function/add_schema_org.md
+++ b/docs/dev/reference/twig/function/add_schema_org.md
@@ -1,0 +1,10 @@
+---
+title: add_schema_org - Twig Function
+linkTitle: add_schema_org
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/attrs.md
+++ b/docs/dev/reference/twig/function/attrs.md
@@ -1,0 +1,10 @@
+---
+title: attrs - Twig Function
+linkTitle: attrs
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/backend_icon.md
+++ b/docs/dev/reference/twig/function/backend_icon.md
@@ -1,0 +1,10 @@
+---
+title: backend_icon - Twig Function
+linkTitle: backend_icon
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/contao_figure.md
+++ b/docs/dev/reference/twig/function/contao_figure.md
@@ -1,0 +1,10 @@
+---
+title: contao_figure - Twig Function
+linkTitle: contao_figure
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/contao_section.md
+++ b/docs/dev/reference/twig/function/contao_section.md
@@ -1,0 +1,10 @@
+---
+title: contao_section - Twig Function
+linkTitle: contao_section
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/contao_sections.md
+++ b/docs/dev/reference/twig/function/contao_sections.md
@@ -1,0 +1,10 @@
+---
+title: contao_sections - Twig Function
+linkTitle: contao_sections
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/content_element.md
+++ b/docs/dev/reference/twig/function/content_element.md
@@ -1,0 +1,54 @@
+---
+title: content_element - Twig Function
+linkTitle: content_element
+description: Renders a content element either by its ID - or by on-the-fly.
+tags: [Twig]
+---
+
+{{< version "5.2" >}}
+
+The [`content_element` function]({{% ref "creating-templates#render-content-elements" %}}) renders a content element.
+
+To render a content element that already exists in the database (similar to the `{{insert_content::*}}` insert tag) you
+can pass its ID:
+
+```twig
+{# Renders the content element ID 8472 #}
+{{ content_element(8472) }}
+```
+
+You can also override the data for an existing content element:
+
+```twig
+{# Renders the content element ID 5618 and overrides its `perRow` setting #}
+{{ 
+    content_element(5618, {
+        perRow: 4
+    }) 
+}}
+```
+
+You can also render a content element on the fly by passing the type of the content element and the configuration:
+
+```twig
+{# Renders a `text` content element with the passed data #}
+{{
+    content_element('text', {
+        text: '<p>Hello World!</p>'
+    })
+}}
+```
+
+You can also pass an existing fragment reference. This is used in the `element_group` content element for example.
+
+```twig
+{# Renders the content element according to the passed `FragmentReference` #}
+{{ content_element(fragment_reference) }}
+```
+
+## Arguments
+
+* `typeOrId`: Either the type of a content element, the database ID of an existing content element or a fragment
+  reference.
+* `data`: The data for the content element to be rendered. You can also use this to overwrite the configuration of an 
+  existing content element.

--- a/docs/dev/reference/twig/function/content_url.md
+++ b/docs/dev/reference/twig/function/content_url.md
@@ -1,0 +1,10 @@
+---
+title: content_url - Twig Function
+linkTitle: content_url
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/csp_hash.md
+++ b/docs/dev/reference/twig/function/csp_hash.md
@@ -1,0 +1,10 @@
+---
+title: csp_hash - Twig Function
+linkTitle: csp_hash
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/csp_nonce.md
+++ b/docs/dev/reference/twig/function/csp_nonce.md
@@ -1,0 +1,10 @@
+---
+title: csp_nonce - Twig Function
+linkTitle: csp_nonce
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/csp_source.md
+++ b/docs/dev/reference/twig/function/csp_source.md
@@ -1,0 +1,10 @@
+---
+title: csp_source - Twig Function
+linkTitle: csp_source
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/figure.md
+++ b/docs/dev/reference/twig/function/figure.md
@@ -1,0 +1,10 @@
+---
+title: figure - Twig Function
+linkTitle: figure
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/frontend_module.md
+++ b/docs/dev/reference/twig/function/frontend_module.md
@@ -1,0 +1,10 @@
+---
+title: frontend_module - Twig Function
+linkTitle: frontend_module
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/include.md
+++ b/docs/dev/reference/twig/function/include.md
@@ -1,0 +1,10 @@
+---
+title: include - Twig Function
+linkTitle: include
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/insert_tag.md
+++ b/docs/dev/reference/twig/function/insert_tag.md
@@ -1,0 +1,10 @@
+---
+title: insert_tag - Twig Function
+linkTitle: insert_tag
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/picture_config.md
+++ b/docs/dev/reference/twig/function/picture_config.md
@@ -1,0 +1,10 @@
+---
+title: picture_config - Twig Function
+linkTitle: picture_config
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/prefix_url.md
+++ b/docs/dev/reference/twig/function/prefix_url.md
@@ -1,0 +1,10 @@
+---
+title: prefix_url - Twig Function
+linkTitle: prefix_url
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/dev/reference/twig/function/slot.md
+++ b/docs/dev/reference/twig/function/slot.md
@@ -1,0 +1,10 @@
+---
+title: slot - Twig Function
+linkTitle: slot
+description:
+tags: [Twig]
+---
+
+{{% notice "note" %}}
+This is not yet documented.
+{{% /notice %}}

--- a/docs/manual/layout/templates/twig/_index.de.md
+++ b/docs/manual/layout/templates/twig/_index.de.md
@@ -5,6 +5,7 @@ url: "layout/templates/twig"
 aliases:
   - /de/layout/templates/twig/
 weight: 10
+tags: [Twig]
 ---
 
 {{% notice note %}}

--- a/docs/manual/layout/templates/twig/_index.en.md
+++ b/docs/manual/layout/templates/twig/_index.en.md
@@ -3,6 +3,7 @@ title: "Twig templates"
 description: "Overview of Twig templates."
 url: "layout/templates/twig"
 weight: 10
+tags: [Twig]
 ---
 
 {{% notice note %}}

--- a/docs/manual/layout/templates/twig/twig-syntax.de.md
+++ b/docs/manual/layout/templates/twig/twig-syntax.de.md
@@ -5,6 +5,7 @@ url: "layout/templates/twig/syntax"
 aliases:
   - /de/layout/templates/twig/syntax
 weight: 20
+tags: [Twig]
 ---
 
 Twig-Templates haben ihre eigene Syntax. Wir stellen hier nur die wichtigsten Regeln vor, die zum Grundverständnis

--- a/docs/manual/layout/templates/twig/twig-syntax.en.md
+++ b/docs/manual/layout/templates/twig/twig-syntax.en.md
@@ -3,6 +3,7 @@ title: "Twig syntax"
 description: "Syntax of Twig."
 url: "layout/templates/twig/syntax"
 weight: 20
+tags: [Twig]
 ---
 
 Twig templates have their own syntax. We present here only the most important rules necessary for a basic understanding

--- a/docs/manual/layout/templates/twig/twig-template-data.de.md
+++ b/docs/manual/layout/templates/twig/twig-template-data.de.md
@@ -5,6 +5,7 @@ url: "layout/templates/twig/data"
 aliases:
   - /de/layout/templates/twig/data/
 weight: 50
+tags: [Twig]
 ---
 
 

--- a/docs/manual/layout/templates/twig/twig-template-data.en.md
+++ b/docs/manual/layout/templates/twig/twig-template-data.en.md
@@ -3,6 +3,7 @@ title: "Show template data"
 description: "Show all template data."
 url: "layout/templates/twig/data"
 weight: 50
+tags: [Twig]
 ---
 
 

--- a/docs/manual/layout/templates/twig/twig-template-manage.de.md
+++ b/docs/manual/layout/templates/twig/twig-template-manage.de.md
@@ -5,6 +5,7 @@ url: "layout/templates/twig/verwaltung"
 weight: 30
 aliases:
   - /de/layout/templates/twig/verwaltung/
+tags: [Twig]
 ---
 
 ## Ordnerstruktur

--- a/docs/manual/layout/templates/twig/twig-template-manage.en.md
+++ b/docs/manual/layout/templates/twig/twig-template-manage.en.md
@@ -3,6 +3,7 @@ title: "Manage templates"
 description: "The management of template files."
 url: "layout/templates/twig/manage"
 weight: 30
+tags: [Twig]
 ---
 
 ## Folder structure

--- a/docs/manual/layout/templates/twig/twig-template-reuse.de.md
+++ b/docs/manual/layout/templates/twig/twig-template-reuse.de.md
@@ -5,6 +5,7 @@ url: "layout/templates/twig/wiederverwendung"
 weight: 40
 aliases:
   - /de/layout/templates/twig/wiederverwendung/
+tags: [Twig]
 ---
 
 Contao setzt mit Twig konsequent auf das Wiederverwenden von Teilen eines Templates. Twig unterstützt viele

--- a/docs/manual/layout/templates/twig/twig-template-reuse.en.md
+++ b/docs/manual/layout/templates/twig/twig-template-reuse.en.md
@@ -3,6 +3,7 @@ title: "Reuse templates"
 description: "Reuse templates"
 url: "layout/templates/twig/reuse"
 weight: 40
+tags: [Twig]
 ---
 
 With Twig, Contao consistently focuses on the reuse of parts of a template. Twig supports many


### PR DESCRIPTION
This adds a Twig reference. Supersedes #1411 

I decided to go a different route and make every Twig filter and function its own page, just like the [Twig documentation](https://twig.symfony.com/doc/3.x/).

This PR initializes the structure and documents the `deserialize` filter and the `content_element` function, serving as a template - they are structured just like in the Twig documentation. All other functions and filters will be yet undocumented, but at least listed.

_Note:_ the user manual part of this PR only adds some tags.