### PR TITLE
Update ddev.en.md

### DIFF
--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -181,18 +181,14 @@ To do this, first install the [cron add-on](https://github.com/ddev/ddev-cron) i
 ddev add-on get ddev/ddev-cron
 ```
 {{% notice info %}}
-If you have been using DDEV for a long time, you may receive an error message when setting up `ddev add-on get ddev/ddev-cron`. The reason for this is that the add-on has only been supported by DDEV since version 1.24. So you need to update DDEV.
+If you have been using DDEV for a long time, you may receive an error message when setting up `ddev add-on get ddev/ddev-cron`. The reason for this is that the add-on has only been supported by DDEV since version 1.24. So you need to update DDEV. For updates, see https://docs.ddev.com/en/stable/users/install/ddev-upgrade/.
 {{% /notice %}}
 
 Then create a `/.ddev/web-build/contao.cron` file with the following content:
 
 ```shell
-* * * * * ddev exec vendor/bin/contao-console contao:cron
+* * * * * php /var/www/html/vendor/bin/contao-console contao:cron
 ```
-
-{{% notice info %}}
-Please note that under certain circumstances, it is not possible to call the contao console outside the container. A `* * * * * php /var/www/html/vendor/bin/contao-console contao:cron` is not possible. This is only possible on root installations. Please use **ddev ssh** or **ddev exec** instead, in accordance with the DDEV Docs.
-{{% /notice %}}
 
 Then restart the DDEV project/container:
 

--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -39,7 +39,7 @@ installed](https://github.com/contao/contao-demo). Via the Contao Manager you ca
 Open the console of your choice, create the desired directory and then change to it. The directory name reflects the subsequent project hostname. However, you can [configure this](https://ddev.readthedocs.io/en/latest/users/extend/additional-hostnames/) additionally.
 
 ```shell
-mkdir contao && cd contao 
+mkdir contao && cd contao
 ```
 
 Create the DDEV configuration with:

--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -215,7 +215,7 @@ services:
     volumes:
     - /home/$USER/repository:/home/$USER/repository:rw
 ```
-Then restart the container with ```dddev restart```.
+Then restart the container with `ddev restart`.
 
 Now you can use the repository in your root **composer.json**. 
 ```

--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -39,7 +39,7 @@ installed](https://github.com/contao/contao-demo). Via the Contao Manager you ca
 Open the console of your choice, create the desired directory and then change to it. The directory name reflects the subsequent project hostname. However, you can [configure this](https://ddev.readthedocs.io/en/latest/users/extend/additional-hostnames/) additionally.
 
 ```shell
-mkdir contao && cd contao
+mkdir contao && cd contao 
 ```
 
 Create the DDEV configuration with:
@@ -171,7 +171,7 @@ ddev add-on get ddev/ddev-phpmyadmin && ddev restart
 With `ddev describe` you can find out how to access the respective database tool.
 
 
-## DDEV Cronjob einrichten
+## Setting up a cron job in DDEV
 
 {{< version-tag "5.5" >}} The [back end search](https://docs.contao.org/manual/en/installation/system-requirements/backend-search/) can be activated by setting up the [Contao cronjob framework](https://docs.contao.org/manual/en/performance/cronjobs/).
 
@@ -180,12 +180,14 @@ To do this, first install the [cron add-on](https://github.com/ddev/ddev-cron) i
 ```shell
 ddev add-on get ddev/ddev-cron
 ```
+{{% notice info %}} If you have been using DDEV for a long time, you may receive an error message when setting up ```ddev add-on get ddev/ddev-cron```. The reason for this is that the add-on has only been supported by DDEV since version 1.24. So you need to update DDEV. {{% /notice %}}
 
 Then create a `/.ddev/web-build/contao.cron` file with the following content:
 
 ```shell
-* * * * * php /var/www/html/vendor/bin/contao-console contao:cron
+* * * * * ddev exec vendor/bin/contao-console contao:cron
 ```
+{{% notice info %}} Please note that under certain circumstances, it is not possible to call the contao console outside the container. A ```* * * * * php /var/www/html/vendor/bin/contao-console contao:cron``` is not possible. This is only possible on root installations. Please use **ddev ssh** or **ddev exec** instead, in accordance with the DDEV Docs. {{% /notice %}}
 
 Then restart the DDEV project/container:
 
@@ -194,3 +196,30 @@ ddev restart
 ```
 
 The Contao cronjob is executed every minute. When setting up for the first time, it may take 1-2 minutes before the search bar is available in the back end.
+
+## Setting up a local shared repository path inside your DDEV container
+
+If you want to configure a path in your container where all your local bundles are stored and which you can use in your **composer.json**, you can do so as follows:
+
+Create a file inside the **./ddev** folder with the name **docker-compose.bundles.yaml**.
+
+The content can look like this (Please adjust the paths to suit your needs.):
+```
+services:
+  web:
+    volumes:
+    - /home/$USER/repository:/home/$USER/repository:rw
+```
+Then restart the container with ```dddev restart```.
+
+Now you can use the repository in your root **composer.json**. 
+```
+"repositories": [
+  {
+    "type": "path",
+    "url": "~/repository/my-local-bundle"
+  }
+],
+```
+
+{{% notice info %}} If the Contao Manager cannot find the repositories, it helps to deactivate the **Composer Resolver Cloud**. {{% /notice %}}

--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -189,7 +189,10 @@ Then create a `/.ddev/web-build/contao.cron` file with the following content:
 ```shell
 * * * * * ddev exec vendor/bin/contao-console contao:cron
 ```
-{{% notice info %}} Please note that under certain circumstances, it is not possible to call the contao console outside the container. A ```* * * * * php /var/www/html/vendor/bin/contao-console contao:cron``` is not possible. This is only possible on root installations. Please use **ddev ssh** or **ddev exec** instead, in accordance with the DDEV Docs. {{% /notice %}}
+
+{{% notice info %}}
+Please note that under certain circumstances, it is not possible to call the contao console outside the container. A `* * * * * php /var/www/html/vendor/bin/contao-console contao:cron` is not possible. This is only possible on root installations. Please use **ddev ssh** or **ddev exec** instead, in accordance with the DDEV Docs.
+{{% /notice %}}
 
 Then restart the DDEV project/container:
 

--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -227,4 +227,6 @@ Now you can use the repository in your root **composer.json**.
 ],
 ```
 
-{{% notice info %}} If the Contao Manager cannot find the repositories, it helps to deactivate the **Composer Resolver Cloud**. {{% /notice %}}
+{{% notice info %}}
+If the Contao Manager cannot find the repositories, it helps to deactivate the **Composer Resolver Cloud**.
+{{% /notice %}}

--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -180,7 +180,9 @@ To do this, first install the [cron add-on](https://github.com/ddev/ddev-cron) i
 ```shell
 ddev add-on get ddev/ddev-cron
 ```
-{{% notice info %}} If you have been using DDEV for a long time, you may receive an error message when setting up ```ddev add-on get ddev/ddev-cron```. The reason for this is that the add-on has only been supported by DDEV since version 1.24. So you need to update DDEV. {{% /notice %}}
+{{% notice info %}}
+If you have been using DDEV for a long time, you may receive an error message when setting up `ddev add-on get ddev/ddev-cron`. The reason for this is that the add-on has only been supported by DDEV since version 1.24. So you need to update DDEV.
+{{% /notice %}}
 
 Then create a `/.ddev/web-build/contao.cron` file with the following content:
 


### PR DESCRIPTION
Ich habe ein ddev Environment unter Windows 11 / WSL / ddev 1.24.7 laufen und bin dieser Anleitung früher oft gefolgt. Dabei ist mir aber aufgefallen, dass sie nicht ganz korrekt bzw. etwas veraltet ist.  Die Korrekturen habe ich hier mal eingepflegt. Gerade auch deswegen, weil die aktuellen Angaben teilweise nicht zum Ziel führten. Die von mir eingepflegten Änderungen habe ich alle getestet und sie sind im o.g. Environment funktionsfähig.