### PR TITLE
Use a site param for the release candidate version

### DIFF
--- a/docs/manual/guides/install-test-versions.de.md
+++ b/docs/manual/guides/install-test-versions.de.md
@@ -50,18 +50,18 @@ werden.
 ## Release Candidates installieren
 
 Release Candidates nutzen eine spezifische Form von sogenannten »Release-Tags«.
-Der erste Release Candidate von Contao `5.5` heißt z. B. `5.5.0-RC1`. Normalerweise
-würde Composer nur _stabile_ Versionen installieren und daher solche Release Candidates
-nicht beachten.
+Der erste Release Candidate von Contao `{{% siteparam "currentReleaseCandidate" %}}` heißt z. B.
+`{{% siteparam "currentReleaseCandidate" %}}.0-RC1`. Normalerweise würde Composer nur _stabile_ Versionen installieren
+und daher solche Release Candidates nicht beachten.
 
 Um die Installation von Release Candidates zu erlauben, muss die `minimum-stability` auf `RC` runter gesetzt werden.
 Alternativ kann man über sogenannte [stability-flags][ComposerStabilityContraints] direkt bei einzelnen Paketen
-niedrigere Stabilitäten erlauben, z. B. mit `"contao/manager-bundle": "5.5.*@RC"` in diesem Fall. In diesem Fall muss man
-allerdings auch zusätzlich das `contao/core-bundle` in die `composer.json` mit aufnehmen, um auch dediziert die
-niedrigere Stabilität bei diesem Paket zu erlauben.
+niedrigere Stabilitäten erlauben, z. B. mit `"contao/manager-bundle": "{{% siteparam "currentReleaseCandidate" %}}.*@RC"`
+in diesem Fall. In diesem Fall muss man allerdings auch zusätzlich das `contao/core-bundle` in die `composer.json` mit
+aufnehmen, um auch dediziert die niedrigere Stabilität bei diesem Paket zu erlauben.
 
