### PR TITLE
Add data container voter documentation

### DIFF
--- a/docs/dev/framework/security/data-container.md
+++ b/docs/dev/framework/security/data-container.md
@@ -2,7 +2,7 @@
 title: "Data Container permissions"
 description: Explanation of creating data container voters.
 aliases:
-    - /framework/security/data_container/
+    - /framework/security/data-container/
 ---
 
 Starting with version 5.0, Contao uses Symfony security voters to check _create_, _read_, _update_ and _delete_ (CRUD) permissions in data containers. This replaces the `checkPermission` onload callbacks that were used in Contao 4 and before. Before implementing your Contao-specific voter, make sure to get familiar with [Symfony security voters](https://symfony.com/doc/current/security/voters.html).
@@ -96,10 +96,12 @@ class ExampleAccessVoter extends AbstractDataContainerVoter
         }
 
         return match (true) {
-            $action instanceof CreateAction => $this->accessDecisionManager->decide($token, ['contao_user.examplep.create']),
+            $action instanceof CreateAction =>
+                $this->accessDecisionManager->decide($token, ['contao_user.examplep.create']),
             $action instanceof ReadAction,
-            $action instanceof UpdateAction => $this->accessDecisionManager->decide($token, ['contao_user.examples'], $action->getCurrentId()),
-            $action instanceof DeleteAction => 
+            $action instanceof UpdateAction =>
+                $this->accessDecisionManager->decide($token, ['contao_user.examples'], $action->getCurrentId()),
+            $action instanceof DeleteAction =>
                 $this->accessDecisionManager->decide($token, ['contao_user.examples'], $action->getCurrentId()) && 
                 $this->accessDecisionManager->decide($token, ['contao_user.examplep.delete']),
         };
@@ -112,7 +114,8 @@ In your archive list view you need to filter out all items the user has no read 
 See following example listener that sets the root IDs for the current user:
 
 ```php
-namespace App\EventListener\DataContainer\ExampleArchive;
+// src/EventListener/DataContainer/ExampleArchiveOnLoadListener.php
+namespace App\EventListener\DataContainer;
 
 use Contao\BackendUser;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
@@ -120,7 +123,7 @@ use Contao\DataContainer;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 #[AsCallback(table: 'tl_example_archive', target: 'config.onload')]
-class ConfigOnLoadListener
+class ExampleArchiveOnLoadListener
 {
     public function __construct(
         private readonly TokenStorageInterface $tokenStorage,

--- a/docs/dev/framework/security/data_container.md
+++ b/docs/dev/framework/security/data_container.md
@@ -27,8 +27,7 @@ $GLOBALS['TL_DCA']['tl_example_archive'] = [
 We also register custom permissions. One to define to which parent record the user can have access to and one to define what kind of CRUD permissions are granted for this table:
 
 ```php
-# contao/config/config.php
-
+// contao/config/config.php
 $GLOBALS['TL_PERMISSIONS'][] = 'examples';
 $GLOBALS['TL_PERMISSIONS'][] = 'examplep';
 ```

--- a/docs/dev/framework/security/data_container.md
+++ b/docs/dev/framework/security/data_container.md
@@ -54,3 +54,35 @@ class ExampleAccessVoter extends AbstractDataContainerVoter
     }
 }
 ```
+
+You still need a onload callback listener to filter out list items not allowed for the user:
+
+```php
+namespace App\EventListener\DataContainer\ExampleArchive;
+
+use Contao\BackendUser;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+use Contao\DataContainer;
+
+#[AsCallback(table: 'tl_example_archive', target: 'config.onload')]
+class ConfigOnLoadListener
+{
+    public function __invoke(?DataContainer $dc = null): void
+    {
+        $user = BackendUser::getInstance();
+
+        if ($user->isAdmin) {
+            return;
+        }
+
+        // Set root IDs
+        if (!\is_array($user->examples) || empty($user->examples)) {
+            $root = [0];
+        } else {
+            $root = $user->examples;
+        }
+
+        $GLOBALS['TL_DCA']['tl_example_archive']['list']['sorting']['root'] = $root;
+    }
+}
+```

--- a/docs/dev/framework/security/data_container.md
+++ b/docs/dev/framework/security/data_container.md
@@ -124,8 +124,7 @@ class ConfigOnLoadListener
 {
     public function __construct(
         private readonly TokenStorageInterface $tokenStorage,
-    )
-    {
+    ) {
     }
 
     public function __invoke(?DataContainer $dc = null): void

--- a/docs/dev/framework/security/data_container.md
+++ b/docs/dev/framework/security/data_container.md
@@ -127,7 +127,7 @@ class ConfigOnLoadListener
     ) {
     }
 
