### PR TITLE
Document branch naming convention for pull requests

### DIFF
--- a/docs/dev/internals/issue-workflow.md
+++ b/docs/dev/internals/issue-workflow.md
@@ -20,8 +20,8 @@ Please assign new PRs to their creator.
 After reading a new PR, please label it either as <span class="issue-label-bug">bug</span> or as
 <span class="issue-label-feature">feature</span>.
 
-If the PR is targeted against an active version branch (e.g. `4.9`), please assign it to the corresponding milestone.
-Do not assign PRs targeted against the main branch (currently `5.x`) to a milestone.
+If the PR is targeted against an active version branch (e.g. `5.7`), please assign it to the corresponding milestone.
+Do not assign PRs targeted against the main branch (currently `main`) to a milestone.
 
 ## Reviewing bug reports
 
@@ -41,3 +41,28 @@ If the bug cannot be fixed without breaking backwards compatibility, please add 
 If it is unclear how to implement the feature, please add the <span class="issue-label-discuss">up for discussion</span>
 label to the ticket. If the feature cannot be implemented without breaking backwards compatibility, please add the
 <span class="issue-label-status">BC break</span> label. 
+
+## Branch naming convention for pull requests
+
+When opening a new PR, please consider the following branch naming convention to make reviewing easier.
+A proper prefix immediately indicates the type of change that you want to PR:
+
+**For bug fixes, use `fix/`**
+- e.g. `fix/disable-turbo-navigation-on-hover`
+
+**For new features, use `feature/`**
+- e.g. `feature/datacontainer_edit_twig_templates`
+
+**For CI or build-chain relates changes, use `ci/`**
+- e.g `ci/my-buildchain-fix-or-feature`
+
+| ✅ Good examples                           | ❌ Bad examples                           |   
+|-------------------------------------------|------------------------------------------|
+| feature/datacontainer_edit_twig_templates | feat/datacontainer_edit_twig_templates   |
+| feature/user-profile-settings             | add-user-profile-settings                |
+| feature/dashboard-event-system            | dashboard-event-system                   |
+| fix/disable-turbo-navigation-on-hover     | bugfix/disable-turbo-navigation-on-hover |
+| fix/session-timeout                       | bug/session-timeout                      |
+| fix/remove-legacy-stuff                   | remove-legacy-stuff                      |
+| ci/tools                                  | chore/tools                              |
+| ci/update-rector-tools                    | rector                                   |

--- a/docs/dev/internals/issue-workflow.md
+++ b/docs/dev/internals/issue-workflow.md
@@ -21,7 +21,6 @@ After reading a new PR, please label it either as <span class="issue-label-bug">
 <span class="issue-label-feature">feature</span>.
 
 If the PR is targeted against an active version branch (e.g. `5.7`), please assign it to the corresponding milestone.
-Do not assign PRs targeted against the main branch (currently `main`) to a milestone.
 
 ## Reviewing bug reports
 


### PR DESCRIPTION
### Description

This PR adds a new section for branch naming convention for pull requests targeted against the `contao/contao` monorepo.
(I additionally updated the version numbers as the main branch is now named `main`)