### PR TITLE
Clarify which cron jobs run on website visit

### DIFF
--- a/docs/manual/performance/cronjobs.de.md
+++ b/docs/manual/performance/cronjobs.de.md
@@ -9,8 +9,15 @@ aliases:
 Contao wird von Haus aus mit einem Cronjob-Framework ausgeliefert. Kurz zusammengefasst ermöglicht dies
 Entwickler*innen eine einfachere und einheitliche Registrierung von Cronjobs für ihre eigenen Erweiterungen.
 
-Cronjobs werden standardmässig immer dann ausgeführt, wenn jemand die Webseite besucht. Dies kann die Performance 
+Cronjobs werden standardmässig immer dann ausgeführt, wenn jemand die Webseite besucht. Dies kann die Performance
 deiner Webseite negativ beeinflussen, weshalb empfohlen wird, echte Cronjobs auf dem Server einzurichten.
+
+{{% notice note %}}
+Cronjobs, die über einen Websitebesuch oder die Route `_contao/cron` ausgelöst werden, führen nicht alle
+registrierten Jobs aus, sondern nur die, die für diesen Aufrufweg vorgesehen sind. Die Indexierung für die
+Backend-Suche wird zum Beispiel ausschliesslich über einen echten CLI-Cronjob aufgebaut. Das ist ein weiterer
+Grund, einen echten Cronjob auf dem Server einzurichten.
+{{% /notice %}}
 
 Dies ist dank des Cronjob Frameworks von Contao sehr einfach zu erreichen. Alles, was dazu benötigt wird, ist ein
 einziger minütlicher Cronjob, der das Framework initialisiert. Contao kümmert sich anschliessend automatisch darum, 

--- a/docs/manual/performance/cronjobs.en.md
+++ b/docs/manual/performance/cronjobs.en.md
@@ -8,8 +8,14 @@ aliases:
 Contao ships with a cronjob framework out of the box. In short, this allows developers to register cronjobs 
 for their own extensions in a simpler and consistent way.
 
-By default, cronjobs are executed whenever someone visits the website. This can negatively affect the 
+By default, cronjobs are executed whenever someone visits the website. This can negatively affect the
 performance of your website, which is why it is recommended to set up real cronjobs on the server.
+
+{{% notice note %}}
+Cron jobs triggered by a website visit or the `_contao/cron` route do not execute all registered jobs, only
+those designed for this trigger. The back end search index, for example, is only built via a real CLI cron job.
+This is another reason to set up a real cron job on the server.
+{{% /notice %}}
 
 This is very easy to achieve thanks to Contao's cronjob framework. All that is needed is a single minutely
 cronjob that initializes the framework. Contao then automatically takes care of running all registered cronjobs 


### PR DESCRIPTION
The article currently explains that cron jobs run on every website visit and recommends setting up a real cron job for performance reasons. However, it does not mention that the web-triggered cron also has functional limitations.

This PR adds a notice block (DE+EN) clarifying that cron jobs triggered by a website visit or the `_contao/cron` route only execute jobs designed for that trigger. The back end search index, for example, is only built via a real CLI cron job. This gives users an additional functional reason to set up a real cron job, beyond the performance argument already covered.