### PR TITLE
Document the optional parameters for `contao:backup:create`

### DIFF
--- a/docs/manual/cli/db-backups.de.md
+++ b/docs/manual/cli/db-backups.de.md
@@ -50,7 +50,7 @@ Der Backup-Befehl erlaubt zusätzliche Argumente, die zur Konfiguration des Befe
 | `--format`        |          | Das Ausgabeformat (`txt`, `json`). Standardwert ist "txt".                                                                                                                                                                                                                                                                 |
 
 {{% notice tip %}}
-Das folgende Beispiel kann verwendet werden, um `tl_undo`, `tl_message_queue` und `tl_version` auszuschliessen und vergibt zusätzlich einen Namen für das Backup.
+Das folgende Beispiel kann verwendet werden, um `tl_undo`, `tl_message_queue` und `tl_version` auszuschließen und vergibt zusätzlich einen Namen für das Backup.
 
 ```bash
 php bin/console contao:backup:create backup__20250101000000.sql -i +tl_undo,+tl_message_queue,+tl_version

--- a/docs/manual/cli/db-backups.de.md
+++ b/docs/manual/cli/db-backups.de.md
@@ -40,6 +40,22 @@ Jedes Mal, wenn ein neues Backup erstellt wird, räumt Contao veraltete Backups 
 Abschnitt »[Konfigurationsmöglichkeiten](#konfigurationsmoeglichkeiten)«.
 {{% /notice %}}
 
+### Options
+
+Der Backup-Befehl erlaubt zusätzliche Argumente, die zur Konfiguration des Befehls verwendet werden können. Diese Argumente können auch innerhalb einer crontab verwendet werden:
+
+| Option            | Shortcut | Description                                                                                                                                                                                                                                                                                                                |
+|-------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--ignore-tables` | `-i`     | Eine kommagetrennte Liste von Datenbanktabellen, die ignoriert werden sollen. Standardmäßig wird die Backup-Konfiguration `contao.backup.ignore_tables` verwendet.<br/>Über die Präfixe "+" und "-" kann die bestehende Konfiguration angepasst werden (z.B. `+tl_user` würde `tl_user` zur bestehenden Liste hinzufügen). | |
+| `--format`        |          | Das Ausgabeformat (`txt`, `json`). Standardwert ist "txt".                                                                                                                                                                                                                                                                 |
+
+{{% notice tip %}}
+Das folgende Beispiel kann verwendet werden, um `tl_undo`, `tl_message_queue` und `tl_version` auszuschliessen und vergibt zusätzlich einen Namen für das Backup.
+```bash
+php bin/console contao:backup:create backup__20250101000000.sql -i +tl_undo,+tl_message_queue,+tl_version
+```
+{{% /notice %}}
+
 ## contao:backup:list
 
 Dieses Kommando lässt uns die bestehenden Backups anzeigen. Die Ausgabe dürfte ungefähr so aussehen:

--- a/docs/manual/cli/db-backups.de.md
+++ b/docs/manual/cli/db-backups.de.md
@@ -51,6 +51,7 @@ Der Backup-Befehl erlaubt zusätzliche Argumente, die zur Konfiguration des Befe
 
 {{% notice tip %}}
 Das folgende Beispiel kann verwendet werden, um `tl_undo`, `tl_message_queue` und `tl_version` auszuschliessen und vergibt zusätzlich einen Namen für das Backup.
+
 ```bash
 php bin/console contao:backup:create backup__20250101000000.sql -i +tl_undo,+tl_message_queue,+tl_version
 ```

--- a/docs/manual/cli/db-backups.en.md
+++ b/docs/manual/cli/db-backups.en.md
@@ -53,6 +53,7 @@ within a crontab.
 
 {{% notice tip %}}
 The following example can be used to exclude `tl_undo`, `tl_message_queue` and `tl_version` plus naming your backup.
+
 ```bash
 php bin/console contao:backup:create backup__20250101000000.sql -i +tl_undo,+tl_message_queue,+tl_version
 ```

--- a/docs/manual/cli/db-backups.en.md
+++ b/docs/manual/cli/db-backups.en.md
@@ -41,6 +41,23 @@ Every time a new backup is created, Contao automatically cleans up obsolete back
 section "[Configuration](#configuration)" for more information.
 {{% /notice %}}
 
+### Options
+
+The backup command allows additional arguments that can be used to configure it to your liking, which can also be used
+within a crontab.
+
+| Option            | Shortcut | Description                                                                                                                                                                                                                                                        |
+|-------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--ignore-tables` | `-i`     | A comma-separated list of database tables to ignore. Defaults to the backup configuration `contao.backup.ignore_tables`.<br/>You can use the prefixes "+" and "-" to modify the existing configuration (e.g. `+tl_user` would add `tl_user` to the existing list). |
+| `--format`        |          | The output format (`txt`, `json`). Defaults to `txt`.                                                                                                                                                                                                              |
+
+{{% notice tip %}}
+The following example can be used to exclude `tl_undo`, `tl_message_queue` and `tl_version` plus naming your backup.
+```bash
+php bin/console contao:backup:create backup__20250101000000.sql -i +tl_undo,+tl_message_queue,+tl_version
+```
+{{% /notice %}}
+
 ## contao:backup:list
 
 This command lets us display the existing backups. The output should look something like this:


### PR DESCRIPTION
### Description

Basically a documentation for the optional parameters `--ignore-tables` and `--format` with an example for ignoring specific tables