### PR TITLE
Fix version shortcode: use version-tag instead of version

### DIFF
--- a/docs/manual/layout/templates/twig/_index.de.md
+++ b/docs/manual/layout/templates/twig/_index.de.md
@@ -43,7 +43,7 @@ Weitergehende Informationen zu Twig-Templates in Contao findest du in der
 
 ## Twig-Templates im Contao-Core
 
-{{< version "5.7" >}} Für jedes `.html5`-Template steht ein Twig-Pendant zur Verfügung. Twig ist damit der
+{{< version-tag "5.7" >}} Für jedes `.html5`-Template steht ein Twig-Pendant zur Verfügung. Twig ist damit der
 neue Standard und löst die HTML5-Templates vollständig ab.
 
 Standardmäßig wird immer die Twig-Version eines Templates verwendet. Liegt jedoch ein gleichnamiges

--- a/docs/manual/layout/templates/twig/_index.en.md
+++ b/docs/manual/layout/templates/twig/_index.en.md
@@ -35,7 +35,7 @@ More information about Twig templates in Contao can be found in the
 
 ## Twig templates in Contao core
 
-{{< version "5.7" >}} Every `.html5` template has a Twig equivalent. Twig is now the new standard and
+{{< version-tag "5.7" >}} Every `.html5` template has a Twig equivalent. Twig is now the new standard and
 fully replaces the HTML5 templates.
 
 By default, the Twig version of a template is always used. However, if a `.html5` template with the same


### PR DESCRIPTION
Fixes a shortcode error introduced in #1729: `{{< version "5.7" >}}` was used inline, but the correct inline shortcode is `{{< version-tag "5.7" >}}`. The block variant `{{< version >}}` is only for standalone version notices, not for inline use within paragraph text.

Changes:
- `docs/manual/layout/templates/twig/_index.de.md`
- `docs/manual/layout/templates/twig/_index.en.md`