### PR TITLE
Fix PHP version in DDEV setup

### DIFF
--- a/docs/manual/guides/local-installation/ddev.de.md
+++ b/docs/manual/guides/local-installation/ddev.de.md
@@ -47,7 +47,7 @@ mkdir contao && cd contao
 DDEV-Konfiguration anlegen mit:
 
 ```shell
-ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.3
+ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.4
 ```
 
 Contao {{% siteparam "currentContaoVersion" %}} installieren:
@@ -94,7 +94,7 @@ mkdir contao && cd contao
 DDEV-Konfiguration anlegen mit:
 
 ```shell
-ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.3
+ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.4
 ```
 
 Nach der Installation müssen die Datenbankzugangsdaten in die `.env.local` eingetragen werden. In diesem Zug richten wir auch direkt 

--- a/docs/manual/guides/local-installation/ddev.de.md
+++ b/docs/manual/guides/local-installation/ddev.de.md
@@ -47,7 +47,7 @@ mkdir contao && cd contao
 DDEV-Konfiguration anlegen mit:
 
 ```shell
-ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
+ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.3
 ```
 
 Contao {{% siteparam "currentContaoVersion" %}} installieren:
@@ -94,7 +94,7 @@ mkdir contao && cd contao
 DDEV-Konfiguration anlegen mit:
 
 ```shell
-ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
+ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.3
 ```
 
 Nach der Installation müssen die Datenbankzugangsdaten in die `.env.local` eingetragen werden. In diesem Zug richten wir auch direkt 

--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -45,7 +45,7 @@ mkdir contao && cd contao
 Create the DDEV configuration with:
 
 ```shell
-ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.3
+ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.4
 ```
 
 Install Contao {{% siteparam "currentContaoVersion" %}}:
@@ -92,7 +92,7 @@ mkdir contao && cd contao
 Create the DDEV configuration with:
 
 ```shell
-ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.3
+ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.4
 ```
 
 After installation, the database access data must be entered in the .env.local. At the same time, we also set up 

--- a/docs/manual/guides/local-installation/ddev.en.md
+++ b/docs/manual/guides/local-installation/ddev.en.md
@@ -45,7 +45,7 @@ mkdir contao && cd contao
 Create the DDEV configuration with:
 
 ```shell
-ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
+ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.3
 ```
 
 Install Contao {{% siteparam "currentContaoVersion" %}}:
@@ -92,7 +92,7 @@ mkdir contao && cd contao
 Create the DDEV configuration with:
 
 ```shell
-ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
+ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.3
 ```
 
 After installation, the database access data must be entered in the .env.local. At the same time, we also set up 


### PR DESCRIPTION
## Description

Update the PHP version in the DDEV installation examples from PHP `8.2` to PHP `8.4`.

The guide inserts the current Contao version into the installation command, while the PHP version in the preceding DDEV configuration is hard-coded. This can cause the two requirements to become inconsistent when the minimum PHP version changes.

This is currently the case for Contao 5.7 (which is shown as the default setup guide):

```console
ddev config --project-type=php --docroot=public --webserver-type=apache-fpm --php-version=8.2
ddev composer create-project contao/managed-edition:5.7
```

Following these commands in a clean project fails during dependency resolution because Contao 5.7 requires PHP `8.3` or higher.

Updating the DDEV configuration to PHP `8.4` ensures that the documented default setup works with the current Contao version shown on the same page.
