### PR TITLE
Document `contao.registration.expiration` (Contao ^5.6)

### DIFF
--- a/docs/manual/system/settings.de.md
+++ b/docs/manual/system/settings.de.md
@@ -351,6 +351,10 @@ contao:
 
     # The path to the Symfony console. Defaults to %kernel.project_dir%/bin/console.
     console_path:         '%kernel.project_dir%/bin/console'
+    registration:
+
+        # The number of days after which unconfirmed registrations expire.
+        expiration:           14
 
     # Allows to define Symfony Messenger workers (messenger:consume). Workers are started every minute using the Contao cron job framework.
     messenger:

--- a/docs/manual/system/settings.en.md
+++ b/docs/manual/system/settings.en.md
@@ -337,6 +337,10 @@ contao:
 
     # The path to the Symfony console. Defaults to %kernel.project_dir%/bin/console.
     console_path:         '%kernel.project_dir%/bin/console'
+    registration:
+
+        # The number of days after which unconfirmed registrations expire.
+        expiration:           14
 
     # Allows to define Symfony Messenger workers (messenger:consume). Workers are started every minute using the Contao cron job framework.
     messenger:


### PR DESCRIPTION
See https://github.com/contao/contao/pull/8511 for more information:

Basically the time for the expiration of the member regristration has now been prolonged from `24 hrs` to `14 days` (but it has not been documented before).

Before:
- `24 hrs till expiration` | 3 days for deleting the optin-token

Now (for member-registration)
- `contao.registration.expiration` (defaults to 14 days) | `contao.registration.expiration` (defaults to 14 days) + 2 days for the optin-token 