### PR TITLE
Remove outdated database configuration

### DIFF
--- a/docs/manual/installation/system-requirements/_index.de.md
+++ b/docs/manual/installation/system-requirements/_index.de.md
@@ -209,24 +209,6 @@ Contao wurde erfolgreich auf MySQL-Servern der Version 5.7 / 8.0 (und gleichwert
 getestet. Die Verwendung von `utf8` anstelle des `utf8mb4`-Zeichensatzes führt zu einer verschlechterten UTF8-Unterstützung (z. B. 
 keine Emojis).
 
-Wenn die oben empfohlenen Optionen auf deinem Server nicht aktiviert werden können, konfiguriere bitte einen anderen 
-Zeichensatz in deiner [`config/config.yaml`](../../system/einstellungen/#config-yml)-Datei:
-
-{{% notice info %}}
-Vor **Contao 4.8** findest du die Datei unter `app/config/config.yaml`.  
-{{% /notice %}}
-
-```yaml
-doctrine:
-    dbal:
-        connections:
-            default:
-                default_table_options:
-                    charset: utf8
-                    collate: utf8_unicode_ci
-                    collation: utf8_unicode_ci
-```
-
 Es wird außerdem empfohlen, MySQL im "Strict Mode" zu betreiben, um korrupte oder abgeschnittene
 Daten zu verhindern und die Datenintegrität zu gewährleisten.
 

--- a/docs/manual/installation/system-requirements/_index.en.md
+++ b/docs/manual/installation/system-requirements/_index.en.md
@@ -204,20 +204,6 @@ no database server types other than MySQL (or a compatible fork like MariaDB) ar
 Contao has been successfully tested on MySQL servers version 5.7 / 8.0 (and equivalent MariaDB versions) with `InnoDB` table format. 
 The use of `utf8` instead of the `utf8mb4` character set results in a worse UTF8 support (e.g. no emojis).
 
-If the above recommended options cannot be enabled on your server, please configure a different character set in your 
-[`config/config.yaml`](../../system/settings/#config-yml) file:
-
-```yaml
-doctrine:
-    dbal:
-        connections:
-            default:
-                default_table_options:
-                    charset: utf8
-                    collate: utf8_unicode_ci
-                    collation: utf8_unicode_ci
-```
-
 It is further recommended to run MySQL in "strict mode" to prevent corrupt or truncated
 data and to guarantee data integrity.
 


### PR DESCRIPTION
This removes the documentation on how to switch from `utf8mb4` to `utf8`. This is legacy and won't even work on modern MySQL servers anymore (current versions do not ship with `utf8` = `utf8mb3` support). Contao 6 will not be compatible with it either so I think we should just remove it entirely in the Contao 5 documentation already.