### PR TITLE
Fix the field callback parameters

### DIFF
--- a/docs/dev/reference/dca/callbacks.md
+++ b/docs/dev/reference/dca/callbacks.md
@@ -750,7 +750,7 @@ Allows you do dynamically adjust the attributes of a field in a DCA before a wid
 
 {{% expand "Parameters" %}}
 * `array` Current attributes
-* `\Contao\DataContainer`/`null` Data Container object
+* `\Contao\DataContainer` Data Container object
 
 **return:** `array` The adjusted attributes array
 {{% /expand %}}
@@ -792,7 +792,7 @@ Allows you to define an individual function to load data into a drop-down menu
 or checkbox list. Useful e.g. for conditional foreinKey-relations.
 
 {{% expand "Parameters" %}}
-* `\Contao\DataContainer`/`null` Data Container object
+* `\Contao\DataContainer` Data Container object
 
 **return:** `array` Array of available options
 {{% /expand %}}


### PR DESCRIPTION
As discussed in https://github.com/contao/contao/pull/9860, all the field callbacks should provide a `DataContainer` object and never `null`, so this PR adjusts the documentation accordingly.

| Callback | docs allow `\|null` |
| --- | --- |
| `attributes` | yes (now fixed) |
| `options` | yes (now fixed) |
| `input_field` | no |
| `load` | no |
| `save` | no |
| `wizard` | no |
| `xlabel` | no |
