### PR TITLE
DDEV command "create" is deprecated

### DIFF
--- a/docs/manual/guides/local-installation/ddev.de.md
+++ b/docs/manual/guides/local-installation/ddev.de.md
@@ -53,7 +53,7 @@ ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --ph
 Contao 5.3 installieren:
 
 ```shell
-ddev composer create contao/managed-edition:5.3
+ddev composer create-project contao/managed-edition:5.3
 ```
 
 Nach der Installation müssen die Datenbankzugangsdaten in die `.env.local` eingetragen werden. In diesem Zug richten wir auch direkt 

--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -51,7 +51,7 @@ ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --ph
 Install Contao 5.3:
 
 ```shell
-ddev composer create contao/managed-edition:5.3
+ddev composer create-project contao/managed-edition:5.3
 ```
 
 After installation, the database credentials must be entered in the `.env.local`. At the same time, we also set up 


### PR DESCRIPTION
Since [DDEV v1.24.5 from May 15, 2025](https://github.com/ddev/ddev/releases/tag/v1.24.5): 

Command "create" is deprecated, please start using the identical "ddev composer create-project" instead