### PR TITLE
contao-manager.phar.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /deepl/vendor
 /deepl/.php_cs.cache
 /link-checker/manual-result.md
+.DS_Store

--- a/docs/manual/installation/contao-manager/_index.de.md
+++ b/docs/manual/installation/contao-manager/_index.de.md
@@ -73,18 +73,8 @@ Pro Contao-Installation wird deshalb eine eigene (Sub)Domain benötigt.
 ### Download und Installation
 
 Der Contao Manager besteht aus einer einzelnen Datei, welche über [contao.org](https://contao.org/de/download.html) 
-heruntergeladen werden kann. Nach erfolgreichem Download erhältst du eine Datei `contao-manager.phar`. 
+heruntergeladen werden kann. Nach erfolgreichem Download erhältst du eine Datei `contao-manager.phar.php`. 
 Übertrage diese Datei in das Verzeichnis `public` auf deinem Webserver.
-
-{{% notice note %}}
-`.phar`-Dateien werden nicht von allen Hosting-Anbietern ausgeführt. Für beste Kompatibilität füge die 
-Dateiendung `.php` hinzu (Finaler Dateiname: `contao-manager.phar.php`).
-{{% /notice %}}
-
-{{% notice warning %}}
-`.php`-Dateien werden von den meisten FTP-Programmen im Text- statt Binär-Modus übertragen, was die 
-Manager-Datei zerstört. Füge deshalb die Dateiendung `.php` erst nach dem Upload hinzu.
-{{% /notice %}}
 
 
 ### Contao Manager aufrufen

--- a/docs/manual/installation/contao-manager/_index.en.md
+++ b/docs/manual/installation/contao-manager/_index.en.md
@@ -65,18 +65,9 @@ Every Contao installation requires a separate (sub)domain.
 ### Download and Installation
 
 The Contao Manager consists of a single file that can be [downloaded from contao.org](https://contao.org/en/download.html). 
-After the successful download you will receive a file `contao-manager.phar`. transfer this file to the directory `public` 
-on your web server.
+After the successful download you will receive a file `contao-manager.phar.php`. transfer this file to the directory 
+`public` on your web server.
 
-{{% notice note %}}
-Files `.phar` are not executed by all hosting providers. For best compatibility, add the file extension `.php`(final 
-file name: `contao-manager.phar.php`).
-{{% /notice %}}
-
-{{% notice warning %}}
-`.php` files are transferred by most FTP programs in text mode instead of binary mode, which destroys the manager file. 
-Therefore, add the file extension `.php` only after the upload. 
-{{% /notice %}}
 
 ### Starting Contao Manager
 

--- a/docs/manual/installation/contao-manager/_index.en.md
+++ b/docs/manual/installation/contao-manager/_index.en.md
@@ -65,7 +65,7 @@ Every Contao installation requires a separate (sub)domain.
 ### Download and Installation
 
 The Contao Manager consists of a single file that can be [downloaded from contao.org](https://contao.org/en/download.html). 
-After the successful download you will receive a file `contao-manager.phar.php`. transfer this file to the directory 
+After the successful download you will receive a file `contao-manager.phar.php`. Transfer this file to the directory 
 `public` on your web server.
 
 

--- a/docs/manual/installation/contao-manager/contao-manager-error.de.md
+++ b/docs/manual/installation/contao-manager/contao-manager-error.de.md
@@ -17,7 +17,7 @@ herunterlädt und sich danach selber überschreibt.
 Beim Aufruf der URL `www.example.com/contao-manager.phar.php` erscheint jedoch nicht die Willkommensseite des Contao 
 Managers.
 
-In diesem Fall, kannst du versuchen die [`.phar`-Datei](https://download.contao.org/contao-manager.phar) direkt 
+In diesem Fall kannst du versuchen, die [`.phar`-Datei](https://download.contao.org/contao-manager.phar) direkt 
 hochzuladen.
 
 

--- a/docs/manual/installation/contao-manager/contao-manager-error.de.md
+++ b/docs/manual/installation/contao-manager/contao-manager-error.de.md
@@ -11,7 +11,7 @@ aliases:
 Du hast den Contao Manager, bestehend aus einer einzelnen Datei, über [contao.org](https://contao.org/de/download.html)
 heruntergeladen. Die Datei `contao-manager.phar.php` hast du in das Verzeichnis `public` auf deinem Webserver übertragen.
 
-Die Download-Datei `contao-manager.phar.php` ist ein PHP-Script welches dir im Hintergrund die benötigte Datei
+Die Download-Datei `contao-manager.phar.php` ist ein PHP-Script, welches dir im Hintergrund die benötigte Datei
 herunterlädt und sich danach selber überschreibt.
 
 Beim Aufruf der URL `www.example.com/contao-manager.phar.php` erscheint jedoch nicht die Willkommensseite des Contao 

--- a/docs/manual/installation/contao-manager/contao-manager-error.de.md
+++ b/docs/manual/installation/contao-manager/contao-manager-error.de.md
@@ -1,0 +1,32 @@
+---
+title: "Contao Manager Fehler"
+description: ""
+url: "installation/contao-manager-error"
+aliases:
+    - /de/installation/contao-manager-fehler/
+---
+
+## Der Contao Manager kann nicht aufgerufen werden
+
+Du hast den Contao Manager bestehend aus einer einzelnen Datei, über [contao.org](https://contao.org/de/download.html)
+heruntergeladen. Die Datei `contao-manager.phar.php` hast du in das Verzeichnis `public` auf deinem Webserver übertragen.
+
+Die Download-Datei `contao-manager.phar.php` ist ein PHP-Script welches dir im Hintergrund die benötigte Datei
+herunterlädt und sich danach selber überschreibt.
+
+Beim Aufruf der URL `www.example.com/contao-manager.phar.php` erscheint jedoch nicht die Willkommensseite des Contao 
+Managers.
+
+In diesem Fall, kannst du versuchen die [`.phar`-Datei](https://download.contao.org/contao-manager.phar) direkt 
+hochzuladen.
+
+
+{{% notice note %}}
+`.phar`-Dateien werden nicht von allen Hosting-Anbietern ausgeführt. Für beste Kompatibilität füge die
+Dateiendung `.php` hinzu (Finaler Dateiname: `contao-manager.phar.php`).
+{{% /notice %}}
+
+{{% notice warning %}}
+`.php`-Dateien werden von den meisten FTP-Programmen im Text- statt Binär-Modus übertragen, was die
+Manager-Datei zerstört. Füge deshalb die Dateiendung `.php` erst nach dem Upload hinzu.
+{{% /notice %}}

--- a/docs/manual/installation/contao-manager/contao-manager-error.de.md
+++ b/docs/manual/installation/contao-manager/contao-manager-error.de.md
@@ -8,7 +8,7 @@ aliases:
 
 ## Der Contao Manager kann nicht aufgerufen werden
 
-Du hast den Contao Manager bestehend aus einer einzelnen Datei, über [contao.org](https://contao.org/de/download.html)
+Du hast den Contao Manager, bestehend aus einer einzelnen Datei, über [contao.org](https://contao.org/de/download.html)
 heruntergeladen. Die Datei `contao-manager.phar.php` hast du in das Verzeichnis `public` auf deinem Webserver übertragen.
 
 Die Download-Datei `contao-manager.phar.php` ist ein PHP-Script welches dir im Hintergrund die benötigte Datei

--- a/docs/manual/installation/contao-manager/contao-manager-error.en.md
+++ b/docs/manual/installation/contao-manager/contao-manager-error.en.md
@@ -1,0 +1,31 @@
+---
+title: 'Contao Manager error'
+description: ''
+url: "installation/contao-manager-error"
+aliases:
+    - /en/installation/contao-manager-error/
+---
+
+## The Contao Manager cannot be accessed
+
+You have downloaded the Contao Manager, consisting of a single file, from [contao.org](https://contao.org/de/download.html) 
+and transferred the file `contao-manager.phar.php` to the `public` directory on your web server.
+
+The download file `contao-manager.phar.php` is a PHP script that downloads the required file in the background
+and then overwrites itself.
+
+However, when you call up the URL `www.example.com/contao-manager.phar.php`, the welcome page of the Contao
+Manager does not appear.
+
+In this case, you can try uploading the [`.phar` file](https://download.contao.org/contao-manager.phar) directly.
+
+
+{{% notice note %}}
+Files `.phar` are not executed by all hosting providers. For best compatibility, add the file extension `.php`(final
+file name: `contao-manager.phar.php`).
+{{% /notice %}}
+
+{{% notice warning %}}
+`.php` files are transferred by most FTP programs in text mode instead of binary mode, which destroys the manager file.
+Therefore, add the file extension `.php` only after the upload.
+{{% /notice %}}

--- a/docs/manual/installation/contao-manager/contao-manager-error.en.md
+++ b/docs/manual/installation/contao-manager/contao-manager-error.en.md
@@ -21,7 +21,7 @@ In this case, you can try uploading the [`.phar` file](https://download.contao.o
 
 
 {{% notice note %}}
-Files `.phar` are not executed by all hosting providers. For best compatibility, add the file extension `.php`(final
+`.phar` files are not executed by all hosting providers. For best compatibility, add the file extension `.php`(final
 file name: `contao-manager.phar.php`).
 {{% /notice %}}
 

--- a/docs/manual/installation/quickstart.de.md
+++ b/docs/manual/installation/quickstart.de.md
@@ -21,9 +21,9 @@ Das Hosting konfigurierst du über das Admin-Panel deines Hosting-Providers.
 ### Wurzelverzeichnis (Document Root)
 
 Von deinem Provider wird dir meistens ein Ordner vorgegeben, wo du deine Webseiten ablegen kannst - das ist häufig
-ein Ordner `/www`, `/public_html` oder `/httpdocs`. Dort kannst du Contao für deine neue Webseite installieren. Es hat sich bewährt,
-in diesem Pfad erstmal einen Unterordner anzulegen z. B. `/example` für die Seite `example.com` - das ist dann dein
-Installations- oder Projektordner.
+ein Ordner `/www`, `/public_html` oder `/httpdocs`. Dort kannst du Contao für deine neue Webseite installieren. Es hat 
+sich bewährt, in diesem Pfad erstmal einen Unterordner anzulegen z. B. `/example` für die Seite `example.com` - das ist 
+dann dein Installations- oder Projektordner.
 
 In Contao befinden sich alle öffentlich erreichbaren Dateien im Unterordner `/public`. Erstelle dazu den Ordner `public`
 in deinem Installationsordner und setze das Wurzelverzeichnis (Document Root) über das Admin-Panel des Hosting-Providers
@@ -42,12 +42,8 @@ anlegst. Die Zugangsdaten werden später benötigt.
 
 Der [Contao Manager](../../installation/contao-manager/) besteht aus einer einzelnen Datei, welche über 
 [contao.org](https://contao.org/de/download.html) heruntergeladen werden kann. Nach erfolgreichem Download erhältst 
-du eine Datei `contao-manager.phar`. Übertrage diese Datei in das Verzeichnis `public` auf deinem Webserver.
+du eine Datei `contao-manager.phar.php`. Übertrage diese Datei in das Verzeichnis `public` auf deinem Webserver.
 
-{{% notice note %}}
-`.phar`-Dateien werden nicht von allen Hosting-Anbietern ausgeführt. Für beste Kompatibilität füge die
-Dateiendung `.php` <b>nach dem Upload</b> hinzu (benenne die Datei <b>auf dem Server</b> in `contao-manager.phar.php` um).
-{{% /notice %}}
 
 ## Contao Manager aufrufen
 

--- a/docs/manual/installation/quickstart.en.md
+++ b/docs/manual/installation/quickstart.en.md
@@ -6,8 +6,9 @@ aliases:
 weight: 15
 ---
 
-We assume here that you want to install either the latest version or the [Long Term Support Version](https://docs.contao.org/manual/en/installation/update-contao/#long-term-support-versions) with the Contao Manager. This is the easiest and recommended way for beginners. Some hosting 
-providers offer 1-click installations. However, for the best user experience, we recommend using the Contao Manager or the console.
+We assume here that you want to install either the latest version or the [Long Term Support Version](https://docs.contao.org/manual/en/installation/update-contao/#long-term-support-versions) with the 
+Contao Manager. This is the easiest and recommended way for beginners. Some hosting providers offer 1-click 
+installations. However, for the best user experience, we recommend using the Contao Manager or the console.
 
 
 ## Hosting configuration
@@ -16,9 +17,9 @@ You configure the hosting via the admin panel of your hosting provider.
 
 ### Root directory (document root)
 
-Your provider will usually give you a folder where you can store your websites - this is often a `/www`, `/public_html` or `/httpdocs`
-folder. There you can install Contao for your new website. It has proven useful to first create a subfolder in this 
-path, e.g. `/example` for the page `example.com` - this is then your installation or project folder.
+Your provider will usually give you a folder where you can store your websites - this is often a `/www`, `/public_html` 
+or `/httpdocs` folder. There you can install Contao for your new website. It has proven useful to first create a 
+subfolder in this path, e.g. `/example` for the page `example.com` - this is then your installation or project folder.
 
 In Contao, all publicly accessible files are located in the `/public` subfolder. Create a folder called `public` and
 set the root directory (document root) of the installation to this subfolder via the admin panel of the hosting provider
@@ -35,13 +36,9 @@ should ideally create right away. Its login credentials will be needed later.
 ## Installing the Contao Manager
 
 The [Contao Manager](../../installation/contao-manager/) consists of a single file which can be downloaded from 
-[contao.org](https://contao.org/en/download). After a successful download you will receive a file called `contao-manager.phar`. 
+[contao.org](https://contao.org/en/download). After a successful download you will receive a file called `contao-manager.phar.php`. 
 Transfer this file to the `public` directory on your web server.
 
-{{% notice note %}}
-`.phar` files are not executed by all hosting providers. For best compatibility, add the `.php` file extension 
-<b>after the upload</b> (i.e. rename the file <b>on the server</b> to `contao-manager.phar.php`).
-{{% /notice %}}
 
 ## Call Contao Manager
 


### PR DESCRIPTION
If that is what you want, I will make the following adjustment in the repo to.contao.org after the merge:

# Used by the Contao Manager
error:
    en: https://docs.contao.org/manual/en/installation/contao-manager-error/
    de: https://docs.contao.org/manual/de/installation/contao-manager-error/