-    public function __invoke(?DataContainer $dc = null): void
+    public function __invoke(): void
     {
         $user = $this->tokenStorage->getToken()?->getUser();
 

--- a/docs/dev/framework/security/data_container.md
+++ b/docs/dev/framework/security/data_container.md
@@ -1,0 +1,56 @@
+---
+title: "Data Container permissions"
+description: Explanation of creating data container voters.
+aliases:
+    - /framework/security/data_container/
+---
+
+Since contao 5 data container permissions can be set by data container voters. This replaces the "checkPermission" onload callbacks that were used in Contao 4 and before.
+
+Contao comes with an bundles abstract class [AbstractDataContainerVoter](https://github.com/contao/contao/blob/5.3/core-bundle/src/Security/Voter/DataContainer/AbstractDataContainerVoter.php).
+A class extending it is able to voter for data container actions. See following example:
+
+```php
+<?php
+
+namespace App\Security\Voter\DataContainer;
+
+use App\Model\ExampleArchiveModel;
+use App\Security\ExamplePermissions;
+use Contao\CoreBundle\Security\DataContainer\CreateAction;
+use Contao\CoreBundle\Security\DataContainer\DeleteAction;
+use Contao\CoreBundle\Security\DataContainer\ReadAction;
+use Contao\CoreBundle\Security\DataContainer\UpdateAction;
+use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+
+class ExampleAccessVoter extends AbstractDataContainerVoter
+{
+    public function __construct(
+        private readonly AccessDecisionManagerInterface $accessDecisionManager
+    ) {
+    }
+
+    protected function getTable(): string
+    {
+        return ExampleArchiveModel::getTable();
+    }
+
+    protected function hasAccess(TokenInterface $token, UpdateAction|CreateAction|ReadAction|DeleteAction $action): bool
+    {
+        if (!$this->accessDecisionManager->decide($token, ['contao_user.modules.example'])) {
+            return false;
+        }
+
+        return match (true) {
+            $action instanceof CreateAction => $this->accessDecisionManager->decide($token,['contao_user.examplep.create']),
+            $action instanceof ReadAction,
+            $action instanceof UpdateAction => $this->accessDecisionManager->decide($token,['contao_user.examples'], $action->getCurrentId()),
+            $action instanceof DeleteAction => 
+                $this->accessDecisionManager->decide($token,['contao_user.examples'], $action->getCurrentId()) && 
+                $this->accessDecisionManager->decide($token,['contao_user.examplep.delete']),
+        };
+    }
+}
+```

--- a/docs/dev/framework/security/data_container.md
+++ b/docs/dev/framework/security/data_container.md
@@ -74,17 +74,14 @@ class ConfigOnLoadListener
 
     public function __invoke(?DataContainer $dc = null): void
     {
-        /**
-         * @var BackendUser|null $user
-         */
         $user = $this->tokenStorage->getToken()?->getUser();
 
-        if ($user && $user->isAdmin) {
+        if (!$user instanceof BackendUser || $user->isAdmin) {
             return;
         }
 
         // Set root IDs
-        if (!$user || !\is_array($user->examples) || empty($user->examples)) {
+        if (!$user->examples || !\is_array($user->examples)) {
             $root = [0];
         } else {
             $root = $user->examples;

--- a/docs/dev/framework/security/data_container.md
+++ b/docs/dev/framework/security/data_container.md
@@ -7,9 +7,10 @@ aliases:
 
 Starting with version 5.0, Contao uses Symfony security voters to check _create_, _read_, _update_ and _delete_ (CRUD) permissions in data containers. This replaces the `checkPermission` onload callbacks that were used in Contao 4 and before. Before implementing your Contao-specific voter, make sure to get familiar with [Symfony security voters](https://symfony.com/doc/current/security/voters.html).
 
-Contao provides an abstract class [AbstractDataContainerVoter](https://github.com/contao/contao/blob/5.3/core-bundle/src/Security/Voter/DataContainer/AbstractDataContainerVoter.php) to simplify voting on CRUD operations for one specific DCA table. See the following example for a typical archive table:
+Contao provides an abstract class [AbstractDataContainerVoter](https://github.com/contao/contao/blob/5.3/core-bundle/src/Security/Voter/DataContainer/AbstractDataContainerVoter.php) to simplify voting on CRUD operations for one specific DCA table. See the following example for a typical parent table definition.
 
-First, we need the archive dca definition:
+First, we need the DCA for the parent table:
+
 ```php
 # contao/dca/tl_example_archive.php
 

--- a/docs/dev/framework/security/data_container.md
+++ b/docs/dev/framework/security/data_container.md
@@ -24,7 +24,8 @@ $GLOBALS['TL_DCA']['tl_example_archive'] = [
 ]
 ```
 
-Register the permissions:
+We also register custom permissions. One to define to which parent record the user can have access to and one to define what kind of CRUD permissions are granted for this table:
+
 ```php
 # contao/config/config.php
 

--- a/docs/dev/framework/security/data_container.md
+++ b/docs/dev/framework/security/data_container.md
@@ -5,10 +5,9 @@ aliases:
     - /framework/security/data_container/
 ---
 
-Since Contao 5 data container permissions can be set by data container voters. This replaces the "checkPermission" onload callbacks that were used in Contao 4 and before.
+Starting with version 5.0, Contao uses Symfony security voters to check _create_, _read_, _update_ and _delete_ (CRUD) permissions in data containers. This replaces the `checkPermission` onload callbacks that were used in Contao 4 and before. Before implementing your Contao-specific voter, make sure to get familiar with [Symfony security voters](https://symfony.com/doc/current/security/voters.html).
 
-Contao provides an abstract class [AbstractDataContainerVoter](https://github.com/contao/contao/blob/5.3/core-bundle/src/Security/Voter/DataContainer/AbstractDataContainerVoter.php) for data container voters.
-A class extending it is able to vote for data container actions. See the following example for a typical archive table:
+Contao provides an abstract class [AbstractDataContainerVoter](https://github.com/contao/contao/blob/5.3/core-bundle/src/Security/Voter/DataContainer/AbstractDataContainerVoter.php) to simplify voting on CRUD operations for one specific DCA table. See the following example for a typical archive table:
 
 First, we need the archive dca definition:
 ```php

--- a/docs/dev/framework/security/data_container.md
+++ b/docs/dev/framework/security/data_container.md
@@ -12,8 +12,7 @@ Contao provides an abstract class [AbstractDataContainerVoter](https://github.co
 First, we need the DCA for the parent table:
 
 ```php
-# contao/dca/tl_example_archive.php
-
+// contao/dca/tl_example_archive.php
 use Contao\DC_Table;
 
 $GLOBALS['TL_DCA']['tl_example_archive'] = [

--- a/docs/dev/framework/security/data_container.md
+++ b/docs/dev/framework/security/data_container.md
@@ -8,7 +8,7 @@ aliases:
 Since contao 5 data container permissions can be set by data container voters. This replaces the "checkPermission" onload callbacks that were used in Contao 4 and before.
 
 Contao comes with an bundles abstract class [AbstractDataContainerVoter](https://github.com/contao/contao/blob/5.3/core-bundle/src/Security/Voter/DataContainer/AbstractDataContainerVoter.php).
-A class extending it is able to voter for data container actions. See following example:
+A class extending it is able to vote for data container actions. See following example:
 
 ```php
 <?php

--- a/docs/dev/framework/security/data_container.md
+++ b/docs/dev/framework/security/data_container.md
@@ -32,28 +32,27 @@ $GLOBALS['TL_PERMISSIONS'][] = 'examples';
 $GLOBALS['TL_PERMISSIONS'][] = 'examplep';
 ```
 
-Add permissions to the user DCA (should be also done for user group!):
+Add permissions to the user group DCA (can be also done for tl_user):
 
 ```php
-// contao/dca/tl_user.php
+// contao/dca/tl_user_group.php
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
 
 PaletteManipulator::create()
     ->addLegend('example_legend', 'amg_legend', PaletteManipulator::POSITION_AFTER)
     ->addField('examples', 'example_legend', PaletteManipulator::POSITION_APPEND)
     ->addField('examplep', 'example_legend', PaletteManipulator::POSITION_APPEND)
-    ->applyToPalette('extend', 'tl_user')
-    ->applyToPalette('custom', 'tl_user')
+    ->applyToPalette('default', 'tl_user_group')
 ;
 
-$GLOBALS['TL_DCA']['tl_user']['fields']['examples'] = [
+$GLOBALS['TL_DCA']['tl_user_group']['fields']['examples'] = [
     'inputType'  => 'checkbox',
     'foreignKey' => 'tl_example_archive.title',
     'eval'       => ['multiple' => true],
     'sql'        => "blob NULL"
 ];
 
-$GLOBALS['TL_DCA']['tl_user']['fields']['examplep'] = [
+$GLOBALS['TL_DCA']['tl_user_group']['fields']['examplep'] = [
     'inputType' => 'checkbox',
     'options'   => ['create', 'delete'],
     'reference' => &$GLOBALS['TL_LANG']['MSC'],

--- a/docs/dev/framework/security/data_container.md
+++ b/docs/dev/framework/security/data_container.md
@@ -32,10 +32,10 @@ $GLOBALS['TL_PERMISSIONS'][] = 'examples';
 $GLOBALS['TL_PERMISSIONS'][] = 'examplep';
 ```
 
-Add permissions to the user dca (should be also done for user_group!):
-```php
-# contao/dca/tl_user.php
+Add permissions to the user DCA (should be also done for user group!):
 
+```php
+// contao/dca/tl_user.php
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
 
 PaletteManipulator::create()
@@ -64,6 +64,7 @@ $GLOBALS['TL_DCA']['tl_user']['fields']['examplep'] = [
 
 Now we can implement the voter:
 ```php
+// src/Security/Voter/DataContainer/ExampleAccessVoter.php
 namespace App\Security\Voter\DataContainer;
 
 use App\Model\ExampleArchiveModel;


### PR DESCRIPTION
This PR add a basic data container action voter documentation.

I could not compile the docs by myself, always got `Error: error building site: process: readAndProcessContent: "[...]/docs/dev/_index.md:77:1": failed to extract shortcode: template for shortcode "notice" not found`, but I think I made everything right :)