### PR TITLE
Mark the XAMPP documentation as outdated

### DIFF
--- a/docs/manual/guides/local-installation/_index.en.md
+++ b/docs/manual/guides/local-installation/_index.en.md
@@ -9,7 +9,7 @@ tags:
 ---
 
 You can also install Contao locally. This requires a web server, a database and PHP. For the different operating systems
-ready-made solutions, such as [XAMPP](https://www.apachefriends.org) or [Laragon](https://laragon.org/), exists. 
+ready-made solutions such as [Laragon](https://laragon.org/) exist. 
 
 Another alternative is using [Docker](https://www.docker.com/). If the current Docker releases are not available for your operating system, you can also use [Docker Desktop](https://docs.docker.com/desktop/).
 

--- a/docs/manual/guides/local-installation/xampp.de.md
+++ b/docs/manual/guides/local-installation/xampp.de.md
@@ -1,5 +1,5 @@
 ---
-title: "XAMPP"
+title: "XAMPP (veraltet)P"
 menuTitle : "Mit XAMPP"
 description: "Lokale Contao Installation mit XAMPP"
 weight: 30
@@ -9,6 +9,10 @@ tags:
    - "Installation"
 ---
 
+{{% notice warning %}}
+XAMPP wird seit längerer Zeit nicht mehr aktiv gepflegt und erlaubt keine Installation von neuen Contao-Versionen.
+Es sollte auf Alternativen ausgewichen werden.
+{{% /notice %}}
 
 In diesem Tutorial wird die lokale Contao Nutzung mit [XAMPP](https://www.apachefriends.org/) für Windows beschrieben. 
 Wir verwenden hierbei eine »XAMPP Portable Version«, die lediglich kopiert werden muß. Du wählst hierzu das 

--- a/docs/manual/guides/local-installation/xampp.en.md
+++ b/docs/manual/guides/local-installation/xampp.en.md
@@ -1,5 +1,5 @@
 ---
-title: "XAMPP"
+title: "XAMPP (outmoded)"
 menuTitle : "With XAMPP"
 description: "Contao installation with XAMPP"
 weight: 30
@@ -9,6 +9,10 @@ tags:
    - "Installation"
 ---
 
+{{% notice warning %}}
+XAMPP has not been actively maintained for quite some time and does not support the installation of new versions of Contao.
+You should consider using alternatives.
+{{% /notice %}}
 
 This tutorial describes the local use of Contao with [XAMPP](https://www.apachefriends.org/) for Windows. 
 We use a »XAMPP Portable Version«, which only needs to be copied. Download the appropriate [Windows archive](https://www.apachefriends.org/download.html) for this purpose.


### PR DESCRIPTION
### Description

This updates the documentation to reflect the current state of the XAMPP project.
<img width="1712" height="538" alt="grafik" src="https://github.com/user-attachments/assets/af48ffbc-a1df-4d88-ae97-1838c677df4a" />
<img width="1658" height="946" alt="grafik" src="https://github.com/user-attachments/assets/a78d5e58-68c8-4caf-9e88-ea2069ac6580" />

XAMPP has been calling for contributors for a while and may receive Pull requests, there however weren't any releases anymore:
https://github.com/ApacheFriends/xampp-build/issues/47
https://mariadb.org/xampp-needs-more-apache-friends/

The last release has been made end of 2023:
https://www.apachefriends.org/blog/new_xampp_20231119.html

As for dependencies, the last PHP version it shipped with was PHP 8.2.12 (Security support for 8.2 ends end of this year - 2026 https://www.php.net/supported-versions.php)

To better reflect the state, I propose to add *warning* to the guide as the Xampp version does not allow you to even install Contao 5.7+ (Minimum required PHP Version is 8.3).

___

For reference:
https://community.contao.org/de/showthread.php?89454-Leidiges-Thema-contao-unter-Xampp&p=604708
