### PR TITLE
Update Hugo to 0.153 and Relearn Theme to 8.3

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -17,7 +17,7 @@ jobs:
             - name: Setup Hugo
               uses: peaceiris/actions-hugo@v2
               with:
-                  hugo-version: '0.144.2'
+                  hugo-version: '0.153.4'
             - name: Build user manual
               run: make build-manual
             - name: Build developer manual

--- a/docs/dev/_index.md
+++ b/docs/dev/_index.md
@@ -3,9 +3,6 @@ title: Contao Developer Documentation
 type: home
 ---
 
-
-# Contao Developer Documentation
-
 Welcome to the Contao manual for developers and the Contao ecosystem!
 This introduction is meant to give you an overall idea of how things work in Contao and its ecosystem, people with assigned
 roles, whom to talk to and where to get help.

--- a/docs/manual/_index.de.md
+++ b/docs/manual/_index.de.md
@@ -3,7 +3,7 @@ title: Contao Handbuch
 type: home
 ---
 
-# Herzlich willkommen
+## Herzlich willkommen
 
 Du bist hier, weil sich die folgenden Menschen (in alphabetischer Reihenfolge) und die Contao Community Tage und Nächte 
 um die Ohren schlagen, um die Contao-Entwicklung voranzutreiben:

--- a/docs/manual/_index.en.md
+++ b/docs/manual/_index.en.md
@@ -3,7 +3,7 @@ title: Contao Manual
 type: home
 ---
 
-# Welcome
+## Welcome
 
 You are here because the following people (in alphabetical order), and the Contao
 Community as a whole, were up day and night in order to further the development

--- a/docs/manual/system/_index.de.md
+++ b/docs/manual/system/_index.de.md
@@ -1,8 +1,7 @@
 ---
 title: "System"
-description: ""
-url: "system"
 description: Dieses Kapitel beschreibt die System Sektion des Contao Backends.
+url: "system"
 aliases:
     - /de/system/
 weight: 5

--- a/page/assets/css/theme-contao.css
+++ b/page/assets/css/theme-contao.css
@@ -108,8 +108,9 @@ b, strong, label, th {
 }
 
 /* Logo */
-#R-header #logo {
+#R-header-wrapper #logo {
     display: block;
+    margin-bottom: 1rem;
 }
 
 #logo svg {
@@ -136,7 +137,6 @@ b, strong, label, th {
 }
 
 .algolia-searchbox {
-    margin-top: 1rem;
     position: relative;
     border: 1px solid var(--MENU-SEARCH-BORDER-color);
     background: var(--MENU-SEARCH-BG-color);


### PR DESCRIPTION
### Description

This updates:
- the current Hugo Relearn Theme version to 8.3.0 e14af475beb94143ae376992e99fcc6e8653d657
- updates hugo to 0.153.4 9913d282275f997f5044e09746cf43f8b3fd68e4

and makes the necessary changes for the update:

- Cleanup of titles and descriptions (duplicates / title is being used) 5cba890dd5170722b4ae02c08aef15141701a658 / cf060907d249ed47ff7a1a9fc993ae8e05f73e4f

- adjust the logo layout to match the old changes 3a6fbaf3df86d3a9e09359a3ad2ba768af31efff

- actually makes "Welcome" / "Herzlich Willkommen" a `<h2>` (The h1 is the page itself and `Welcome` should not be the `<h1>` due to SEO reasons 🙈 ) f1e658bb3056ccad2bc25280c21cbc19bf2acc18