### PR TITLE
Fix syntax errors in `add_schema_org` and `attrs` Twig function examples

### DIFF
--- a/docs/dev/reference/twig/functions/add_schema_org.md
+++ b/docs/dev/reference/twig/functions/add_schema_org.md
@@ -22,9 +22,9 @@ The above example uses the [`Event`](https://schema.org/Event) Schema.org Type. 
 ```twig
 {% do add_schema_org({
     '@type': 'Events',
-    'identifier' => '#/schema/events/' ~ id,
-    'name' => title,
-    'startDate' => startTime|date('Y-m-d\TH:i:sP'),
+    'identifier': '#/schema/events/' ~ id,
+    'name': title,
+    'startDate': startTime|date('Y-m-d\TH:i:sP'),
 }) %}
 ```
 

--- a/docs/dev/reference/twig/functions/attrs.md
+++ b/docs/dev/reference/twig/functions/attrs.md
@@ -47,7 +47,7 @@ Add and remove styles
 
 ```twig
 attrs().addStyle('color: red')                          {# <div style="color: red;"> #}
-attrs().addStyle(['color' => 'red', 'margin' => '1em'])
+attrs().addStyle({'color': 'red', 'margin': '1em'})
 attrs().removeStyle('color')                            {# Removes just the color style #}
 ```
 
@@ -91,7 +91,7 @@ Inline styles with conditions?
 
 ```twig
 <div{{ attrs()
-    .addStyle(['background' => bgColor])
+    .addStyle({'background': bgColor})
     .addStyle('border: 1px solid red;', hasError) }}>
     Content
 </div>


### PR DESCRIPTION
Using `=>` to assign values and `[...]` is not valid syntax for Twig mappings.