### PR TITLE
Update Twig templates overview for Contao 5.7 (DE+EN)

### DIFF
--- a/docs/manual/layout/templates/twig/_index.de.md
+++ b/docs/manual/layout/templates/twig/_index.de.md
@@ -9,14 +9,14 @@ tags: [Twig]
 ---
 
 {{% notice note %}}
-Der gesamte Abschnitt behandelt die Verwendung von Twig-Templates in Contao ab Version 5.0.  
+Der gesamte Abschnitt behandelt die Verwendung von Twig-Templates in Contao ab Version 5.0.
 In Contao können Twig-Templates zwar seit Version 4.12 genutzt werden, aber erst seit Contao 5.0 werden Twig-Templates
 auch im Contao-Core verwendet. Es wurde darauf verzichtet, die abweichende Verwendung von Twig-Templates in älteren
 Versionen im Handbuch zu dokumentieren.
 {{% /notice %}}
 
 Twig ist eine Template Engine für PHP und die Standard Template Engine von Symfony. Sie ist schnell, sicher und leicht
-erweiterbar.  
+erweiterbar.
 Mit Twig-Templates kann das Design von der Programmierung strikt getrennt werden.
 
 Wie ein PHP-Template wird ein Twig-Template für die Ausgabe eines Moduls, Inhaltselements, Formulars oder einer anderen
