### PR TITLE
Add layout note to generatePage hook

### DIFF
--- a/docs/dev/reference/hooks/generatePage.md
+++ b/docs/dev/reference/hooks/generatePage.md
@@ -14,7 +14,7 @@ and does not expect a return value.
 
 {{% notice note %}}
 The `generatePage` hook does not work when using the modern "Twig layout with slots" layout type.
-Use the [`LayoutEvent`](/reference/events/#layoutevent) instead.
+Use the [`LayoutEvent`]({{% relref "events#layoutevent" %}}) instead.
 {{% /notice %}}
 
 ## Parameters

--- a/docs/dev/reference/hooks/generatePage.md
+++ b/docs/dev/reference/hooks/generatePage.md
@@ -12,6 +12,10 @@ The `generatePage` hook is triggered before the main layout (fe_page) is compile
 It passes the page object, the layout object and a self-reference as arguments 
 and does not expect a return value.
 
+{{% notice note %}}
+The `generatePage` hook does not work when using the modern "Twig layout with slots" layout type.
+Use the [`LayoutEvent`](/reference/events/#layoutevent) instead.
+{{% /notice %}}
 
 ## Parameters
 


### PR DESCRIPTION
This PR add a note to the generatePage hook that it is not working with the new Twig slot layouts.