-Hier ist ein komplettes Beispiel, um die neueste Contao `5.5` Version installieren
-zu lassen, _inklusive_ den neuesten Release Candidates (wenn vorhanden):
+Hier ist ein komplettes Beispiel, um die neueste Contao `{{% siteparam "currentReleaseCandidate" %}}` Version
+installieren zu lassen, _inklusive_ den neuesten Release Candidates (wenn vorhanden):
 
 ```json
 {
@@ -70,15 +70,15 @@ zu lassen, _inklusive_ den neuesten Release Candidates (wenn vorhanden):
     "license": "LGPL-3.0-or-later",
     "type": "project",
     "require": {
-        "contao/calendar-bundle": "^5.5@RC",
-        "contao/comments-bundle": "^5.5@RC",
+        "contao/calendar-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC",
+        "contao/comments-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC",
         "contao/conflicts": "@dev",
-        "contao/core-bundle": "^5.5@RC",
-        "contao/faq-bundle": "^5.5@RC",
-        "contao/listing-bundle": "^5.5@RC",
-        "contao/manager-bundle": "5.5.*@RC",
-        "contao/news-bundle": "^5.5@RC",
-        "contao/newsletter-bundle": "^5.5@RC"
+        "contao/core-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC",
+        "contao/faq-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC",
+        "contao/listing-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC",
+        "contao/manager-bundle": "{{% siteparam "currentReleaseCandidate" %}}.*@RC",
+        "contao/news-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC",
+        "contao/newsletter-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC"
     },
     "config": {
         "allow-plugins": {
@@ -107,8 +107,8 @@ zu lassen, _inklusive_ den neuesten Release Candidates (wenn vorhanden):
 Die angeforderten Versionen der anderen Contao Bundles muss nicht unbedingt von
 deren ursprünglichen Angaben geändert werden. Zum Beispiel erlaubt eine Angabe von
 `^5.3` (wie es der Fall wäre, wenn man von einer Contao 5.3 LTS Version aktualisieren
-würde) auch die Installation aller `5.5` Versionen (oder höher). Siehe dazu auch die Dokumentation
-von Composer über diese spezielle [Versions Syntax](https://getcomposer.org/doc/articles/versions.md).
+würde) auch die Installation aller `{{% siteparam "currentReleaseCandidate" %}}` Versionen (oder höher). Siehe dazu auch
+die Dokumentation von Composer über diese spezielle [Versions Syntax](https://getcomposer.org/doc/articles/versions.md).
 Nur die Version des `contao/manager-bundle` muss angepasst werden.
 {{% /notice %}}
 
@@ -188,8 +188,8 @@ kann stattdessen dieser Branch in der oben erwähnten `composer.json` verlangt w
 
 Die Testversionen können auch ohne manuelle Änderung der `composer.json` direkt
 über den Contao Manager installiert werden. Dazu editiert man bei »Contao Open Source
-CMS« die angeforderte Versionsangabe entweder auf bspw. `5.5.*@RC`, um Release
-Candidates, oder `5.5.x-dev` um Entwicklerversionen installieren 
+CMS« die angeforderte Versionsangabe entweder auf bspw. `{{% siteparam "currentReleaseCandidate" %}}.*@RC`, um Release
+Candidates, oder `{{% siteparam "currentReleaseCandidate" %}}.x-dev` um Entwicklerversionen installieren 
 zu lassen.
 
 ![Contao Manager Versionsangabe]({{% asset "images/manual/guides/de/install-version/contao-manager-versionseingabe.gif" %}}?classes=shadow)

--- a/docs/manual/guides/install-test-versions.de.md
+++ b/docs/manual/guides/install-test-versions.de.md
@@ -57,7 +57,7 @@ und daher solche Release Candidates nicht beachten.
 Um die Installation von Release Candidates zu erlauben, muss die `minimum-stability` auf `RC` runter gesetzt werden.
 Alternativ kann man über sogenannte [stability-flags][ComposerStabilityContraints] direkt bei einzelnen Paketen
 niedrigere Stabilitäten erlauben, z. B. mit `"contao/manager-bundle": "{{% siteparam "currentReleaseCandidate" %}}.*@RC"`
-in diesem Fall. In diesem Fall muss man allerdings auch zusätzlich das `contao/core-bundle` in die `composer.json` mit
+. In diesem Fall muss man allerdings auch zusätzlich das `contao/core-bundle` in die `composer.json` mit
 aufnehmen, um auch dediziert die niedrigere Stabilität bei diesem Paket zu erlauben.
 
 Hier ist ein komplettes Beispiel, um die neueste Contao `{{% siteparam "currentReleaseCandidate" %}}` Version

--- a/docs/manual/guides/install-test-versions.en.md
+++ b/docs/manual/guides/install-test-versions.en.md
@@ -46,17 +46,19 @@ the `composer.json`, a full package update needs to be executed of course.
 ## Installing Release Candidates
 
 Release candidates use a specific release version tag. For example the first release
-candidate of Contao `5.5` will have a release tag called `5.5.0-RC1`. Usually Composer
-will only install _stable_ versions by default and thus skip any such release candidates.
+candidate of Contao `{{% siteparam "currentReleaseCandidate" %}}` will have a release tag called
+`{{% siteparam "currentReleaseCandidate" %}}.0-RC1`. Usually Composer will only install _stable_ versions by default and
+thus skip any such release candidates.
 
 To allow the installation of release candidates, the `minimum-stability` needs to be lowered to `RC` in the
 `composer.json`. Alternatively you can also use [stability-flags][ComposerStabilityContraints] for each package in order
-to allow them to be installed in lower stabilities, e.g. `"contao/manager-bundle": "5.5.*@RC". In this case you will
-also have to add the `contao/core-bundle` package to your project's `composer.json` in order to allow the lower
-stability for this package as well.
+to allow them to be installed in lower stabilities, e.g.
+`"contao/manager-bundle": "{{% siteparam "currentReleaseCandidate" %}}.*@RC"`. In this case you will also have to add
+the `contao/core-bundle` package to your project's `composer.json` in order to allow the lower stability for this
+package as well.
 