@@ -31,9 +31,9 @@ z. B. [Erweitern](wiederverwendung/#erweitern),
 [horizontale Wiederverwendung](wiederverwendung/#horizontale-wiederverwendung) oder
 [Makros](https://docs.contao.org/dev/framework/templates/creating-templates/#macros).
 Deshalb sollten keine Templates mehr komplett überschrieben werden, wie das bei den PHP-Templates häufig üblich bzw.
-notwendig war.  
+notwendig war.
 Wir werden innerhalb des Handbuches nur die wichtigste Technik - das Erweitern von Twig-Templates für Contao genauer
-behandeln.  
+behandeln.
 Weitergehende Informationen zu Twig-Templates in Contao findest du in der
 [Entwicklerdokumentation](https://docs.contao.org/dev/framework/templates/).
 {{% /notice %}}
@@ -43,23 +43,31 @@ Weitergehende Informationen zu Twig-Templates in Contao findest du in der
 
 ## Twig-Templates im Contao-Core
 
-In Contao 5 werden für viele Core-Elemente Twig-Templates zur Verfügung gestellt. Das bedeutet, dass Template
-Anpassungen auch in den Twig-Templates erfolgen müssen.  
-Für eine Übergangszeit kann noch auf die PHP-Templates zurückgegriffen werden. Die notwendigen Einstellungen
-dafür findest du in der [Upgrade-Anleitung](https://github.com/contao/contao/blob/5.x/UPGRADE.md#content-elements).
+{{< version "5.7" >}}
+
+Ab Contao 5.7 steht für jedes `.html5`-Template ein Twig-Pendant zur Verfügung. Twig ist damit der
+neue Standard und löst die HTML5-Templates vollständig ab.
+
+Standardmäßig wird immer die Twig-Version eines Templates verwendet. Liegt jedoch ein gleichnamiges
+`.html5`-Template in deinem `templates`-Verzeichnis, hat dieses Vorrang gegenüber dem Twig-Template.
+
+**Beispiel:** `news_full.html.twig` wird verwendet, solange kein `news_full.html5` im `templates`-Ordner
+vorhanden ist.
+
+Für eine Übergangszeit kann noch auf die PHP-Templates zurückgegriffen werden. Informationen zur Nutzung
+der alten Inhaltselemente (`ce_*.html5`) findest du in der
+[Upgrade-Anleitung](https://github.com/contao/contao/blob/5.x/UPGRADE.md#content-elements).
 
 {{% notice warning %}}
-Wir empfehlen dringend diese Möglichkeit nur in Ausnahmefällen zu nutzen, z. B. um nach einem Upgrade auf
-Contao 5 mehr Zeit für die notwendigen Anpassungen zu haben.  
-Bedenke dabei auch, dass Erweiterungen für Contao 5 unter Umständen keine Möglichkeiten mehr zur Nutzung von
-PHP-Templates mitbringen.
+Wir empfehlen dringend, auf jegliche HTML5-Templates und die alten Inhaltselemente (Präfix `ce_`)
+zu verzichten. Nutze diese Möglichkeit nur in Ausnahmefällen, z. B. um nach einem Upgrade auf Contao 5
+mehr Zeit für die notwendigen Anpassungen zu haben.
+Bedenke dabei auch, dass Erweiterungen für Contao 5 unter Umständen keine Unterstützung für
+PHP-Templates mehr mitbringen.
 {{% /notice %}}
-
-Derzeit steht noch nicht für jedes Modul/Inhaltselement ein Twig-Template zur Verfügung. In diesen Fällen werden
-weiterhin die bisherigen (PHP/Legacy) Templates herangezogen.
 
 
 ## Dateiendungen
 
 Twig-Templates haben die Dateiendung `.twig`. Zusätzlich wird noch der Ausgabetyp angegeben.
-Für eine Ausgabe von HTML wird die Dateiendung `html.twig` verwendet.
+Für eine Ausgabe von HTML wird die Dateiendung `.html.twig` verwendet.

--- a/docs/manual/layout/templates/twig/_index.de.md
+++ b/docs/manual/layout/templates/twig/_index.de.md
@@ -43,9 +43,7 @@ Weitergehende Informationen zu Twig-Templates in Contao findest du in der
 
 ## Twig-Templates im Contao-Core
 
-{{< version "5.7" >}}
-
-Ab Contao 5.7 steht für jedes `.html5`-Template ein Twig-Pendant zur Verfügung. Twig ist damit der
+{{< version "5.7" >}} Für jedes `.html5`-Template steht ein Twig-Pendant zur Verfügung. Twig ist damit der
 neue Standard und löst die HTML5-Templates vollständig ab.
 
 Standardmäßig wird immer die Twig-Version eines Templates verwendet. Liegt jedoch ein gleichnamiges

--- a/docs/manual/layout/templates/twig/_index.de.md
+++ b/docs/manual/layout/templates/twig/_index.de.md
@@ -9,14 +9,14 @@ tags: [Twig]
 ---
 
 {{% notice note %}}
-Der gesamte Abschnitt behandelt die Verwendung von Twig-Templates in Contao ab Version 5.0.
+Der gesamte Abschnitt behandelt die Verwendung von Twig-Templates in Contao ab Version 5.0.  
 In Contao können Twig-Templates zwar seit Version 4.12 genutzt werden, aber erst seit Contao 5.0 werden Twig-Templates
 auch im Contao-Core verwendet. Es wurde darauf verzichtet, die abweichende Verwendung von Twig-Templates in älteren
 Versionen im Handbuch zu dokumentieren.
 {{% /notice %}}
 
 Twig ist eine Template Engine für PHP und die Standard Template Engine von Symfony. Sie ist schnell, sicher und leicht
-erweiterbar.
+erweiterbar.  
 Mit Twig-Templates kann das Design von der Programmierung strikt getrennt werden.
 
 Wie ein PHP-Template wird ein Twig-Template für die Ausgabe eines Moduls, Inhaltselements, Formulars oder einer anderen
@@ -31,9 +31,9 @@ z. B. [Erweitern](wiederverwendung/#erweitern),
 [horizontale Wiederverwendung](wiederverwendung/#horizontale-wiederverwendung) oder
 [Makros](https://docs.contao.org/dev/framework/templates/creating-templates/#macros).
 Deshalb sollten keine Templates mehr komplett überschrieben werden, wie das bei den PHP-Templates häufig üblich bzw.
-notwendig war.
+notwendig war.  
 Wir werden innerhalb des Handbuches nur die wichtigste Technik - das Erweitern von Twig-Templates für Contao genauer
-behandeln.
+behandeln.  
 Weitergehende Informationen zu Twig-Templates in Contao findest du in der
 [Entwicklerdokumentation](https://docs.contao.org/dev/framework/templates/).
 {{% /notice %}}

--- a/docs/manual/layout/templates/twig/_index.en.md
+++ b/docs/manual/layout/templates/twig/_index.en.md
@@ -7,12 +7,12 @@ tags: [Twig]
 ---
 
 {{% notice note %}}
-This entire section covers the use of Twig templates in Contao since version 5.0.
+This entire section covers the use of Twig templates in Contao since version 5.0.  
 Although Twig templates can be used in Contao since version 4.12, Twig templates are only used in Contao core since
 Contao 5.0. We did not document the different use of Twig templates in older versions in the manual.
 {{% /notice %}}
 
-Twig is a template engine for PHP and the default template engine of Symfony. It is fast, secure and easily extensible.
+Twig is a template engine for PHP and the default template engine of Symfony. It is fast, secure and easily extensible.  
 With Twig templates, design can be strictly separated from programming.
 
 Like a PHP template, a Twig template is used to output a module, content element, form, or other component.
@@ -24,7 +24,7 @@ Twig templates consistently rely on the powerful template structuring and reuse 
 [Embed](https://docs.contao.org/dev/framework/templates/creating-templates/#embeds),
 [Horizontal reuse](reuse/#horizontal-reuse) or
 [Macros](https://docs.contao.org/dev/framework/templates/creating-templates/#macros).
-Therefore, templates should no longer be completely overwritten, as was often common or necessary with PHP templates.
+Therefore, templates should no longer be completely overwritten, as was often common or necessary with PHP templates.   
 Within the manual, we will only cover the most important technique - extending Twig templates for Contao in more detail.
 More information about Twig templates in Contao can be found in the
 [developer documentation](https://docs.contao.org/dev/framework/templates/).

--- a/docs/manual/layout/templates/twig/_index.en.md
+++ b/docs/manual/layout/templates/twig/_index.en.md
@@ -35,9 +35,7 @@ More information about Twig templates in Contao can be found in the
 
 ## Twig templates in Contao core
 
-{{< version "5.7" >}}
-
-As of Contao 5.7, every `.html5` template has a Twig equivalent. Twig is now the new standard and
+{{< version "5.7" >}} Every `.html5` template has a Twig equivalent. Twig is now the new standard and
 fully replaces the HTML5 templates.
 
 By default, the Twig version of a template is always used. However, if a `.html5` template with the same

--- a/docs/manual/layout/templates/twig/_index.en.md
+++ b/docs/manual/layout/templates/twig/_index.en.md
@@ -7,15 +7,15 @@ tags: [Twig]
 ---
 
 {{% notice note %}}
-This entire section covers the use of Twig templates in Contao since version 5.0.  
+This entire section covers the use of Twig templates in Contao since version 5.0.
 Although Twig templates can be used in Contao since version 4.12, Twig templates are only used in Contao core since
 Contao 5.0. We did not document the different use of Twig templates in older versions in the manual.
 {{% /notice %}}
 
-Twig is a template engine for PHP and the default template engine of Symfony. It is fast, secure and easily extensible.  
+Twig is a template engine for PHP and the default template engine of Symfony. It is fast, secure and easily extensible.
 With Twig templates, design can be strictly separated from programming.
 
-Like a PHP template, a Twig template is used to output a module, content item, form, or other component.
+Like a PHP template, a Twig template is used to output a module, content element, form, or other component.
 
 {{% notice info %}}
 Twig templates consistently rely on the powerful template structuring and reuse methods, such as
@@ -24,7 +24,7 @@ Twig templates consistently rely on the powerful template structuring and reuse 
 [Embed](https://docs.contao.org/dev/framework/templates/creating-templates/#embeds),
 [Horizontal reuse](reuse/#horizontal-reuse) or
 [Macros](https://docs.contao.org/dev/framework/templates/creating-templates/#macros).
-Therefore, templates should no longer be completely overwritten, as was often common or necessary with PHP templates.   
+Therefore, templates should no longer be completely overwritten, as was often common or necessary with PHP templates.
 Within the manual, we will only cover the most important technique - extending Twig templates for Contao in more detail.
 More information about Twig templates in Contao can be found in the
 [developer documentation](https://docs.contao.org/dev/framework/templates/).
@@ -35,22 +35,29 @@ More information about Twig templates in Contao can be found in the
 
 ## Twig templates in Contao core
 
-In Contao 5, Twig templates are provided for many core elements. This means that template adjustments must also be made
-in Twig templates.    
-For a transition period, you can still use the PHP templates. The necessary settings for this can be found in the
+{{< version "5.7" >}}
+
+As of Contao 5.7, every `.html5` template has a Twig equivalent. Twig is now the new standard and
+fully replaces the HTML5 templates.
+
+By default, the Twig version of a template is always used. However, if a `.html5` template with the same
+name exists in your `templates` directory, it takes precedence over the Twig template.
+
+**Example:** `news_full.html.twig` is used as long as no `news_full.html5` exists in the `templates` folder.
+
+For a transition period, you can still fall back to PHP templates. Information on using the legacy
+content elements (`ce_*.html5`) can be found in the
 [upgrade instructions](https://github.com/contao/contao/blob/5.x/UPGRADE.md#content-elements).
 
 {{% notice warning %}}
-We strongly recommend to use this option only in exceptional cases, e.g. to have more time for necessary adjustments
-after an upgrade to Contao 5 to have more time for the necessary customizations.  
+We strongly recommend avoiding HTML5 templates and the legacy content elements (prefix `ce_`).
+Use this option only in exceptional cases, e.g. to have more time for the necessary adjustments
+after an upgrade to Contao 5.
 Keep in mind that extensions for Contao 5 may no longer support the use of PHP templates.
 {{% /notice %}}
 
-Currently, a Twig template is not yet available for every module/content element. In these cases the previous
-(PHP/legacy) templates are still used.
 
+## File extensions
 
-## File endings
-
-Twig templates have the file extension `.twig`. Additionally the output type is specified.   
-For an output of HTML the file extension `html.twig` is used.
+Twig templates have the file extension `.twig`. Additionally, the output type is specified.
+For an HTML output, the file extension `.html.twig` is used.


### PR DESCRIPTION
As of Contao 5.7, every `.html5` template has a Twig equivalent and Twig is now the default standard. The section \"Twig templates in Contao core\" was updated to reflect this:

- Updated the opening paragraph to state that as of 5.7, every `.html5` template has a Twig equivalent and Twig is now the new standard
- Added explanation of the template resolution logic: Twig is used by default; a `.html5` file in the `templates` folder takes precedence
- Added a concrete example (`news_full.html.twig` / `news_full.html5`)
- Made the transition period paragraph more specific, referencing legacy `ce_*.html5` elements
- Strengthened the warning to explicitly recommend against HTML5 templates and legacy `ce_*` content elements
- Removed the outdated paragraph stating that not every element has a Twig template yet
- Minor fix: `.html.twig` file extension (dot was missing)