### PR TITLE
Add missing parameter to `csp_hash` Twig function

### DIFF
--- a/docs/dev/framework/csp.md
+++ b/docs/dev/framework/csp.md
@@ -135,7 +135,7 @@ $cspHandler->addHash('style-src', 'display:none');
 {{% /tab %}}
 {{% tab title="Twig" %}}
 ```twig
-{% do csp_hash('display:none') %}
+{% do csp_hash('style-src', 'display:none') %}
 <div style="display:none">
 ```
 {{% /tab %}}


### PR DESCRIPTION
The `csp_hash` function, as it uses the `CspRuntime`s `addHash` method, expects at least two arguments, the directive and the source. 
In the documentation currently only the second argument is passed, which wont work.