-Here is a full example for installing the latest Contao `5.5` version, _including_
-its latest release candidates (if there are any):
+Here is a full example for installing the latest Contao `{{% siteparam "currentReleaseCandidate" %}}` version,
+_including_ its latest release candidates (if there are any):
 
 ```json
 {
@@ -65,15 +67,15 @@ its latest release candidates (if there are any):
     "license": "LGPL-3.0-or-later",
     "type": "project",
     "require": {
-        "contao/calendar-bundle": "^5.5@RC",
-        "contao/comments-bundle": "^5.5@RC",
+        "contao/calendar-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC",
+        "contao/comments-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC",
         "contao/conflicts": "@dev",
-        "contao/core-bundle": "^5.5@RC",
-        "contao/faq-bundle": "^5.5@RC",
-        "contao/listing-bundle": "^5.5@RC",
-        "contao/manager-bundle": "5.5.*@RC",
-        "contao/news-bundle": "^5.5@RC",
-        "contao/newsletter-bundle": "^5.5@RC"
+        "contao/core-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC",
+        "contao/faq-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC",
+        "contao/listing-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC",
+        "contao/manager-bundle": "{{% siteparam "currentReleaseCandidate" %}}.*@RC",
+        "contao/news-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC",
+        "contao/newsletter-bundle": "^{{% siteparam "currentReleaseCandidate" %}}@RC"
     },
     "config": {
         "allow-plugins": {
@@ -101,8 +103,8 @@ its latest release candidates (if there are any):
 {{% notice tip %}}
 The version requirement of the other bundles do not need to be changed from their
 default value. For example, a version requirement of `^5.3` (like if you would update 
-from the Contao 5.3 LTS version) also allows any `5.5` version. See Composer's documentation
-on the [version requirement syntax](https://getcomposer.org/doc/articles/versions.md). 
+from the Contao 5.3 LTS version) also allows any `{{% siteparam "currentReleaseCandidate" %}}` version. See Composer's
+documentation on the [version requirement syntax](https://getcomposer.org/doc/articles/versions.md). 
 Only the requested version of the `contao/manager-bundle` needs to be adjusted.
 {{% /notice %}}
 
@@ -181,8 +183,9 @@ of development of the next bugfix version, you can require this branch in the ab
 
 These test versions can also be installed via the Contao Manager, without having
 to manually change the `composer.json`. You can edit the required version of "Contao
-Open Source CMS" to `5.5.*@RC` for example, in order to install release candidates.
-Or you can enter `5.5.x-dev` in order to install development versions.
+Open Source CMS" to `{{% siteparam "currentReleaseCandidate" %}}.*@RC` for example, in order to install release
+candidates. Or you can enter `{{% siteparam "currentReleaseCandidate" %}}.x-dev` in order to install development
+versions.
 
 ![Contao Manager Versionsangabe]({{% asset "images/manual/guides/en/install-version/contao-manager-enter-custom-version.gif" %}}?classes=shadow)
 

--- a/page/config/_default/params.yml
+++ b/page/config/_default/params.yml
@@ -13,6 +13,7 @@ disableLanguageSwitch: true
 documentation_label: Documentation
 disableInlineCopyToClipBoard: true
 currentContaoVersion: '5.5'
+currentReleaseCandidate: '5.6'
 disableLandingPageButton: true
 banner:
   show: true


### PR DESCRIPTION
### Description

* same as https://github.com/contao/docs/pull/1496 but now easier to change :)
* introduces a site param `currentReleaseCandidate`

_Yes, if you copy the composer.json via the copy button, it will be the 5.6 version ;)_ 

#### Before

<img width="1222" height="755" alt="image" src="https://github.com/user-attachments/assets/588d8c8f-3758-4ac9-95cc-a329e1751164" />

#### After

<img width="1225" height="647" alt="image" src="https://github.com/user-attachments/assets/69a0e0cf-e632-47b0-be6c-9c04a573a522" />
