### PR TITLE
Document the removal of configuration options

### DIFF
--- a/docs/manual/migration/_index.de.md
+++ b/docs/manual/migration/_index.de.md
@@ -145,6 +145,18 @@ in Contao 5 nicht mehr - daher muss dies nun an den richtigen Ort übertragen we
 [Entwickler-Dokumentation][ConfigTranslations].
 
 
+#### `contao/config.yaml`
+
+In Contao 5 werden folgende Konfigurationen in der `config.yaml` nicht mehr unterstützt und müssen gelöscht werden:
+
+| Eintrag               | Ersatz                                   |
+|-----------------------|------------------------------------------|
+| contao.prepend_locale | Einstellbar im Startpunkt einer Webseite |
+| contao.url_suffix     | Einstellbar im Startpunkt einer Webseite |
+| contao.legacy_routing | -                                        |
+| contao.encryption_key | -                                        |
+
+
 ### Interne Stylesheets exportieren
 
 In Contao 5 entfällt der [interne CSS-Editor][ManageStylesheets]. Vor der Aktualisierung müssen daher die bestehenden internen Stylesheets 

--- a/docs/manual/migration/_index.en.md
+++ b/docs/manual/migration/_index.en.md
@@ -143,6 +143,18 @@ any such adjsutments will need to be moved to the correct location now. See the 
 details.
 
 
+#### `contao/config.yaml`
+
+The following configurations within the `config.yaml` have been removed in Contao 5 and need to be deleted:
+
+| Entry                 | Replacement                                       |
+|-----------------------|---------------------------------------------------|
+| contao.prepend_locale | Adjustable within the starting point of a website |
+| contao.url_suffix     | Adjustable within the starting point of a website |
+| contao.legacy_routing | -                                                 |
+| contao.encryption_key | -                                                 |
+
+
 ### Export Internal Stylesheets
 
 Contao 5 drops the [internal CSS editor][ManageStylesheets]. If you are still using such internal stylesheets you will need to 


### PR DESCRIPTION
### Description

* #1474 

Checked the `config.yaml` of 4.13 and 5.x and only saw `contao.legacy_routing` and `contao.encryption_key`.
I did however add `contao.url_suffix` and `contao.prepend_locale` as these do not exist anymore and are the usual culprits as well.